### PR TITLE
Perf get simple name

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -34,6 +34,9 @@ public class BaseStrategy implements Strategy {
     /** The logger */
     protected final Logger log = LoggerFactory.getLogger(getClass());
     
+    /** The class name */
+    protected final String className = getClass().getSimpleName();
+    
     /** Name of the strategy */
     private String name;
 	
@@ -144,7 +147,7 @@ public class BaseStrategy implements Strategy {
      * @param enter true if the strategy should enter, false otherwise
      */
     protected void traceShouldEnter(int index, boolean enter) {
-        log.trace(">>> {}#shouldEnter({}): {}", getClass().getSimpleName(), index, enter);
+        log.trace(">>> {}#shouldEnter({}): {}", className, index, enter);
     }
 
     /**
@@ -153,6 +156,6 @@ public class BaseStrategy implements Strategy {
      * @param exit true if the strategy should exit, false otherwise
      */
     protected void traceShouldExit(int index, boolean exit) {
-        log.trace(">>> {}#shouldExit({}): {}", getClass().getSimpleName(), index, exit);
+        log.trace(">>> {}#shouldExit({}): {}", className, index, exit);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AbstractRule.java
@@ -34,12 +34,15 @@ public abstract class AbstractRule implements Rule {
     /** The logger */
     protected final Logger log = LoggerFactory.getLogger(getClass());
     
+    /** The class name */
+    protected final String className = getClass().getSimpleName();
+    
     /**
      * Traces the isSatisfied() method calls.
      * @param index the tick index
      * @param isSatisfied true if the rule is satisfied, false otherwise
      */
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
-        log.trace("{}#isSatisfied({}): {}", getClass().getSimpleName(), index, isSatisfied);
+        log.trace("{}#isSatisfied({}): {}", className, index, isSatisfied);
     }
 }


### PR DESCRIPTION
Fixes #90 .

Changes proposed in this pull request:
- Transparent change to move calls to getSimpleName() out of log.trace() in BaseStrategy and AbstractRule.

- [ ] added an entry to the unreleased section of `CHANGES.md` 
