### PR TITLE
Leave last bar uncached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **DoubleNum**: `Num` implementation to support calculations based on `double` primitive
 - **BigDecimalNum**: Default `Num` implementation of `BaseTimeSeries`
 - **TestUtils**: removed convenience methods for permuted parameters, fixed all unit tests
+- **CachedIndicator**: Last bar is not cached to support real time indicators
 ### Removed/Deprecated
 - **Decimal**: _removed_. Replaced by `Num` interface
 - **TimeSeries#addBar(Bar bar)**: _deprecated_. Use `TimeSeries#addBar(Time, open, high, low, ...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **AbstractIndicator**: new `AbstractIndicator#numOf(Number n)` function as counterpart of dropped `Decimal.valueOf(double|int|..)`
 - **TimeSeries | Bar**: preferred way to add bar data to a `TimeSeries` is directly to the series via new `TimeSeries#addBar(time,open,high,..)` functions. It ensures to use the correct `Num` implementation of the series
 - **XlsTestsUtils**: now processes xls with one or more days between data rows (daily, weekly, monthly, etc).  Also handle xls #DIV/0! calculated cells (imported as NaN.NaN)
+- **CachedIndicator**: Last bar is not cached to support real time indicators
 ### Added
 - **BaseTimeSeries.SeriesBuilder**: simplifies creation of BaseTimeSeries.
 - **Num**: Extracted interface of dropped `Decimal` class
 - **DoubleNum**: `Num` implementation to support calculations based on `double` primitive
 - **BigDecimalNum**: Default `Num` implementation of `BaseTimeSeries`
 - **TestUtils**: removed convenience methods for permuted parameters, fixed all unit tests
-- **CachedIndicator**: Last bar is not cached to support real time indicators
 ### Removed/Deprecated
 - **Decimal**: _removed_. Replaced by `Num` interface
 - **TimeSeries#addBar(Bar bar)**: _deprecated_. Use `TimeSeries#addBar(Time, open, high, low, ...)`

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -92,21 +92,27 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
                 results.set(0, result);
             }
         } else {
-            increaseLengthTo(index, maximumResultCount);
-            if (index > highestResultIndex) {
-                // Result not calculated yet
-                highestResultIndex = index;
+            if (index == series.getEndIndex()) {
+                // Don't cache result if last bar
                 result = calculate(index);
-                results.set(results.size()-1, result);
             } else {
-                // Result covered by current cache
-                int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);
-                result = results.get(resultInnerIndex);
-                if (result == null) {
+                increaseLengthTo(index, maximumResultCount);
+                if (index > highestResultIndex) {
+                    // Result not calculated yet
+                    highestResultIndex = index;
                     result = calculate(index);
-                    results.set(resultInnerIndex, result);
+                    results.set(results.size()-1, result);
+                } else {
+                    // Result covered by current cache
+                    int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);
+                    result = results.get(resultInnerIndex);
+                    if (result == null) {
+                        result = calculate(index);
+                        results.set(resultInnerIndex, result);
+                    }
                 }
             }
+
         }
         return result;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -163,4 +163,26 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,Nu
             fail(t.getMessage());
         }
     }
+
+    @Test
+    public void leaveLastBarUncached() {
+        TimeSeries timeSeries = new MockTimeSeries(numFunction);
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(timeSeries);
+        assertNumEquals(5000, closePrice.getValue(timeSeries.getEndIndex()));
+        timeSeries.getLastBar().addTrade(numOf(10), numOf(5));
+        assertNumEquals(5, closePrice.getValue(timeSeries.getEndIndex()));
+
+    }
+
+    @Test
+    public void leaveBarsBeforeLastBarCached() {
+        TimeSeries timeSeries = new MockTimeSeries(numFunction);
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(timeSeries);
+
+        // Add a forgotten trade, should be ignored in the cached indicator
+        assertNumEquals(2, closePrice.getValue(1));
+        timeSeries.getBar(1).addTrade(numOf(10), numOf(5));
+        assertNumEquals(2, closePrice.getValue(1));
+    }
+
 }


### PR DESCRIPTION
Fixes #149

Leaves last bar uncached in order to have real time indicators, allowing real time data sources to add trades to the last bar and retrieve updated indicators.