### PR TITLE
remove ta4j- prefix from maven release tag format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
                 <version>2.5</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>ta4j-@{project.version}</tagNameFormat>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
                     <!-- Avoid issue: http://jira.codehaus.org/browse/MGPG-9 -->
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <useReleaseProfile>false</useReleaseProfile>


### PR DESCRIPTION
Related to #16 

Changes proposed in this pull request:
- drop the `ta4j-` prefix from git tags

Once this has been agreed upon I will push all previous tags.


