### PR TITLE
Removed unnecessary last tick index calculation

### DIFF
--- a/ta4j/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -210,8 +210,9 @@ public class BaseTimeSeries implements TimeSeries {
         if (tick == null) {
             throw new IllegalArgumentException("Cannot add null tick");
         }
-        final int lastTickIndex = ticks.size() - 1;
+
         if (!ticks.isEmpty()) {
+            final int lastTickIndex = ticks.size() - 1;
             ZonedDateTime seriesEndTime = ticks.get(lastTickIndex).getEndTime();
             if (!tick.getEndTime().isAfter(seriesEndTime)) {
                 throw new IllegalArgumentException("Cannot add a tick with end time <= to series end time");


### PR DESCRIPTION
Removed unnecessary last tick index calculation if the ticks list is empty:

https://github.com/ta4j/ta4j/blob/d699fe77a21a1bdcd99a320a444f79a3c297d131/ta4j/src/main/java/eu/verdelhan/ta4j/BaseTimeSeries.java#L213-L219

The statement in line 213 should be included in the body of the if clause, so that in case of an empty tick list we won't have a redundant last tick index calculation.