### PR TITLE
performance improvement

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -182,7 +182,7 @@ public class BaseStrategy implements Strategy {
      */
     protected void traceShouldEnter(int index, boolean enter) {
         if ( log.isTraceEnabled() ) {
-            log.trace(">>> {}#shouldEnter({}): {}", getClass().getSimpleName(), index, enter);
+            log.trace(">>> {}#shouldEnter({}): {}", className, index, enter);
         }
     }
 
@@ -193,7 +193,7 @@ public class BaseStrategy implements Strategy {
      */
     protected void traceShouldExit(int index, boolean exit) {
         if ( log.isTraceEnabled() ) {
-            log.trace(">>> {}#shouldExit({}): {}", getClass().getSimpleName(), index, exit);
+            log.trace(">>> {}#shouldExit({}): {}", className, index, exit);
         }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -181,7 +181,9 @@ public class BaseStrategy implements Strategy {
      * @param enter true if the strategy should enter, false otherwise
      */
     protected void traceShouldEnter(int index, boolean enter) {
-        log.trace(">>> {}#shouldEnter({}): {}", className, index, enter);
+        if ( log.isTraceEnabled() ) {
+            log.trace(">>> {}#shouldEnter({}): {}", getClass().getSimpleName(), index, enter);
+        }
     }
 
     /**
@@ -190,6 +192,8 @@ public class BaseStrategy implements Strategy {
      * @param exit true if the strategy should exit, false otherwise
      */
     protected void traceShouldExit(int index, boolean exit) {
-        log.trace(">>> {}#shouldExit({}): {}", className, index, exit);
+        if ( log.isTraceEnabled() ) {
+            log.trace(">>> {}#shouldExit({}): {}", getClass().getSimpleName(), index, exit);
+        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -66,7 +66,7 @@ public class UlcerIndexIndicator extends CachedIndicator<Decimal> {
             squaredAverage = squaredAverage.plus(percentageDrawdown.pow(2));
         }
         squaredAverage = squaredAverage.dividedBy(Decimal.valueOf(numberOfObservations));
-        return Decimal.valueOf(Math.sqrt(squaredAverage.toDouble()));
+        return Decimal.valueOf(Math.sqrt(squaredAverage.doubleValue()));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -62,7 +62,7 @@ public class PearsonCorrelationIndicator extends RecursiveCachedIndicator<Decima
 		
 		if (toSqrt.isGreaterThan(Decimal.ZERO)) {
 			// pearson = (n * Sxy - Sx * Sy) / sqrt((n * Sxx - Sx * Sx) * (n * Syy - Sy * Sy))
-			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(Decimal.valueOf(Math.sqrt(toSqrt.toDouble())));
+			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(Decimal.valueOf(Math.sqrt(toSqrt.doubleValue())));
 		}
 
 		return Decimal.NaN;

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AbstractRule.java
@@ -43,6 +43,8 @@ public abstract class AbstractRule implements Rule {
      * @param isSatisfied true if the rule is satisfied, false otherwise
      */
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
-        log.trace("{}#isSatisfied({}): {}", className, index, isSatisfied);
+        if ( log.isTraceEnabled() ) {
+            log.trace("{}#isSatisfied({}): {}", getClass().getSimpleName(), index, isSatisfied);
+        }
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -51,7 +51,7 @@ public class Quickstart {
 
         // Getting the close price of the bars
         Decimal firstClosePrice = series.getBar(0).getClosePrice();
-        System.out.println("First close price: " + firstClosePrice.toDouble());
+        System.out.println("First close price: " + firstClosePrice.doubleValue());
         // Or within an indicator:
         ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
         // Here is the same close price:
@@ -60,7 +60,7 @@ public class Quickstart {
         // Getting the simple moving average (SMA) of the close price over the last 5 bars
         SMAIndicator shortSma = new SMAIndicator(closePrice, 5);
         // Here is the 5-bars-SMA value at the 42nd index
-        System.out.println("5-bars-SMA value at the 42nd index: " + shortSma.getValue(42).toDouble());
+        System.out.println("5-bars-SMA value at the 42nd index: " + shortSma.getValue(42).doubleValue());
 
         // Getting a longer SMA (e.g. over the 30 last bars)
         SMAIndicator longSma = new SMAIndicator(closePrice, 30);

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -59,7 +59,7 @@ public class BuyAndSellSignalsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -59,7 +59,7 @@ public class CashFlowToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Minute(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Minute(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
@@ -136,7 +136,7 @@ public class TradingBotOnMovingTimeSeries {
             Thread.sleep(30); // I know...
             Bar newBar = generateRandomBar();
             System.out.println("------------------------------------------------------\n"
-                    + "Bar "+i+" added, close price = " + newBar.getClosePrice().toDouble());
+                    + "Bar "+i+" added, close price = " + newBar.getClosePrice().doubleValue());
             series.addBar(newBar);
 
             int endIndex = series.getEndIndex();

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -68,11 +68,11 @@ public class CandlestickChart {
         for (int i = 0; i < nbBars; i++) {
             Bar bar = series.getBar(i);
             dates[i] = new Date(bar.getEndTime().toEpochSecond() * 1000);
-            opens[i] = bar.getOpenPrice().toDouble();
-            highs[i] = bar.getMaxPrice().toDouble();
-            lows[i] = bar.getMinPrice().toDouble();
-            closes[i] = bar.getClosePrice().toDouble();
-            volumes[i] = bar.getVolume().toDouble();
+            opens[i] = bar.getOpenPrice().doubleValue();
+            highs[i] = bar.getMaxPrice().doubleValue();
+            lows[i] = bar.getMinPrice().doubleValue();
+            closes[i] = bar.getClosePrice().doubleValue();
+            volumes[i] = bar.getVolume().doubleValue();
         }
 
         OHLCDataset dataset = new DefaultHighLowDataset("btc", dates, highs, lows, opens, closes, volumes);
@@ -91,7 +91,7 @@ public class CandlestickChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries("Btc price");
         for (int i = 0; i < series.getBarCount(); i++) {
             Bar bar = series.getBar(i);
-            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).doubleValue());
         }
         dataset.addSeries(chartTimeSeries);
         return dataset;

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -62,7 +62,7 @@ public class IndicatorsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Day(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Day(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }


### PR DESCRIPTION
according to visualvm, these "traceXYZ" methods used up to 15% of CPU time during my backtesting runs.