### PR TITLE
Adding addPrice function to TimeSeries and Bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **TimeSeries | Bar**: preferred way to add bar data to a `TimeSeries` is directly to the series via new `TimeSeries#addBar(time,open,high,..)` functions. It ensures to use the correct `Num` implementation of the series
 - **XlsTestsUtils**: now processes xls with one or more days between data rows (daily, weekly, monthly, etc).  Also handle xls #DIV/0! calculated cells (imported as NaN.NaN)
 - **CachedIndicator**: Last bar is not cached to support real time indicators
+- **TimeSeries | Bar **: added new `#addPrice(price)` function that adds price to (last) bar.
 ### Added
 - **BaseTimeSeries.SeriesBuilder**: simplifies creation of BaseTimeSeries.
 - **Num**: Extracted interface of dropped `Decimal` class
 - **DoubleNum**: `Num` implementation to support calculations based on `double` primitive
 - **BigDecimalNum**: Default `Num` implementation of `BaseTimeSeries`
 - **TestUtils**: removed convenience methods for permuted parameters, fixed all unit tests
+- **TestUtils**: added parametrized abstract test classes to allow two test runs with `DoubleNum` and `BigDecimalNum`
 ### Removed/Deprecated
 - **Decimal**: _removed_. Replaced by `Num` interface
 - **TimeSeries#addBar(Bar bar)**: _deprecated_. Use `TimeSeries#addBar(Time, open, high, low, ...)`

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -158,4 +158,15 @@ public interface Bar extends Serializable {
      * @param tradePrice the price
      */
     void addTrade(Num tradeVolume, Num tradePrice);
+
+
+    default void addPrice(String price, Function<Number, Num> numFunction){
+        addPrice(numFunction.apply(new BigDecimal(price)));
+    }
+
+    default void addPrice(Number price, Function<Number, Num> numFunction){
+        addPrice(numFunction.apply(price));
+    }
+
+    void addPrice(Num price);
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -221,25 +221,30 @@ public class BaseBar implements Bar {
      * @param tradePrice the price
      */
     public void addTrade(Num tradeVolume, Num tradePrice) {
-        if (openPrice == null) {
-            openPrice = tradePrice;
-        }
-        closePrice = tradePrice;
-
-        if (maxPrice == null) {
-            maxPrice = tradePrice;
-        } else {
-            maxPrice = maxPrice.isLessThan(tradePrice) ? tradePrice : maxPrice;
-        }
-        if (minPrice == null) {
-            minPrice = tradePrice;
-        } else {
-            minPrice = minPrice.isGreaterThan(tradePrice) ? tradePrice : minPrice;
-        }
+        addPrice(tradePrice);
 
         volume = volume.plus(tradeVolume);
         amount = amount.plus(tradeVolume.multipliedBy(tradePrice));
         trades++;
+    }
+
+    @Override
+    public void addPrice(Num price) {
+        if (openPrice == null) {
+            openPrice = price;
+        }
+
+        closePrice = price;
+        if (maxPrice == null) {
+            maxPrice = price;
+        } else if(maxPrice.isLessThan(price)) {
+            maxPrice = price;
+        }
+        if (minPrice == null) {
+            minPrice = price;
+        } else if(minPrice.isGreaterThan(price)){
+            minPrice = price;
+        }
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -314,11 +314,10 @@ public class BaseTimeSeries implements TimeSeries {
     }
 
     /**
-     * @deprecated will be private in next release. Use other {@link #addBar(Duration, ZonedDateTime) addBar function}
-     * @param bar the bar to be added
+     * @param bar the <code>Bar</code> to be added
+     * @apiNote to add bar data directly use #addBar(Duration, ZonedDateTime, Num, Num, Num, Num, Num)
      */
     @Override
-    @Deprecated
     public void addBar(Bar bar) {
         Objects.requireNonNull(bar);
         if(!checkBar(bar)){
@@ -346,73 +345,27 @@ public class BaseTimeSeries implements TimeSeries {
     }
 
     @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function, converts to Num before calling constructor
     public void addBar(Duration timePeriod, ZonedDateTime endTime) {
-        this.addBar(new BaseBar(timePeriod,endTime, function()));
+        this.addBar(new BaseBar(timePeriod, endTime, function()));
     }
 
     @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function, converts to Num before calling constructor
-    public void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice,
-                       Number volume) {
-        this.addBar(new BaseBar(endTime, numOf(openPrice), numOf(highPrice), numOf(lowPrice), numOf(closePrice),
-                numOf(volume), numOf(0)));
-    }
-
-    @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function, converts to Num before calling constructor
-    public void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice,
-                       Number volume, Number amount) {
-        this.addBar(new BaseBar(endTime, numOf(openPrice), numOf(highPrice), numOf(lowPrice), numOf(closePrice),
-                numOf(volume), numOf(amount)));
-    }
-
-    @Override
-    public void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice) {
-        this.addBar(endTime,openPrice,highPrice,lowPrice,closePrice,0);
-    }
-
-    @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
-    public void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice,
-                       String volume) {
-        this.addBar(new BaseBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
-                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(new BigDecimal(volume)),
-                numOf(0)));
-    }
-
-    @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
-    public void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice,
-                       String volume, String amount) {
-        this.addBar(new BaseBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
-                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(new BigDecimal(volume)),
-                numOf(new BigDecimal(amount))));
-    }
-
-    @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
-    public void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice) {
-        this.addBar(new BaseBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
-                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(0),
-                numOf(0)));
-    }
-
-    @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
     public void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume) {
         this.addBar(new BaseBar(endTime, openPrice,highPrice,lowPrice,closePrice,volume, numOf(0)));
     }
 
     @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
+    public void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount) {
+        this.addBar(new BaseBar(endTime,openPrice,highPrice,lowPrice,closePrice,volume,amount));
+    }
+
+    @Override
     public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
                        Num closePrice, Num volume) {
         this.addBar(new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, numOf(0)));
     }
 
     @Override
-    @SuppressWarnings( "deprecation" ) // will also work with private addBar function
     public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
                        Num closePrice, Num volume, Num amount) {
         this.addBar(new BaseBar(timePeriod, endTime, openPrice,highPrice,lowPrice,closePrice,volume, amount));
@@ -431,6 +384,11 @@ public class BaseTimeSeries implements TimeSeries {
     @Override
     public void addTrade(Num tradeVolume, Num tradePrice) {
         getLastBar().addTrade(tradeVolume,tradePrice);
+    }
+
+    @Override
+    public void addPrice(Num price) {
+        getLastBar().addPrice(price);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
@@ -25,6 +25,7 @@ package org.ta4j.core;
 import org.ta4j.core.num.Num;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -144,27 +145,133 @@ public interface TimeSeries extends Serializable {
      * Exceeding bars are removed.
      * @param bar the bar to be added
      * @see TimeSeries#setMaximumBarCount(int)
-     * @deprecated use the {@link #addBar(Duration, ZonedDateTime)}  other addBar functions} to add and convert data directly
+     * @apiNote use #addBar(Duration, ZonedDateTime, Num, Num, Num, Num, Num) to add bar data directly
      */
     void addBar(Bar bar);
 
+    /**
+     * Adds a bar at the end of the series.
+     * @param timePeriod the {@link Duration} of this bar
+     * @param endTime the {@link ZonedDateTime end time} of this bar
+     */
     void addBar(Duration timePeriod, ZonedDateTime endTime);
-    void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice);
-    void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice, Number volume);
-    void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice, Number volume, Number amount);
 
-    void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice);
-    void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume);
-    void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume, String amount);
+    default void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice){
+        this.addBar(endTime, numOf(openPrice), numOf(highPrice), numOf(lowPrice), numOf(closePrice), numOf(0), numOf(0));
+    }
 
-    void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume);
-    void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume);
-    void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount);
+    default void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice,
+                        Number volume){
+        this.addBar(endTime, numOf(openPrice), numOf(highPrice), numOf(lowPrice), numOf(closePrice), numOf(volume));
+    }
 
-    void addTrade(Number price, Number amount);
-    void addTrade(String price, String amount);
+    default void addBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice, Number closePrice,
+                        Number volume, Number amount){
+        this.addBar(endTime, numOf(openPrice), numOf(highPrice), numOf(lowPrice), numOf(closePrice), numOf(volume),
+                numOf(amount));
+    }
+
+    default void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice){
+        this.addBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
+                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(0),
+                numOf(0));
+    }
+
+    default void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice,
+                        String volume){
+        this.addBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
+                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(new BigDecimal(volume)),
+                numOf(0));
+    }
+
+    default void addBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice,
+                        String volume, String amount){
+        this.addBar(endTime, numOf(new BigDecimal(openPrice)), numOf(new BigDecimal(highPrice)),
+                numOf(new BigDecimal(lowPrice)), numOf(new BigDecimal(closePrice)), numOf(new BigDecimal(volume)),
+                numOf(new BigDecimal(amount)));
+    }
+
+    default void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume){
+        this.addBar(endTime, openPrice, highPrice, lowPrice, closePrice, volume, numOf(0));
+    }
+
+    /**
+     * Adds a new <code>Bar</code> to the time series.
+     * @param endTime end time of the bar
+     * @param openPrice the open price
+     * @param highPrice the high/max price
+     * @param lowPrice the low/min price
+     * @param closePrice the last/close price
+     * @param volume the volume (default zero)
+     * @param amount the amount (default zero)
+     */
+    void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume,
+                Num amount);
+
+    /**
+     * Adds a new <code>Bar</code> to the time series.
+     * @param endTime end time of the bar
+     * @param openPrice the open price
+     * @param highPrice the high/max price
+     * @param lowPrice the low/min price
+     * @param closePrice the last/close price
+     * @param volume the volume (default zero)
+     */
+    void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+                Num volume);
+
+    /**
+     * Adds a new <code>Bar</code> to the time series.
+     * @param timePeriod the time period of the bar
+     * @param endTime end time of the bar
+     * @param openPrice the open price
+     * @param highPrice the high/max price
+     * @param lowPrice the low/min price
+     * @param closePrice the last/close price
+     * @param volume the volume (default zero)
+     * @param amount the amount (default zero)
+     */
+    void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+                Num volume, Num amount);
+
+    /**
+     * Adds a trade at the end of bar period.
+     * @param tradeVolume the traded volume
+     * @param tradePrice the price
+     */
+    default void addTrade(Number tradeVolume, Number tradePrice){
+        addTrade(numOf(tradeVolume), numOf(tradePrice));
+    }
+
+    /**
+     * Adds a trade at the end of bar period.
+     * @param tradeVolume the traded volume
+     * @param tradePrice the price
+     */
+    default void addTrade(String tradeVolume, String tradePrice){
+        addTrade(numOf(new BigDecimal(tradeVolume)), numOf(new BigDecimal(tradePrice)));
+    }
+
+    /**
+     * Adds a trade at the end of bar period.
+     * @param tradeVolume the traded volume
+     * @param tradePrice the price
+     */
     void addTrade(Num tradeVolume, Num tradePrice);
 
+    /**
+     * Adds a price to the last bar
+     * @param price the price for the bar
+     */
+    void addPrice(Num price);
+
+    default void addPrice(String price){
+        addPrice(new BigDecimal(price));
+    }
+
+    default void addPrice(Number price){
+        addPrice(numOf(price));
+    }
 
     /**
      * Returns a new TimeSeries implementation that is a subset of this TimeSeries implementation.

--- a/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
@@ -25,6 +25,10 @@ package org.ta4j.core;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.MaxPriceIndicator;
+import org.ta4j.core.indicators.helpers.MinPriceIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.BigDecimalNum;
 import org.ta4j.core.num.DoubleNum;
@@ -243,6 +247,33 @@ public class TimeSeriesTest extends AbstractIndicatorTest<TimeSeries,Num> {
         assertEquals(2, defaultSeries.getBarCount());
         assertEquals(0, defaultSeries.getBeginIndex());
         assertEquals(1, defaultSeries.getEndIndex());
+    }
+
+    @Test
+    public void addPriceTest(){
+        ClosePriceIndicator cp = new ClosePriceIndicator(defaultSeries);
+        MaxPriceIndicator mxPrice = new MaxPriceIndicator(defaultSeries);
+        MinPriceIndicator mnPrice = new MinPriceIndicator(defaultSeries);
+        PreviousValueIndicator prevValue = new PreviousValueIndicator(cp, 1);
+
+        Num adding1 = numOf(100);
+        Num prevClose = defaultSeries.getBar(defaultSeries.getEndIndex()-1).getClosePrice();
+        Num currentMin = mnPrice.getValue(defaultSeries.getEndIndex());
+        Num currentClose = cp.getValue(defaultSeries.getEndIndex());
+
+        TestUtils.assertNumEquals(currentClose, defaultSeries.getLastBar().getClosePrice());
+        defaultSeries.addPrice(adding1);
+        TestUtils.assertNumEquals(adding1, cp.getValue(defaultSeries.getEndIndex())); // adding1 is new close
+        TestUtils.assertNumEquals(adding1, mxPrice.getValue(defaultSeries.getEndIndex())); // adding1 also new max
+        TestUtils.assertNumEquals(currentMin, mnPrice.getValue(defaultSeries.getEndIndex())); // min stays same
+        TestUtils.assertNumEquals(prevClose, prevValue.getValue(defaultSeries.getEndIndex())); // previous close stays same
+
+        Num adding2 = numOf(0);
+        defaultSeries.addPrice(adding2);
+        TestUtils.assertNumEquals(adding2, cp.getValue(defaultSeries.getEndIndex())); // adding2 is new close
+        TestUtils.assertNumEquals(adding1, mxPrice.getValue(defaultSeries.getEndIndex())); // max stays 100
+        TestUtils.assertNumEquals(adding2, mnPrice.getValue(defaultSeries.getEndIndex())); // min is new adding2
+        TestUtils.assertNumEquals(prevClose, prevValue.getValue(defaultSeries.getEndIndex())); // previous close stays same
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Last value of CachedIndicator will not be cached since PR #181. This PR
allows to use corresponding function TimSeries#addPrice and Bar#addPrice
to add a single price (that could be available in real time trading) to
the last bar of the TimeSeries or the Bar.

Enhances: #103 #160 #149

Changes proposed in this pull request:
- `addPrice(Num price)` function added to Bar
- `addPrice(Num price`) function added to TimeSeries
- changes `Bar|TimeSeries#addTrade(Num amount, Num price)` to use new addPrice function

- [X] added an entry to the unreleased section of `CHANGES.md` 
