### PR TITLE
Fix wrong indexing in Indicator.toDouble()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Fixed
+- Fixed wrong indexing in `Indicator.toDouble()`.
+
 ### Changed
 - **ALL INDICATORS**: `Decimal` replaced by `Num`.
 - **AbstractIndicator**: new `AbstractIndicator#numOf(Number n)` function as counterpart of dropped `Decimal.valueOf(double|int|..)`

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -38,17 +38,5 @@
             <version>3.17</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.9.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -38,5 +38,17 @@
             <version>3.17</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *   The MIT License (MIT)
  *
- *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization 
+ *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization
  *   & respective authors (see AUTHORS)
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -23,56 +23,32 @@
  *******************************************************************************/
 package org.ta4j.core;
 
+import org.junit.Test;
+import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
-import java.io.Serializable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
- * Indicator over a {@link TimeSeries time series}.
- * <p/p>
- * For each index of the time series, returns a value of type <b>T</b>.
+ * Tests for {@link Indicator}.
  *
- * @param <T> the type of returned value (Double, Boolean, etc.)
+ * @author Johnny Lim
  */
-public interface Indicator<T> extends Serializable {
+public class IndicatorTest {
 
-    /**
-     * @param index the bar index
-     * @return the value of the indicator
-     */
-    T getValue(int index);
+	@Test
+	public void toDouble() {
+		Indicator<Num> indicator = mock(Indicator.class);
+		when(indicator.getValue(8)).thenReturn(DoubleNum.valueOf(1d));
+		when(indicator.getValue(9)).thenReturn(DoubleNum.valueOf(2d));
+		when(indicator.getValue(10)).thenReturn(DoubleNum.valueOf(3d));
 
-	/**
-	 * @return the related time series
-	 */
-	TimeSeries getTimeSeries();
+		int index = 10;
+		int barCount = 3;
 
-	/**
-	 * @return  the {@link Num Num extending class} for the given {@link Number}
-	 */
-	Num numOf(Number number);
-
-	 /**
-	 * Returns all values from an {@link Indicator} as an array of Doubles. The
-	 * returned doubles could have a minor loss of precise, if {@link Indicator}
-	 * was based on {@link Num Num}.
-	 *
-	 * @param ref the indicator
-	 * @param index the index
-	 * @param barCount the barCount
-	 * @return array of Doubles within the barCount
-	 */
-	static Double[] toDouble(Indicator<Num> ref, int index, int barCount) {
-
-		Double[] all = new Double[barCount];
-
-		int startIndex = Math.max(0, index - barCount + 1);
-		for (int i = 0; i < barCount; i++) {
-			Num number = ref.getValue(i + startIndex);
-			all[i] = number.doubleValue();
-		}
-
-		return all;
+		assertThat(Indicator.toDouble(indicator, index, barCount)).containsExactly(1d, 2d, 3d);
 	}
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
@@ -23,13 +23,14 @@
  *******************************************************************************/
 package org.ta4j.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
-import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.mocks.MockIndicator;
 import org.ta4j.core.num.Num;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link Indicator}.
@@ -40,15 +41,22 @@ public class IndicatorTest {
 
 	@Test
 	public void toDouble() {
-		Indicator<Num> indicator = mock(Indicator.class);
-		when(indicator.getValue(8)).thenReturn(DoubleNum.valueOf(1d));
-		when(indicator.getValue(9)).thenReturn(DoubleNum.valueOf(2d));
-		when(indicator.getValue(10)).thenReturn(DoubleNum.valueOf(3d));
+		TimeSeries series = new BaseTimeSeries();
+		List<Num> values = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			values.add(series.numOf(i));
+		}
+		Indicator<Num> indicator = new MockIndicator(series, values);
 
 		int index = 10;
 		int barCount = 3;
 
-		assertThat(Indicator.toDouble(indicator, index, barCount)).containsExactly(1d, 2d, 3d);
+		Double[] doubles = Indicator.toDouble(indicator, index, barCount);
+
+		assertTrue(doubles.length == barCount);
+		assertTrue(doubles[0] == 8d);
+		assertTrue(doubles[1] == 9d);
+		assertTrue(doubles[2] == 10d);
 	}
 
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix wrong indexing in `Indicator.toDouble()`.
- Add a test for it and AssertJ and Mockito for easy tests.

- [X] added an entry to the unreleased section of `CHANGES.md` 
