### PR TITLE
TestUtils: fix int, remove assertValuesEquals, add NotEquals methods

### DIFF
--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -69,7 +69,7 @@ public class TestUtils {
      * @throws AssertionError if the actual value is not equal to the given {@code int} representation
      */
     public static void assertNumEquals(int expected, Num actual) {
-        assertEquals(expected, actual.intValue());
+        assertEquals(actual.numOf(expected), actual);
     }
 
     /**
@@ -90,26 +90,12 @@ public class TestUtils {
      * @param unexpected the given {@code int} representation to compare the actual value to
      * @throws AssertionError if the actual value is equal to the given {@code int} representation
      */
-    public static void assertNumNotEquals(int unexpected,Num actual) {
-        assertNotEquals(unexpected, actual.intValue());
+    public static void assertNumNotEquals(int unexpected, Num actual) {
+        assertNotEquals(actual.numOf(unexpected), actual);
     }
 
     /**
-     * Verifies that expected values match indicator values.
-     *
-     * @param expectedValues expected list of values
-     * @param actualIndicator indicator to compare
-     */
-    public static void assertValuesEquals(Indicator<Num> actualIndicator, List<Num> expectedValues) {
-        assertEquals("Size does not match,", expectedValues.size(), actualIndicator.getTimeSeries().getBarCount());
-        for (int i = 0; i < expectedValues.size(); i++) {
-            assertEquals(String.format("Values at index <%d> does not match,", i),
-                    expectedValues.get(i).doubleValue(), actualIndicator.getValue(i).doubleValue(), GENERAL_OFFSET);
-        }
-    }
-
-    /**
-     * Verifies that two indicators have the same size and values
+     * Verifies that two indicators have the same size and values to an offset
      * @param expected indicator of expected values
      * @param actual indicator of actual values
      */
@@ -121,6 +107,54 @@ public class TestUtils {
                     expected.getValue(i).doubleValue(),
                     actual.getValue(i).doubleValue(), GENERAL_OFFSET);
         }
+    }
+
+    /**
+     * Verifies that two indicators have either different size or different values to an offset
+     * @param expected indicator of expected values
+     * @param actual indicator of actual values
+     */
+    public static void assertIndicatorNotEquals(Indicator<Num> expected, Indicator<Num> actual) {
+        if (expected.getTimeSeries().getBarCount() != actual.getTimeSeries().getBarCount())
+            return;
+        for (int i = 0; i < expected.getTimeSeries().getBarCount(); i++) {
+            if (Math.abs(expected.getValue(i).doubleValue() - actual.getValue(i).doubleValue()) > GENERAL_OFFSET)
+                return;
+        }
+        throw new AssertionError("Indicators match to " + GENERAL_OFFSET);
+    }
+
+    /**
+     * Verifies that the actual {@code Num} value is not equal to the given {@code String} representation.
+     *
+     * @param actual the actual {@code Num} value
+     * @param expected the given {@code String} representation to compare the actual value to
+     * @throws AssertionError if the actual value is equal to the given {@code String} representation
+     */
+    public static void assertNumNotEquals(String expected, Num actual) {
+        assertNotEquals(actual.numOf(new BigDecimal(expected)), actual);
+    }
+
+    /**
+     * Verifies that the actual {@code Num} value is not equal to the given {@code Num}.
+     *
+     * @param actual the actual {@code Num} value
+     * @param expected the given {@code Num} representation to compare the actual value to
+     * @throws AssertionError if the actual value is equal to the given {@code Num} representation
+     */
+    public static void assertNumNotEquals(Num expected, Num actual) {
+        assertNotEquals(expected, actual);
+    }
+
+    /**
+     * Verifies that the actual {@code Num} value is not equal (within a positive offset) to the given {@code double} representation.
+     *
+     * @param actual the actual {@code Num} value
+     * @param expected the given {@code double} representation to compare the actual value to
+     * @throws AssertionError if the actual value is equal to the given {@code double} representation
+     */
+    public static void assertNumNotEquals(double expected, Num actual) {
+        assertNotEquals(expected, actual.doubleValue(), GENERAL_OFFSET);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -1,0 +1,100 @@
+package org.ta4j.core;
+
+import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.Num;
+
+import static org.ta4j.core.TestUtils.*;
+
+public class TestUtilsTest extends AbstractIndicatorTest {
+
+    private static final String stringDouble = "1234567890.12345";
+    private static final String diffStringDouble = "1234567890.12346";
+    private static final BigDecimal bigDecimalDouble = new BigDecimal(stringDouble);
+    private static final BigDecimal diffBigDecimalDouble = new BigDecimal(diffStringDouble);
+    private static final int aInt = 1234567890;
+    private static final int diffInt = 1234567891;
+    private static final double aDouble = 1234567890.1234;
+    private static final double diffDouble = 1234567890.1235;
+    private static Num numStringDouble;
+    private static Num diffNumStringDouble;
+    private static Num numInt;
+    private static Num diffNumInt;
+    private static Num numDouble;
+    private static Num diffNumDouble;
+    private static Indicator<Num> indicator;
+    private static Indicator<Num> diffIndicator;
+
+    public TestUtilsTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+        numStringDouble = numOf(bigDecimalDouble);
+        diffNumStringDouble = numOf(diffBigDecimalDouble);
+        numInt = numOf(aInt);
+        diffNumInt = numOf(diffInt);
+        numDouble = numOf(aDouble);
+        diffNumDouble = numOf(diffDouble);
+        TimeSeries series = randomSeries();
+        TimeSeries diffSeries = randomSeries();
+        indicator = new ClosePriceIndicator(series);
+        diffIndicator = new ClosePriceIndicator(diffSeries);
+    }
+
+    private TimeSeries randomSeries() {
+        BaseTimeSeries.SeriesBuilder builder = new BaseTimeSeries.SeriesBuilder();
+        TimeSeries series = builder.withNumTypeOf(numFunction).build();
+        ZonedDateTime time = ZonedDateTime.of(1970, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault());
+        double random;
+        for (int i = 0; i < 1000; i++) {
+            random = Math.random();
+            time = time.plusDays(i);
+            series.addBar(new BaseBar(time, random, random, random, random, random, numFunction));
+        }
+        return series;
+    }
+
+    @Test
+    public void testStringNum() {
+        assertNumEquals(stringDouble, numStringDouble);
+        assertNumNotEquals(stringDouble, diffNumStringDouble);
+        assertNumNotEquals(diffStringDouble, numStringDouble);
+        assertNumEquals(diffStringDouble, diffNumStringDouble);
+    }
+
+    @Test
+    public void testNumNum() {
+        assertNumEquals(numStringDouble, numStringDouble);
+        assertNumNotEquals(numStringDouble, diffNumStringDouble);
+        assertNumNotEquals(diffNumStringDouble, numStringDouble);
+        assertNumEquals(diffNumStringDouble, diffNumStringDouble);
+    }
+
+    @Test
+    public void testIntNum() {
+        assertNumEquals(aInt, numInt);
+        assertNumNotEquals(aInt, diffNumInt);
+        assertNumNotEquals(diffInt, numInt);
+        assertNumEquals(diffInt, diffNumInt);
+    }
+
+    @Test
+    public void testDoubleNum() {
+        assertNumEquals(aDouble, numDouble);
+        assertNumNotEquals(aDouble, diffNumDouble);
+        assertNumNotEquals(diffDouble, numDouble);
+        assertNumEquals(diffDouble, diffNumDouble);
+    }
+
+    @Test
+    public void testIndicator() {
+        assertIndicatorEquals(indicator, indicator);
+        assertIndicatorNotEquals(indicator, diffIndicator);
+        assertIndicatorNotEquals(diffIndicator, indicator);
+        assertIndicatorEquals(diffIndicator, diffIndicator);
+    }
+}


### PR DESCRIPTION
Fixes #232 .

Changes proposed in this pull request:
- TestUtils: fix int, remove assertValuesEquals, add NotEquals methods
- Add TestUtilsTest for testing assert* methods
- 

- [ ] added an entry to the unreleased section of `CHANGES.md` 
