### PR TITLE
Fix/limit ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 - **ATRIndicator**: fixed calculations
 - **PlusDI, MinusDI, ADX**: fixed calculations
+- **[Versus]BuyAndHoldCriterion**: limited calculate to range of trading record
 
 ### Changed
 - **JustOnceRule**: now it is possible to add another rule so that this rule is satisfied if the inner rule is satisfied for the first time

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
@@ -35,13 +35,12 @@ public class BuyAndHoldCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public double calculate(TimeSeries series, TradingRecord tradingRecord) {
-        //return series.getBar(series.getEndIndex()).getClosePrice().dividedBy(series.getBar(series.getBeginIndex()).getClosePrice()).doubleValue();
         if (tradingRecord.getTradeCount() == 0) {
             return 1.0d;
         }
         int firstEntryIndex = tradingRecord.getTrades().get(0).getEntry().getIndex();
         int lastExitIndex = tradingRecord.getTrades().get(tradingRecord.getTradeCount()-1).getExit().getIndex();
-        
+
         return series.getBar(lastExitIndex).getClosePrice().dividedBy(series.getBar(firstEntryIndex).getClosePrice()).doubleValue();
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
@@ -35,7 +35,14 @@ public class BuyAndHoldCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public double calculate(TimeSeries series, TradingRecord tradingRecord) {
-        return series.getBar(series.getEndIndex()).getClosePrice().dividedBy(series.getBar(series.getBeginIndex()).getClosePrice()).doubleValue();
+        //return series.getBar(series.getEndIndex()).getClosePrice().dividedBy(series.getBar(series.getBeginIndex()).getClosePrice()).doubleValue();
+        if (tradingRecord.getTradeCount() == 0) {
+            return 1.0d;
+        }
+        int firstEntryIndex = tradingRecord.getTrades().get(0).getEntry().getIndex();
+        int lastExitIndex = tradingRecord.getTrades().get(tradingRecord.getTradeCount()-1).getExit().getIndex();
+        
+        return series.getBar(lastExitIndex).getClosePrice().dividedBy(series.getBar(firstEntryIndex).getClosePrice()).doubleValue();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
@@ -44,8 +44,13 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
     @Override
     public double calculate(TimeSeries series, TradingRecord tradingRecord) {
         TradingRecord fakeRecord = new BaseTradingRecord();
-        fakeRecord.enter(series.getBeginIndex());
-        fakeRecord.exit(series.getEndIndex());
+        if (tradingRecord.getTradeCount() == 0) {
+            return 1d;
+        }
+        int firstEntryIndex = tradingRecord.getTrades().get(0).getEntry().getIndex();
+        int lastExitIndex = tradingRecord.getTrades().get(tradingRecord.getTradeCount()-1).getExit().getIndex();
+        fakeRecord.enter(firstEntryIndex);
+        fakeRecord.exit(lastExitIndex);
 
         return criterion.calculate(series, tradingRecord) / criterion.calculate(series, fakeRecord);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
@@ -69,7 +69,7 @@ public class BuyAndHoldCriterionTest {
         AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
         assertEquals(1d, buyAndHold.calculate(series, new BaseTradingRecord()), TATestsUtils.TA_OFFSET);
     }
-    
+
     @Test
     public void calculateWithOpenTrade() {
         MockTimeSeries series = new MockTimeSeries(100, 95, 100, 80, 85, 70);

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
@@ -31,6 +31,17 @@ import static org.junit.Assert.*;
 public class BuyAndHoldCriterionTest {
 
     @Test
+    public void calculateWithSubrange() {
+        MockTimeSeries series = new MockTimeSeries(100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.buyAt(1), Order.sellAt(2),
+                Order.buyAt(3), Order.sellAt(4));
+
+        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        assertEquals(95d / 105, buyAndHold.calculate(series, tradingRecord), TATestsUtils.TA_OFFSET);
+    }
+
+    @Test
     public void calculateOnlyWithGainTrades() {
         MockTimeSeries series = new MockTimeSeries(100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(
@@ -55,9 +66,16 @@ public class BuyAndHoldCriterionTest {
     @Test
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(100, 95, 100, 80, 85, 70);
-
         AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
-        assertEquals(0.7, buyAndHold.calculate(series, new BaseTradingRecord()), TATestsUtils.TA_OFFSET);
+        assertEquals(1d, buyAndHold.calculate(series, new BaseTradingRecord()), TATestsUtils.TA_OFFSET);
+    }
+    
+    @Test
+    public void calculateWithOpenTrade() {
+        MockTimeSeries series = new MockTimeSeries(100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(1));
+        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        assertEquals(1d, buyAndHold.calculate(series, tradingRecord), TATestsUtils.TA_OFFSET);
     }
     
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
@@ -31,6 +31,17 @@ import static org.junit.Assert.*;
 public class VersusBuyAndHoldCriterionTest {
 
     @Test
+    public void calculateWithSubrange() {
+        MockTimeSeries series = new MockTimeSeries(100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.buyAt(1), Order.sellAt(2),
+                Order.buyAt(3), Order.sellAt(4));
+
+        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        assertEquals((110d / 105) * (95d / 100) / (95d / 105), buyAndHold.calculate(series, tradingRecord), TATestsUtils.TA_OFFSET);
+    }
+
+    @Test
     public void calculateOnlyWithGainTrades() {
         MockTimeSeries series = new MockTimeSeries(100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(
@@ -64,9 +75,18 @@ public class VersusBuyAndHoldCriterionTest {
     @Test
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(100, 95, 100, 80, 85, 70);
-
         AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
-        assertEquals(1 / 0.7, buyAndHold.calculate(series, new BaseTradingRecord()), TATestsUtils.TA_OFFSET);
+        assertEquals(1d, buyAndHold.calculate(series, new BaseTradingRecord()), TATestsUtils.TA_OFFSET);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(1));
+        assertEquals(1d, buyAndHold.calculate(series, tradingRecord), TATestsUtils.TA_OFFSET);
+    }
+
+    @Test
+    public void calculateWithOpenTrade() {
+        MockTimeSeries series = new MockTimeSeries(100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(1));
+        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        assertEquals(1d, buyAndHold.calculate(series, tradingRecord), TATestsUtils.TA_OFFSET);
     }
 
     @Test


### PR DESCRIPTION
Fixes #119 .

Changes proposed in this pull request:
- Limit [Versus]BuyAndHold calculations to range of trading record
- Fix test cases with no trades to return 1d
- 

- [x] added an entry to the unreleased section of `CHANGES.md` 
