### PR TITLE
Remove unnecessary setting of element in results cache array

### DIFF
--- a/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
+++ b/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java
@@ -103,8 +103,8 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
                 result = results.get(resultInnerIndex);
                 if (result == null) {
                     result = calculate(index);
+                    results.set(resultInnerIndex, result);
                 }
-                results.set(resultInnerIndex, result);
             }
         }
         return result;


### PR DESCRIPTION
Remove unnecessary setting of element in results cache array in the scenario the value has already been calculated:

https://github.com/ta4j/ta4j/blob/a9786edf0b5a92a353b65d52599dea10ea8ef715/ta4j/src/main/java/eu/verdelhan/ta4j/indicators/CachedIndicator.java#L103-L107

The statement in line 107 should be included in the body of the if clause so that the element in `resultInnerIndex` is not overwritten by itself when `result` is not null.