### PR TITLE
Fix bug in assertNumEquals that wrongly compares the String and Num

### DIFF
--- a/ta4j-core/src/test/java/org/ta4j/core/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/NumTest.java
@@ -1,5 +1,6 @@
 package org.ta4j.core;
 
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.num.BigDecimalNum;
@@ -147,6 +148,11 @@ public class NumTest extends AbstractIndicatorTest {
         assertFalse(five.equals(five.function().apply(6)));
         assertFalse(five.equals(five.function().apply((float)15)));
         assertFalse(five.equals(five.function().apply((short)45)));
+    }
+
+    @Test(expected = ComparisonFailure.class)
+    public void testNumEqualsFailsIfThereIsADifference() {
+        assertNumEquals("1", numOf(2));
     }
 
     //TODO: add precision tests for BigDecimalNum

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -46,7 +46,7 @@ public class TestUtils {
      * @throws AssertionError if the actual value is not equal to the given {@code String} representation
      */
     public static void assertNumEquals(String expected, Num actual) {
-        assertEquals(expected, actual.numOf(new BigDecimal(expected)).toString());
+        assertEquals(expected, actual.toString());
     }
 
     public static void assertNumEquals(Num expected, Num actual){


### PR DESCRIPTION
There is a (major) bug in the test framework:

```java
    public static void assertNumEquals(String expected, Num actual) {
        assertEquals(expected, actual.numOf(new BigDecimal(expected)).toString());
    }
```

Notice that it's basically checking that expected == expected, making all the tests green, but not checking what's it's supposed to do.

E.g. if you take the develop branch and run the LowestValueIndicatorTest

```java
    @Test
    public void lowestValueIndicatorUsingTimeFrame5UsingClosePrice() {
        data = new MockTimeSeries(numFunction,1, 2, 3, 4, 3, 4, 5, 6, 4, 3, 2, 4, 3, 1);

        LowestValueIndicator lowestValue = new LowestValueIndicator(new ClosePriceIndicator(data), 5);
        assertNumEquals("9999.0", lowestValue.getValue(1));
    }
```

This will be green, while of/c the lowest value should be 1 and not 9999

I fixed it by checking `expected` vs `actual.toString()`, but now there are some small formatting differences between the `DoubleNum` and `BigDecimal` implementation and i'm not sure how you guys see this and how it should be.

E.g.:

```
Expected :0.45
Actual   :0.450

Expected :0.45
Actual   :0.44999999999999996
```

What's your guys vision on this and how should the (now failing) tests be fixed?