### PR TITLE
Use BigDecimal::valueof instead of instantiating a new BigDecimal for int and long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Changed
 - **JustOnceRule**: Now it is possible to add another rule so that this rule is satisfied if the inner rule is satisfied for the first time
 - **MeanDeviationIndicator**: moved to statistics package
+- **Decimal**: Use `BigDecimal::valueof` instead of instantiating a new BigDecimal for int and long
 
 ## Added
 - **ConvergenceDivergenceIndicator**: New Indicator for positive/negative convergence and divergence.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Changed
 - **JustOnceRule**: Now it is possible to add another rule so that this rule is satisfied if the inner rule is satisfied for the first time
 - **MeanDeviationIndicator**: moved to statistics package
-- **Decimal**: Use `BigDecimal::valueof` instead of instantiating a new BigDecimal for int and long
+- **Decimal**: Use `BigDecimal::valueof` instead of instantiating a new BigDecimal for double, int and long
 
 ## Added
 - **ConvergenceDivergenceIndicator**: New Indicator for positive/negative convergence and divergence.

--- a/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
@@ -81,11 +81,11 @@ public final class Decimal implements Comparable<Decimal>, Serializable {
     }
 
     private Decimal(int val) {
-        delegate = new BigDecimal(val, MATH_CONTEXT);
+        delegate = BigDecimal.valueOf(val);
     }
 
     private Decimal(long val) {
-        delegate = new BigDecimal(val, MATH_CONTEXT);
+        delegate = BigDecimal.valueOf(val);
     }
 
     private Decimal(BigDecimal val) {

--- a/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
@@ -77,7 +77,7 @@ public final class Decimal implements Comparable<Decimal>, Serializable {
      * @param val the double value
      */
     private Decimal(double val) {
-        delegate = new BigDecimal(val, MATH_CONTEXT);
+        delegate = BigDecimal.valueOf(val);
     }
 
     private Decimal(int val) {

--- a/ta4j-core/src/test/java/org/ta4j/core/DecimalTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/DecimalTest.java
@@ -2,12 +2,22 @@ package org.ta4j.core;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static org.junit.Assert.*;
 
 
 public class DecimalTest {
     @Test
-    public void valueOf() {
+    public void testValueOf() {
         assertEquals(Decimal.valueOf(0.33), Decimal.valueOf("0.33"));
+    }
+
+    @Test
+    public void testMultiplicationSymmetricity(){
+        Decimal decimalFromString = Decimal.valueOf("0.33");
+        Decimal decimalFromDouble = Decimal.valueOf(0.33);
+
+        assertEquals(decimalFromString.multipliedBy(decimalFromDouble), decimalFromDouble.multipliedBy(decimalFromString));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/DecimalTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/DecimalTest.java
@@ -1,0 +1,13 @@
+package org.ta4j.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class DecimalTest {
+    @Test
+    public void valueOf() {
+        assertEquals(Decimal.valueOf(0.33), Decimal.valueOf("0.33"));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1439,7 +1439,7 @@ public class PivotPointIndicatorTest {
         //r3
         assertEquals(r3.getValue(0), Decimal.NaN);
         assertEquals(r3.getValue(19), Decimal.NaN); // no previous month
-        assertDecimalEquals(r3.getValue(series_1_days.getEndIndex()-19), Double.valueOf("168.7399"));
+        assertDecimalEquals(r3.getValue(series_1_days.getEndIndex()-19), Double.valueOf("168.74"));
         assertDecimalEquals(r3.getValue(series_1_days.getEndIndex()), Double.valueOf("208.25000"));
 
     }


### PR DESCRIPTION
This is a minor change done in Decimal class.

Depending on JRE implementation, this will give a slight performance boost when creating BigDecimals out of integer values 0 to 10. This is due to the caching mechanism that BigDecimal implements.

Using `MATH_CONTEXT` during long or int creation is not particularly useful. Defining the `MATH_CONTEXT` during math calculations suffices. 

- [X] added an entry to the unreleased section of `CHANGES.md` 
