### PR TITLE
Update and clean javadoc. Remove deprecated toDouble() calls, clean code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -66,7 +66,7 @@ public class BaseStrategy implements Strategy {
      * Constructor.
      * @param entryRule the entry rule
      * @param exitRule the exit rule
-     * @param unstablePeriod
+     * @param unstablePeriod strategy will ignore possible signals at <code>index</code> < <code>unstablePeriod</code>
      */
     public BaseStrategy(Rule entryRule, Rule exitRule, int unstablePeriod) {
         this(null, entryRule, exitRule, unstablePeriod);
@@ -87,7 +87,7 @@ public class BaseStrategy implements Strategy {
      * @param name the name of the strategy
      * @param entryRule the entry rule
      * @param exitRule the exit rule
-     * @param unstablePeriod
+     * @param unstablePeriod strategy will ignore possible signals at <code>index</code> < <code>unstablePeriod</code>
      */
     public BaseStrategy(String name, Rule entryRule, Rule exitRule, int unstablePeriod) {
         if (entryRule == null || exitRule == null) {

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -22,13 +22,13 @@
  */
 package org.ta4j.core;
 
-import com.sun.istack.internal.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Base implementation of a {@link TimeSeries}.
@@ -118,9 +118,10 @@ public class BaseTimeSeries implements TimeSeries {
      * @param seriesEndIndex the end index (inclusive) of the time series
      * @param constrained true to constrain the time series (i.e. indexes cannot change), false otherwise
      */
-    private BaseTimeSeries(String name, @NotNull List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
-        this.name = name;
+    private BaseTimeSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
+        Objects.requireNonNull(bars);
         this.bars = bars;
+        this.name = name;
         if (bars.isEmpty()) {
         	// Bar list empty
             this.seriesBeginIndex = -1;

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -22,13 +22,13 @@
  */
 package org.ta4j.core;
 
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import com.sun.istack.internal.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base implementation of a {@link TimeSeries}.
@@ -118,9 +118,9 @@ public class BaseTimeSeries implements TimeSeries {
      * @param seriesEndIndex the end index (inclusive) of the time series
      * @param constrained true to constrain the time series (i.e. indexes cannot change), false otherwise
      */
-    private BaseTimeSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
+    private BaseTimeSeries(String name, @NotNull List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
         this.name = name;
-        this.bars = bars == null ? new ArrayList<>() : bars;
+        this.bars = bars;
         if (bars.isEmpty()) {
         	// Bar list empty
             this.seriesBeginIndex = -1;

--- a/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Decimal.java
@@ -491,11 +491,8 @@ public final class Decimal
             return false;
         }
         final Decimal other = (Decimal) obj;
-        if (this.delegate != other.delegate
-                && (this.delegate == null || (this.delegate.compareTo(other.delegate) != 0))) {
-            return false;
-        }
-        return true;
+        return this.delegate == other.delegate
+                || (this.delegate != null && (this.delegate.compareTo(other.delegate) == 0));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
@@ -66,8 +66,6 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append(" (").append(criterion).append(')');
-        return sb.toString();
+        return super.toString() + " (" + criterion + ')';
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -127,15 +127,15 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
             int newResultsCount = Math.min(index-highestResultIndex, maxLength);
             if (newResultsCount == maxLength) {
                 results.clear();
-                results.addAll(Collections.<T> nCopies(maxLength, null));
+                results.addAll(Collections.nCopies(maxLength, null));
             } else if (newResultsCount > 0) {
-                results.addAll(Collections.<T> nCopies(newResultsCount, null));
+                results.addAll(Collections.nCopies(newResultsCount, null));
                 removeExceedingResults(maxLength);
             }
         } else {
             // First use of cache
             assert results.isEmpty() : "Cache results list should be empty";
-            results.addAll(Collections.<T> nCopies(Math.min(index+1, maxLength), null));
+            results.addAll(Collections.nCopies(Math.min(index+1, maxLength), null));
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -35,22 +35,22 @@ import org.ta4j.core.Indicator;
 public class MACDIndicator extends CachedIndicator<Decimal> {
 
     private static final long serialVersionUID = -6899062131135971403L;
-    
+
     private final EMAIndicator shortTermEma;
     private final EMAIndicator longTermEma;
 
     /**
      * Constructor with shortTimeFrame "12" and longTimeFrame "26".
-     * 
+     *
      * @param indicator the indicator
      */
     public MACDIndicator(Indicator<Decimal> indicator) {
        this(indicator, 12, 26);
     }
-    
+
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the indicator
      * @param shortTimeFrame the short time frame (normally 12)
      * @param longTimeFrame the long time frame (normally 26)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -66,7 +66,7 @@ public class UlcerIndexIndicator extends CachedIndicator<Decimal> {
             squaredAverage = squaredAverage.plus(percentageDrawdown.pow(2));
         }
         squaredAverage = squaredAverage.dividedBy(Decimal.valueOf(numberOfObservations));
-        return Decimal.valueOf(Math.sqrt(squaredAverage.toDouble()));
+        return Decimal.valueOf(Math.sqrt(squaredAverage.doubleValue()));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -69,7 +69,7 @@ public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
 		 * Transforms the decimal indicator to a boolean indicator by
 		 * indicator.isLessThanOrEqual(coefficient).
 		 */
-		isLessThanOrEqual;
+		isLessThanOrEqual
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
 		 * Transforms the decimal indicator to a boolean indicator by
 		 * indicator.isZero().
 		 */
-		isZero;
+		isZero
 	}
 
 	private Indicator<Decimal> indicator;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -72,7 +72,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		 * other-{@link Indicator indicator} increase within a timeFrame. In
 		 * short: "other" makes higher highs while "ref" makes lower lows.
 		 */
-		negativeDivergent;
+		negativeDivergent
 	}
 	
 	/**
@@ -112,7 +112,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		 * consecutively within a timeFrame. In short: "other" makes strict
 		 * lower lows and "ref" makes strict higher highs.
 		 */
-		negativeDivergentStrict;
+		negativeDivergentStrict
 	}
 
 
@@ -202,7 +202,6 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	 * @param ref the indicator
 	 * @param other the other indicator
 	 * @param timeFrame the time frame
-	 * @param type of strict convergence or divergence
 	 */
 	public ConvergenceDivergenceIndicator(Indicator<Decimal> ref, Indicator<Decimal> other, int timeFrame,
 			ConvergenceDivergenceStrictType strictType) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
@@ -75,7 +75,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Decimal> {
 		 * Transforms the input indicator 
 		 * by indicator.min(coefficient).
 		 */
-		min;
+		min
 	}
 
 	/**
@@ -98,7 +98,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Decimal> {
 		 * Transforms the input indicator 
 		 * by indicator.log().
 		 */
-		log;
+		log
 	}
 
 	private Indicator<Decimal> indicator;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
@@ -40,6 +40,7 @@ public class FixedIndicator<T> extends AbstractIndicator<T> {
      * Constructor.
      * @param values the values to be returned by this indicator
      */
+    @SuppressWarnings("unchecked") // the only way to insert elements of type T is via the constructor
     public FixedIndicator(T... values) {
         super(null);
         this.values.addAll(Arrays.asList(values));

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -62,7 +62,7 @@ public class PearsonCorrelationIndicator extends RecursiveCachedIndicator<Decima
 		
 		if (toSqrt.isGreaterThan(Decimal.ZERO)) {
 			// pearson = (n * Sxy - Sx * Sy) / sqrt((n * Sxx - Sx * Sx) * (n * Syy - Sy * Sy))
-			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(Decimal.valueOf(Math.sqrt(toSqrt.toDouble())));
+			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(Decimal.valueOf(Math.sqrt(toSqrt.doubleValue())));
 		}
 
 		return Decimal.NaN;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
@@ -39,7 +39,7 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Decimal> {
 	 * The type for the outcome of the {@link SimpleLinearRegressionIndicator}
 	 */
 	public enum SimpleLinearRegressionType {
-		y, slope, intercept;
+		y, slope, intercept
 	}
 
 	private Indicator<Decimal> indicator;
@@ -52,7 +52,7 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Decimal> {
 	 * Constructor for the y-values of the formula (y = slope * x + intercept).
 	 * 
 	 * @param indicator the indicator for the x-values of the formula.
-	 * @param timeFrame
+	 * @param timeFrame the time frame
 	 */
 	public SimpleLinearRegressionIndicator(Indicator<Decimal> indicator, int timeFrame) {
 		this(indicator, timeFrame, SimpleLinearRegressionType.y);
@@ -62,7 +62,7 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Decimal> {
 	 * Constructor.
 	 * 
 	 * @param indicator the indicator for the x-values of the formula.
-	 * @param timeFrame
+	 * @param timeFrame the time frame
 	 * @param type the type of the outcome value (y, slope, intercept)
 	 */
 	public SimpleLinearRegressionIndicator(Indicator<Decimal> indicator, int timeFrame,
@@ -76,12 +76,11 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Decimal> {
     @Override
     protected Decimal calculate(int index) {
         final int startIndex = Math.max(0, index - timeFrame + 1);
-        final int endIndex = index;
-        if (endIndex - startIndex + 1 < 2) {
+        if (index - startIndex + 1 < 2) {
             // Not enough observations to compute a regression line
             return Decimal.NaN;
         }
-        calculateRegressionLine(startIndex, endIndex);
+        calculateRegressionLine(startIndex, index);
         
         if (type == SimpleLinearRegressionType.slope) {
             return slope;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
@@ -40,7 +40,7 @@ public class ChaikinOscillatorIndicator extends CachedIndicator<Decimal> {
 	/**
 	 * Constructor.
 	 * 
-	 * @param series
+	 * @param series the {@link TimeSeries}
 	 * @param shortTimeFrame (usually 3)
 	 * @param longTimeFrame (usually 10)
 	 */
@@ -53,7 +53,7 @@ public class ChaikinOscillatorIndicator extends CachedIndicator<Decimal> {
 	/**
 	 * Constructor.
 	 * 
-	 * @param series
+	 * @param series the {@link TimeSeries}
 	 */
 	public ChaikinOscillatorIndicator(TimeSeries series) {
 		this(series, 3, 10);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -25,12 +25,15 @@ package org.ta4j.core.indicators.volume;
 import org.ta4j.core.Decimal;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.indicators.helpers.*;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.MaxPriceIndicator;
+import org.ta4j.core.indicators.helpers.MinPriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
 
 /**
  * Intraday Intensity Index
- * @see <a https://www.investopedia.com/terms/i/intradayintensityindex.asp>
- *     https://www.investopedia.com/terms/i/intradayintensityindex.asp</a>
+ * see https://www.investopedia.com/terms/i/intradayintensityindex.asp
+ *     https://www.investopedia.com/terms/i/intradayintensityindex.asp
  */
 public class IIIIndicator extends CachedIndicator<Decimal> {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/IsFallingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/IsFallingRule.java
@@ -80,7 +80,7 @@ public class IsFallingRule extends AbstractRule {
 
 		double ratio = count / (double) timeFrame;
 
-		final boolean satisfied = ratio >= minStrenght ? true : false;
+		final boolean satisfied = ratio >= minStrenght;
 		traceIsSatisfied(index, satisfied);
 		return satisfied;
 	}

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/IsRisingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/IsRisingRule.java
@@ -80,7 +80,7 @@ public class IsRisingRule extends AbstractRule {
 
 		double ratio = count / (double) timeFrame;
 		
-		final boolean satisfied = ratio >= minStrenght ? true : false;
+		final boolean satisfied = ratio >= minStrenght;
 		traceIsSatisfied(index, satisfied);
 		return satisfied;
 	}

--- a/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
@@ -47,6 +47,7 @@ public class TimeSeriesTest {
 
     private String defaultName;
 
+    @SuppressWarnings("deprecation") // it is purposed to test the deprecated sub series creation
     @Before
     public void setUp() {
         bars = new LinkedList<>();
@@ -60,6 +61,7 @@ public class TimeSeriesTest {
         defaultName = "Series Name";
 
         defaultSeries = new BaseTimeSeries(defaultName, bars);
+
         constrainedSeries = new BaseTimeSeries(defaultSeries,2, 4);
         emptySeries = new BaseTimeSeries();
 

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -22,26 +22,18 @@
  */
 package org.ta4j.core;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.*;
+import org.ta4j.core.mocks.MockIndicator;
+import org.ta4j.core.mocks.MockTradingRecord;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.zip.DataFormatException;
-
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.CellValue;
-import org.apache.poi.ss.usermodel.DateUtil;
-import org.apache.poi.ss.usermodel.FormulaEvaluator;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.ta4j.core.mocks.MockIndicator;
-import org.ta4j.core.mocks.MockTradingRecord;
 
 public class XlsTestsUtils {
 
@@ -232,7 +224,7 @@ public class XlsTestsUtils {
             }
             // after the data section header is found, add all rows that don't
             // have "//" in the first cell
-            if (noHeader == false) {
+            if (!noHeader) {
                 if (evaluator.evaluate(row.getCell(0)).formatAsString().compareTo("\"//\"") != 0) {
                     rows.add(row);
                 }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
@@ -23,7 +23,10 @@
 package org.ta4j.core.analysis;
 
 import org.junit.Test;
-import org.ta4j.core.*;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Order;
+import org.ta4j.core.TimeSeries;
+import org.ta4j.core.TradingRecord;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockTimeSeries;
 
@@ -203,7 +206,7 @@ public class CashFlowTest {
     @Test
     public void reallyLongCashFlow() {
         int size = 1000000;
-        TimeSeries sampleTimeSeries = new MockTimeSeries(Collections.nCopies(size, (Bar) new MockBar(10)));
+        TimeSeries sampleTimeSeries = new MockTimeSeries(Collections.nCopies(size, new MockBar(10)));
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, sampleTimeSeries), Order.sellAt(size - 1, sampleTimeSeries));
         CashFlow cashFlow = new CashFlow(sampleTimeSeries, tradingRecord);
         assertDecimalEquals(cashFlow.getValue(size - 1), 1);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
@@ -22,28 +22,23 @@
  */
 package org.ta4j.core.indicators;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.mocks.MockBar;
+import org.ta4j.core.mocks.MockTimeSeries;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.mocks.MockBar;
-import org.ta4j.core.mocks.MockTimeSeries;
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class ATRIndicatorTest extends IndicatorTest<TimeSeries, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public ATRIndicatorTest() throws Exception {
-        super((data, params) -> new ATRIndicator((TimeSeries) data, (int) params[0]));
+        super((data, params) -> new ATRIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "ATR.xls", 7);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
@@ -22,31 +22,26 @@
  */
 package org.ta4j.core.indicators;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertDecimalEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBar;
+import org.ta4j.core.mocks.MockTimeSeries;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.mocks.MockBar;
-import org.ta4j.core.mocks.MockTimeSeries;
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertDecimalEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class EMAIndicatorTest extends IndicatorTest<Indicator<Decimal>, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public EMAIndicatorTest() throws Exception {
-        super((data, params) -> new EMAIndicator((Indicator<Decimal>) data, (int) params[0]));
+        super((data, params) -> new EMAIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "EMA.xls", 6);
     }
     private TimeSeries data;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
@@ -22,30 +22,25 @@
  */
 package org.ta4j.core.indicators;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBar;
+import org.ta4j.core.mocks.MockTimeSeries;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.mocks.MockBar;
-import org.ta4j.core.mocks.MockTimeSeries;
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class MMAIndicatorTest extends IndicatorTest<Indicator<Decimal>, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public MMAIndicatorTest() throws Exception {
-        super((data, params) -> new MMAIndicator((Indicator<Decimal>) data, (int) params[0]));
+        super((data, params) -> new MMAIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "MMA.xls", 6);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -22,20 +22,16 @@
  */
 package org.ta4j.core.indicators;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.GainIndicator;
 import org.ta4j.core.indicators.helpers.LossIndicator;
 import org.ta4j.core.mocks.MockTimeSeries;
+
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class RSIIndicatorTest extends IndicatorTest<Indicator<Decimal>, Decimal> {
 
@@ -44,7 +40,7 @@ public class RSIIndicatorTest extends IndicatorTest<Indicator<Decimal>, Decimal>
     //private ExternalIndicatorTest sql;
 
     public RSIIndicatorTest() {
-        super((data, params) -> new RSIIndicator((Indicator<Decimal>) data, (int) params[0]));
+        super((data, params) -> new RSIIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "RSI.xls", 10);
         //sql = new SQLIndicatorTest(this.getClass(), "RSI.db", username, pass, table, column);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
@@ -22,26 +22,22 @@
  */
 package org.ta4j.core.indicators;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockTimeSeries;
+
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TATestsUtils.assertDecimalEquals;
 import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-import org.ta4j.core.mocks.MockTimeSeries;
 
 public class SMAIndicatorTest extends IndicatorTest<Indicator<Decimal>, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public SMAIndicatorTest() throws Exception {
-        super((data, params) -> new SMAIndicator((Indicator<Decimal>) data, (int) params[0]));
+        super((data, params) -> new SMAIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "SMA.xls", 6);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
@@ -22,24 +22,20 @@
  */
 package org.ta4j.core.indicators.adx;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
-
 import org.junit.Test;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.IndicatorTest;
 import org.ta4j.core.indicators.XLSIndicatorTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class ADXIndicatorTest extends IndicatorTest<TimeSeries, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public ADXIndicatorTest() throws Exception {
-        super((data, params) -> new ADXIndicator((TimeSeries) data, (int) params[0], (int) params[1]));
+        super((data, params) -> new ADXIndicator(data, (int) params[0], (int) params[1]));
         xls = new XLSIndicatorTest(this.getClass(), "ADX.xls", 15);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
@@ -22,24 +22,20 @@
  */
 package org.ta4j.core.indicators.adx;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
-
 import org.junit.Test;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.IndicatorTest;
 import org.ta4j.core.indicators.XLSIndicatorTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class MinusDIIndicatorTest extends IndicatorTest<TimeSeries, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public MinusDIIndicatorTest() {
-        super((data, params) -> new MinusDIIndicator((TimeSeries) data, (int) params[0]));
+        super((data, params) -> new MinusDIIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "ADX.xls", 13);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
@@ -22,24 +22,20 @@
  */
 package org.ta4j.core.indicators.adx;
 
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
-
 import org.junit.Test;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TATestsUtils;
-import org.ta4j.core.TimeSeries;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.IndicatorTest;
 import org.ta4j.core.indicators.XLSIndicatorTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TATestsUtils.assertIndicatorEquals;
 
 public class PlusDIIndicatorTest extends IndicatorTest<TimeSeries, Decimal> {
 
     private ExternalIndicatorTest xls;
 
     public PlusDIIndicatorTest() throws Exception {
-        super((data, params) -> new PlusDIIndicator((TimeSeries) data, (int) params[0]));
+        super((data, params) -> new PlusDIIndicator(data, (int) params[0]));
         xls = new XLSIndicatorTest(this.getClass(), "ADX.xls", 12);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
@@ -24,10 +24,8 @@
 package org.ta4j.core.indicators.volume;
 
 
-import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
-import org.ta4j.core.Decimal;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockTimeSeries;

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -51,7 +51,7 @@ public class Quickstart {
 
         // Getting the close price of the bars
         Decimal firstClosePrice = series.getBar(0).getClosePrice();
-        System.out.println("First close price: " + firstClosePrice.toDouble());
+        System.out.println("First close price: " + firstClosePrice.doubleValue());
         // Or within an indicator:
         ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
         // Here is the same close price:
@@ -60,7 +60,7 @@ public class Quickstart {
         // Getting the simple moving average (SMA) of the close price over the last 5 bars
         SMAIndicator shortSma = new SMAIndicator(closePrice, 5);
         // Here is the 5-bars-SMA value at the 42nd index
-        System.out.println("5-bars-SMA value at the 42nd index: " + shortSma.getValue(42).toDouble());
+        System.out.println("5-bars-SMA value at the 42nd index: " + shortSma.getValue(42).doubleValue());
 
         // Getting a longer SMA (e.g. over the 30 last bars)
         SMAIndicator longSma = new SMAIndicator(closePrice, 30);

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -59,7 +59,7 @@ public class BuyAndSellSignalsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -59,7 +59,7 @@ public class CashFlowToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Minute(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Minute(new Date(bar.getEndTime().toEpochSecond() * 1000)), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
@@ -22,23 +22,14 @@
  */
 package ta4jexamples.bots;
 
-import java.time.ZonedDateTime;
-
-import org.ta4j.core.Bar;
-import org.ta4j.core.BaseBar;
-import org.ta4j.core.BaseStrategy;
-import org.ta4j.core.BaseTradingRecord;
-import org.ta4j.core.Decimal;
-import org.ta4j.core.Order;
-import org.ta4j.core.Strategy;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.TradingRecord;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.trading.rules.OverIndicatorRule;
 import org.ta4j.core.trading.rules.UnderIndicatorRule;
-
 import ta4jexamples.loaders.CsvTradesLoader;
+
+import java.time.ZonedDateTime;
 
 /**
  * This class is an example of a dummy trading bot using ta4j.
@@ -79,11 +70,10 @@ public class TradingBotOnMovingTimeSeries {
         // Signals
         // Buy when SMA goes over close price
         // Sell when close price goes over SMA
-        Strategy buySellSignals = new BaseStrategy(
+        return new BaseStrategy(
                 new OverIndicatorRule(sma, closePrice),
                 new UnderIndicatorRule(sma, closePrice)
         );
-        return buySellSignals;
     }
 
     /**
@@ -136,7 +126,7 @@ public class TradingBotOnMovingTimeSeries {
             Thread.sleep(30); // I know...
             Bar newBar = generateRandomBar();
             System.out.println("------------------------------------------------------\n"
-                    + "Bar "+i+" added, close price = " + newBar.getClosePrice().toDouble());
+                    + "Bar "+i+" added, close price = " + newBar.getClosePrice().doubleValue());
             series.addBar(newBar);
 
             int endIndex = series.getEndIndex();

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -22,9 +22,6 @@
  */
 package ta4jexamples.indicators;
 
-import java.awt.*;
-import java.util.Date;
-
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
@@ -42,8 +39,10 @@ import org.jfree.ui.RefineryUtilities;
 import org.ta4j.core.Bar;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
-
 import ta4jexamples.loaders.CsvTradesLoader;
+
+import java.awt.*;
+import java.util.Date;
 
 /**
  * This class builds a traditional candlestick chart.
@@ -68,16 +67,14 @@ public class CandlestickChart {
         for (int i = 0; i < nbBars; i++) {
             Bar bar = series.getBar(i);
             dates[i] = new Date(bar.getEndTime().toEpochSecond() * 1000);
-            opens[i] = bar.getOpenPrice().toDouble();
-            highs[i] = bar.getMaxPrice().toDouble();
-            lows[i] = bar.getMinPrice().toDouble();
-            closes[i] = bar.getClosePrice().toDouble();
-            volumes[i] = bar.getVolume().toDouble();
+            opens[i] = bar.getOpenPrice().doubleValue();
+            highs[i] = bar.getMaxPrice().doubleValue();
+            lows[i] = bar.getMinPrice().doubleValue();
+            closes[i] = bar.getClosePrice().doubleValue();
+            volumes[i] = bar.getVolume().doubleValue();
         }
 
-        OHLCDataset dataset = new DefaultHighLowDataset("btc", dates, highs, lows, opens, closes, volumes);
-
-        return dataset;
+        return new DefaultHighLowDataset("btc", dates, highs, lows, opens, closes, volumes);
     }
 
     /**

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -62,7 +62,7 @@ public class IndicatorsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barseries.getBarCount(); i++) {
             Bar bar = barseries.getBar(i);
-            chartTimeSeries.add(new Day(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).toDouble());
+            chartTimeSeries.add(new Day(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
@@ -22,24 +22,19 @@
  */
 package ta4jexamples.indicators;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.ATRIndicator;
-import org.ta4j.core.indicators.EMAIndicator;
-import org.ta4j.core.indicators.PPOIndicator;
-import org.ta4j.core.indicators.ROCIndicator;
-import org.ta4j.core.indicators.RSIIndicator;
-import org.ta4j.core.indicators.SMAIndicator;
-import org.ta4j.core.indicators.WilliamsRIndicator;
+import org.ta4j.core.indicators.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.PriceVariationIndicator;
 import org.ta4j.core.indicators.helpers.TypicalPriceIndicator;
 import org.ta4j.core.indicators.statistics.StandardDeviationIndicator;
 import ta4jexamples.loaders.CsvTradesLoader;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * This class builds a CSV file containing values from indicators.
@@ -122,6 +117,7 @@ public class IndicatorsToCsv {
                     writer.close();
                 }
             } catch (IOException ioe) {
+                ioe.printStackTrace();
             }
         }
 

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -22,6 +22,12 @@
  */
 package ta4jexamples.loaders;
 
+import com.opencsv.CSVReader;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseTimeSeries;
+import org.ta4j.core.TimeSeries;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,13 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.ta4j.core.Bar;
-import org.ta4j.core.BaseBar;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.TimeSeries;
-
-import com.opencsv.CSVReader;
 
 /**
  * This class builds a Ta4j time series from a CSV file containing trades.
@@ -68,6 +67,7 @@ public class CsvTradesLoader {
                 try {
                     csvReader.close();
                 } catch (IOException ioe) {
+                    ioe.printStackTrace();
                 }
             }
         }

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -22,26 +22,20 @@
  */
 package ta4jexamples.walkforward;
 
+import org.ta4j.core.*;
+import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import ta4jexamples.loaders.CsvTradesLoader;
+import ta4jexamples.strategies.CCICorrectionStrategy;
+import ta4jexamples.strategies.GlobalExtremaStrategy;
+import ta4jexamples.strategies.MovingMomentumStrategy;
+import ta4jexamples.strategies.RSI2Strategy;
+
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.ta4j.core.AnalysisCriterion;
-import org.ta4j.core.BaseTimeSeries;
-import org.ta4j.core.Strategy;
-import org.ta4j.core.TimeSeries;
-import org.ta4j.core.TimeSeriesManager;
-import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
-
-import ta4jexamples.loaders.CsvTradesLoader;
-import ta4jexamples.strategies.CCICorrectionStrategy;
-import ta4jexamples.strategies.GlobalExtremaStrategy;
-import ta4jexamples.strategies.MovingMomentumStrategy;
-import ta4jexamples.strategies.RSI2Strategy;
 
 /**
  * Walk-forward optimization example.
@@ -122,7 +116,7 @@ public class WalkForward {
             subseriesNbBars++;
         }
 
-        return new BaseTimeSeries(series, beginIndex, beginIndex + subseriesNbBars - 1);
+        return series.getSubSeries(beginIndex, beginIndex + subseriesNbBars);
     }
 
     /**


### PR DESCRIPTION
Changes proposed in this pull request:
- update javadoc
- clean code (simplify some if and returne statements, remove redundant casts
- remove deprecated calls (toDouble() and new TimeSeries(series, begin, end)
