### PR TITLE
Leave last bar uncached

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -97,7 +97,10 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
                 // Result not calculated yet
                 highestResultIndex = index;
                 result = calculate(index);
-                results.set(results.size()-1, result);
+                if(index != series.getEndIndex()) {
+                    // Only cache results before last bar
+                    results.set(results.size()-1, result);
+                }
             } else {
                 // Result covered by current cache
                 int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -158,4 +158,22 @@ public class CachedIndicatorTest {
             fail(t.getMessage());
         }
     }
+
+    @Test
+    public void leaveLastBarUncached() {
+        TimeSeries timeSeries = new MockTimeSeries(1,2,3);
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(timeSeries);
+        assertEquals(3, closePrice.getValue(2).doubleValue(),0.001);
+        timeSeries.getLastBar().addTrade(10, 5);
+        assertEquals(5, closePrice.getValue(2).doubleValue(),0.001);
+    }
+
+    @Test
+    public void leaveBarsBeforeLastBarCached() {
+        TimeSeries timeSeries = new MockTimeSeries(1,2,3);
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(timeSeries);
+        assertEquals(2, closePrice.getValue(1).doubleValue(),0.001);
+        timeSeries.getBar(1).addTrade(10, 5);
+        assertEquals(2, closePrice.getValue(1).doubleValue(),0.001);
+    }
 }


### PR DESCRIPTION
Fixes #149 

Changes proposed in this pull request:
- Leaves last bar uncached in order to have real time indicators, allowing real time data sources to add trades to the last bar and retrieve updated indicators.