### PR TITLE
establish changelog, add note in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Changes proposed in this pull request:
 - 
 - 
 
-
+- [ ] added an entry to the unreleased section of `CHANGES.md` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangelog.com/en/1.0.0/) from version 0.9 onwards.
+
+## Unreleased
+
+## 0.9 (2017-09-07)
+
+- **BREAKING** drops Java 7 support
+- use `java.time` instead of `java.util.Date`
+
+## 0.8 (2016-02-25)
+## 0.7 (2015-05-21)
+## 0.6 (2015-02-05)
+## 0.5 (2014-10-22)
+## 0.4 (2014-05-28)
+## 0.3 (2014-03-11)


### PR DESCRIPTION
I've always been missing a CHANGELOG from this project. Sometimes releases just break everything (such as the recent BaseTimeSeries/TimeSeries split) and the only way to figure it out is by reading commit messages. Breakage is part of life and that's ok but we should be communicating it properly.

📺 &nbsp; [Related talk that I think presents some nice food for thought.](https://www.youtube.com/watch?v=oyLBGkS5ICk)