### PR TITLE
bug fix:  ATR(1) was built as ATR(chopTimeFrame)

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -45,7 +45,7 @@ public class ChopIndicator extends CachedIndicator<Num> {
 	 */
 	public ChopIndicator( TimeSeries timeseries, int ciTimeFrame, int scaleTo ) {
 		super( timeseries );
-        this.atrIndicator = new ATRIndicator( timeseries, ciTimeFrame );
+        this.atrIndicator = new ATRIndicator( timeseries, 1 );	// ATR(1) = Average True Range (Period of 1)
         hvi = new HighestValueIndicator( new MaxPriceIndicator(timeseries), ciTimeFrame );
         lvi = new LowestValueIndicator( new MinPriceIndicator(timeseries), ciTimeFrame );
         this.timeFrame = ciTimeFrame;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- bug fix:  ATR(timeframe=1) was built as ATR(timeframe=chopTimeFrame)