### PR TITLE
Avoid stack overflows in KAMAIndicator by using RecursiveCachedIndicator.

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/KAMAIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/KAMAIndicator.java
@@ -24,14 +24,14 @@ package eu.verdelhan.ta4j.indicators;
 
 import eu.verdelhan.ta4j.Decimal;
 import eu.verdelhan.ta4j.Indicator;
-import eu.verdelhan.ta4j.indicators.CachedIndicator;
+import eu.verdelhan.ta4j.indicators.RecursiveCachedIndicator;
 
 /**
  * The Kaufman's Adaptive Moving Average (KAMA)  Indicator.
  * 
  * @see http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:kaufman_s_adaptive_moving_average
  */
-public class KAMAIndicator extends CachedIndicator<Decimal> {
+public class KAMAIndicator extends RecursiveCachedIndicator<Decimal> {
 
     private final Indicator<Decimal> price;
     

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/CachedIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/CachedIndicatorTest.java
@@ -153,7 +153,7 @@ public class CachedIndicatorTest {
 
         ZLEMAIndicator zlema = new ZLEMAIndicator(new ClosePriceIndicator(series), 1);
         try {
-            assertDecimalEquals(zlema.getValue(8), "9");
+            assertDecimalEquals(zlema.getValue(8), "4996");
         } catch (Throwable t) {
             fail(t.getMessage());
         }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/KAMAIndicatorTest.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/indicators/KAMAIndicatorTest.java
@@ -24,6 +24,7 @@ package eu.verdelhan.ta4j.indicators;
 
 import static eu.verdelhan.ta4j.TATestsUtils.assertDecimalEquals;
 
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -104,5 +105,19 @@ public class KAMAIndicatorTest {
         assertDecimalEquals(kama.getValue(46), 111.5688);
         assertDecimalEquals(kama.getValue(47), 111.5522);
         assertDecimalEquals(kama.getValue(48), 111.5595);
+    }
+
+    @Test
+    public void getValueOnDeepIndicesShouldNotCauseStackOverflow() {
+        TimeSeries series = new MockTimeSeries();
+        series.setMaximumTickCount(5000);
+        assertEquals(5000, series.getTickCount());
+
+        KAMAIndicator kama = new KAMAIndicator(new ClosePriceIndicator(series), 10, 2, 30);
+        try {
+            assertDecimalEquals(kama.getValue(3000), "2999.75");
+        } catch (Throwable t) {
+            fail(t.getMessage());
+        }
     }
 }

--- a/ta4j/src/test/java/eu/verdelhan/ta4j/mocks/MockTimeSeries.java
+++ b/ta4j/src/test/java/eu/verdelhan/ta4j/mocks/MockTimeSeries.java
@@ -84,7 +84,7 @@ public class MockTimeSeries extends BaseTimeSeries {
 
     private static List<Tick> arbitraryTicks() {
         ArrayList<Tick> ticks = new ArrayList<>();
-        for (double i = 0d; i < 10; i++) {
+        for (double i = 0d; i < 5000; i++) {
             ticks.add(new MockTick(ZonedDateTime.now(), i, i + 1, i + 2, i + 3, i + 4, i + 5, (int) (i + 6)));
         }
         return ticks;


### PR DESCRIPTION
`KAMAIndicator` can trigger stack overflows when a constrained time series has a
large maximum tick count and a deep tick index is requested, since the value for
that index is calculated recursively by `CachedIndicator`.

Fixes #4.