### PR TITLE
remove AbstractCriterionTest(Function<Number, Num>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **AroonUpIndicator**: redundant TimeSeries call was removed from constructor
 - **AroonDownIndicator**: redundant TimeSeries call was removed from constructor
 - **BaseTimeSeries**: added setDefaultFunction() to SeriesBuilder for setting the default Num type function for all new TimeSeries built by that SeriesBuilder, updated BuildTimeSeries example
+- **<various>CriterionTest**: changed from explicit constructor calls to `AbstractCriterionTest.getCriterion()` calls.
 
 ### Added
 - **BaseTimeSeries.SeriesBuilder**: simplifies creation of BaseTimeSeries.
@@ -50,6 +51,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **TestUtils**: removed convenience methods for permuted parameters, fixed all unit tests
 - **BaseTimeSeries**: _Constructor_ `BaseTimeSeries(TimeSeries defaultSeries, int seriesBeginIndex, int seriesEndIndex)` _removed_. Use `TimeSeries.getSubseries(int i, int i)` instead
 - **BigDecimalNum**: _removed_.  Replaced by `PrecisionNum`
+- **AbstractCriterionTest**: removed constructor `AbstractCriterionTest(Function<Number, Num)`.  Use `AbstractCriterionTest(CriterionFactory, Function<Number, Num>)`. 
 
 ## 0.11 (released January 25, 2018)
 

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
@@ -48,7 +48,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     private List<Strategy> strategies;
 
     public AbstractAnalysisCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new TotalProfitCriterion(), numFunction);
     }
 
     @Before
@@ -64,7 +64,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     public void bestShouldBeAlwaysOperateOnProfit() {
         MockTimeSeries series = new MockTimeSeries(numFunction,6.0, 9.0, 6.0, 6.0);
         TimeSeriesManager manager = new TimeSeriesManager(series);
-        Strategy bestStrategy = new TotalProfitCriterion().chooseBest(manager, strategies);
+        Strategy bestStrategy = getCriterion().chooseBest(manager, strategies);
         assertEquals(alwaysStrategy, bestStrategy);
     }
 
@@ -72,7 +72,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     public void bestShouldBeBuyAndHoldOnLoss() {
         MockTimeSeries series = new MockTimeSeries(numFunction,6.0, 3.0, 6.0, 6.0);
         TimeSeriesManager manager = new TimeSeriesManager(series);
-        Strategy bestStrategy = new TotalProfitCriterion().chooseBest(manager, strategies);
+        Strategy bestStrategy = getCriterion().chooseBest(manager, strategies);
         assertEquals(buyAndHoldStrategy, bestStrategy);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractCriterionTest.java
@@ -56,11 +56,6 @@ public abstract class AbstractCriterionTest {
         this.numFunction = numFunction;
     }
 
-    public AbstractCriterionTest(Function<Number, Num> numFunction){
-        this.factory = null;
-        this.numFunction = numFunction;
-    }
-
     /**
      * Generates an AnalysisCriterion given criterion parameters.
      * 

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitCriterionTest.java
@@ -37,7 +37,7 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest{
     private MockTimeSeries series;
 
     public AverageProfitCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new AverageProfitCriterion(), numFunction);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest{
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
-        AnalysisCriterion averageProfit = new AverageProfitCriterion();
+        AnalysisCriterion averageProfit = getCriterion();
         assertNumEquals(1.0243, averageProfit.calculate(series, tradingRecord));
     }
 
@@ -54,7 +54,7 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest{
     public void calculateWithASimpleTrade() {
         series = new MockTimeSeries(numFunction,100d, 105d, 110d, 100d, 95d, 105d);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0,series), Order.sellAt(2,series));
-        AnalysisCriterion averageProfit = new AverageProfitCriterion();
+        AnalysisCriterion averageProfit = getCriterion();
         assertNumEquals(numOf(110d/100).pow(numOf(1d/3)), averageProfit.calculate(series, tradingRecord));
     }
 
@@ -64,14 +64,14 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest{
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
-        AnalysisCriterion averageProfit = new AverageProfitCriterion();
+        AnalysisCriterion averageProfit = getCriterion();
         assertNumEquals(numOf(95d/100 * 70d/100).pow(numOf(1d / 6)), averageProfit.calculate(series, tradingRecord));
     }
 
     @Test
     public void calculateWithNoBarsShouldReturn1() {
         series = new MockTimeSeries(numFunction,100, 95, 100, 80, 85, 70);
-        AnalysisCriterion averageProfit = new AverageProfitCriterion();
+        AnalysisCriterion averageProfit = getCriterion();
         assertNumEquals(1, averageProfit.calculate(series, new BaseTradingRecord()));
     }
 
@@ -79,13 +79,13 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest{
     public void calculateWithOneTrade() {
         series = new MockTimeSeries(numFunction,100, 105);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
-        AnalysisCriterion average = new AverageProfitCriterion();
+        AnalysisCriterion average = getCriterion();
         assertNumEquals(numOf(105d / 100).pow(numOf(0.5)), average.calculate(series, trade));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new AverageProfitCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterionTest.java
@@ -36,7 +36,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class AverageProfitableTradesCriterionTest extends AbstractCriterionTest {
 
     public AverageProfitableTradesCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new AverageProfitableTradesCriterion(), numFunction);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class AverageProfitableTradesCriterionTest extends AbstractCriterionTest 
                 Order.buyAt(2, series), Order.sellAt(3, series),
                 Order.buyAt(4, series), Order.sellAt(5, series));
         
-        AverageProfitableTradesCriterion average = new AverageProfitableTradesCriterion();
+        AnalysisCriterion average = getCriterion();
         
         assertNumEquals(2d/3, average.calculate(series, tradingRecord));
     }
@@ -57,7 +57,7 @@ public class AverageProfitableTradesCriterionTest extends AbstractCriterionTest 
         TimeSeries series = new MockTimeSeries(numFunction,100d, 95d, 102d, 105d, 97d, 113d);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
             
-        AverageProfitableTradesCriterion average = new AverageProfitableTradesCriterion();
+        AnalysisCriterion average = getCriterion();
         assertNumEquals(numOf(0), average.calculate(series, trade));
         
         trade = new Trade(Order.buyAt(1, series), Order.sellAt(2, series));
@@ -66,7 +66,7 @@ public class AverageProfitableTradesCriterionTest extends AbstractCriterionTest 
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new AverageProfitableTradesCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(12), numOf(8)));
         assertFalse(criterion.betterThan(numOf(8), numOf(12)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterionTest.java
@@ -36,7 +36,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class BuyAndHoldCriterionTest extends AbstractCriterionTest{
 
     public BuyAndHoldCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new BuyAndHoldCriterion(), numFunction);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class BuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(1.05, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -57,7 +57,7 @@ public class BuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(0.7, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -65,7 +65,7 @@ public class BuyAndHoldCriterionTest extends AbstractCriterionTest{
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
     
@@ -73,13 +73,13 @@ public class BuyAndHoldCriterionTest extends AbstractCriterionTest{
     public void calculateWithOneTrade() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
-        AnalysisCriterion buyAndHold = new BuyAndHoldCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(105d/100, buyAndHold.calculate(series, trade));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new BuyAndHoldCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(1.3), numOf(1.1)));
         assertFalse(criterion.betterThan(numOf(0.6), numOf(0.9)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
@@ -36,13 +36,13 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
 
     public MaximumDrawdownCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new MaximumDrawdownCriterion(), numFunction);
     }
 
     @Test
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 1, 2, 3, 6, 5, 20, 3);
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
 
         assertNumEquals(0d, mdd.calculate(series, new BaseTradingRecord()));
     }
@@ -50,7 +50,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
     @Test
     public void calculateWithOnlyGains() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 1, 2, 3, 6, 8, 20, 3);
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(2,series), Order.sellAt(5,series));
@@ -61,7 +61,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
     @Test
     public void calculateShouldWork() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 1, 2, 3, 6, 5, 20, 3);
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(3,series), Order.sellAt(4,series),
@@ -74,14 +74,14 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
     @Test
     public void calculateWithNullSeriesSizeShouldReturn0() {
         MockTimeSeries series = new MockTimeSeries(numFunction, new double[] {});
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
         assertNumEquals(0d, mdd.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
     public void withTradesThatSellBeforeBuying() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 2, 1, 3, 5, 6, 3, 20);
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(3,series), Order.sellAt(4,series),
@@ -92,7 +92,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
     @Test
     public void withSimpleTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 1, 10, 5, 6, 1);
-        MaximumDrawdownCriterion mdd = new MaximumDrawdownCriterion();
+        AnalysisCriterion mdd = getCriterion();
         TradingRecord tradingRecord = new BaseTradingRecord(
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(1,series), Order.sellAt(2,series),
@@ -103,7 +103,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new MaximumDrawdownCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(0.9), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.2), numOf(0.4)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterionTest.java
@@ -36,14 +36,14 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class NumberOfBarsCriterionTest extends AbstractCriterionTest {
 
     public NumberOfBarsCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new NumberOfBarsCriterion(), numFunction);
     }
 
     @Test
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105, 110, 100, 95, 105);
 
-        AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
+        AnalysisCriterion numberOfBars = getCriterion();
         assertNumEquals(0, numberOfBars.calculate(series, new BaseTradingRecord()));
     }
 
@@ -54,7 +54,7 @@ public class NumberOfBarsCriterionTest extends AbstractCriterionTest {
                 Order.buyAt(0,series), Order.sellAt(2,series),
                 Order.buyAt(3,series), Order.sellAt(5,series));
 
-        AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
+        AnalysisCriterion numberOfBars = getCriterion();
         assertNumEquals(6, numberOfBars.calculate(series, tradingRecord));
     }
 
@@ -62,13 +62,13 @@ public class NumberOfBarsCriterionTest extends AbstractCriterionTest {
     public void calculateWithOneTrade() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
         Trade t = new Trade(Order.buyAt(2,series), Order.sellAt(5,series));
-        AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
+        AnalysisCriterion numberOfBars = getCriterion();
         assertNumEquals(4, numberOfBars.calculate(series, t));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new NumberOfBarsCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(3), numOf(6)));
         assertFalse(criterion.betterThan(numOf(6), numOf(2)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfTradesCriterionTest.java
@@ -36,14 +36,14 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class NumberOfTradesCriterionTest extends AbstractCriterionTest{
 
     public NumberOfTradesCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new NumberOfTradesCriterion(), numFunction);
     }
 
     @Test
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105, 110, 100, 95, 105);
 
-        AnalysisCriterion buyAndHold = new NumberOfTradesCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(0, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
 
@@ -54,7 +54,7 @@ public class NumberOfTradesCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = new NumberOfTradesCriterion();
+        AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(2, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -62,14 +62,14 @@ public class NumberOfTradesCriterionTest extends AbstractCriterionTest{
     public void calculateWithOneTrade() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105, 110, 100, 95, 105);
         Trade trade = new Trade();
-        NumberOfTradesCriterion tradesCriterion = new NumberOfTradesCriterion();
+        AnalysisCriterion tradesCriterion = getCriterion();
 
         assertNumEquals(1, tradesCriterion.calculate(series, trade));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new NumberOfTradesCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(3), numOf(6)));
         assertFalse(criterion.betterThan(numOf(7), numOf(4)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterionTest.java
@@ -36,15 +36,15 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class RewardRiskRatioCriterionTest extends AbstractCriterionTest{
 
-    private RewardRiskRatioCriterion rrc;
+    private AnalysisCriterion rrc;
 
     public RewardRiskRatioCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new RewardRiskRatioCriterion(), numFunction);
     }
 
     @Before
     public void setUp() {
-        this.rrc = new RewardRiskRatioCriterion();
+        this.rrc = getCriterion();
     }
 
     @Test
@@ -84,13 +84,13 @@ public class RewardRiskRatioCriterionTest extends AbstractCriterionTest{
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 95, 100, 90, 95, 80, 120);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
 
-        RewardRiskRatioCriterion ratioCriterion = new RewardRiskRatioCriterion();
+        AnalysisCriterion ratioCriterion = getCriterion();
         assertNumEquals((95d/100) / ((1d - 0.95d)), ratioCriterion.calculate(series, trade));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new RewardRiskRatioCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(3.5), numOf(2.2)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.7)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalProfitCriterionTest.java
@@ -36,7 +36,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 public class TotalProfitCriterionTest extends AbstractCriterionTest{
 
     public TotalProfitCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new TotalProfitCriterion(), numFunction);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0,series), Order.sellAt(2,series),
                 Order.buyAt(3,series), Order.sellAt(5,series));
 
-        AnalysisCriterion profit = new TotalProfitCriterion();
+        AnalysisCriterion profit = getCriterion();
         assertNumEquals(1.10 * 1.05, profit.calculate(series, tradingRecord));
     }
 
@@ -57,7 +57,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(2,series), Order.sellAt(5,series));
 
-        AnalysisCriterion profit = new TotalProfitCriterion();
+        AnalysisCriterion profit = getCriterion();
         assertNumEquals(0.95 * 0.7, profit.calculate(series, tradingRecord));
     }
 
@@ -68,7 +68,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest{
                 Order.sellAt(0,series), Order.buyAt(1,series),
                 Order.sellAt(2,series), Order.buyAt(5,series));
 
-        AnalysisCriterion profit = new TotalProfitCriterion();
+        AnalysisCriterion profit = getCriterion();
         assertNumEquals((1 / 0.95) * (1 / 0.7), profit.calculate(series, tradingRecord));
     }
 
@@ -76,14 +76,14 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest{
     public void calculateWithNoTradesShouldReturn1() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion profit = new TotalProfitCriterion();
+        AnalysisCriterion profit = getCriterion();
         assertNumEquals(1d, profit.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
     public void calculateWithOpenedTradeShouldReturn1() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
-        AnalysisCriterion profit = new TotalProfitCriterion();
+        AnalysisCriterion profit = getCriterion();
         Trade trade = new Trade();
         assertNumEquals(1d, profit.calculate(series, trade));
         trade.operate(0);
@@ -92,7 +92,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest{
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new TotalProfitCriterion();
+        AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
@@ -37,7 +37,7 @@ import static org.ta4j.core.num.NaN.NaN;
 public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
 
     public VersusBuyAndHoldCriterionTest(Function<Number, Num> numFunction) {
-        super(numFunction);
+        super((params) -> new VersusBuyAndHoldCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0,series), Order.sellAt(2,series),
                 Order.buyAt(3,series), Order.sellAt(5,series));
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
         assertNumEquals(1.10 * 1.05 / 1.05, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -58,7 +58,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(2,series), Order.sellAt(5,series));
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
         assertNumEquals(0.95 * 0.7 / 0.7, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -67,7 +67,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
         Trade trade = new Trade(Order.buyAt(0,series), Order.sellAt(1,series));
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
         assertNumEquals((100d / 70) / (100d / 95), buyAndHold.calculate(series, trade));
     }
 
@@ -75,7 +75,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
     public void calculateWithNoTrades() {
         MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
         assertNumEquals(1 / 0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
 
@@ -86,7 +86,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0, NaN, NaN), Order.sellAt(1, NaN, NaN),
                 Order.buyAt(2, NaN, NaN), Order.sellAt(5, NaN, NaN));
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new AverageProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new AverageProfitCriterion());
 
         assertNumEquals(Math.pow(95d/100 * 130d/100, 1d/6) / Math.pow(130d / 100, 1d/6), buyAndHold.calculate(series, tradingRecord));
     }
@@ -98,14 +98,14 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest{
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(2,series), Order.sellAt(5,series));
 
-        AnalysisCriterion buyAndHold = new VersusBuyAndHoldCriterion(new NumberOfBarsCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new NumberOfBarsCriterion());
 
         assertNumEquals(6d/6d, buyAndHold.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion criterion = getCriterion(new TotalProfitCriterion());
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }


### PR DESCRIPTION
removed AbstractCriterionTest(Function<Number, Num>)
<various>CriterionTest: fix to call getCriterion()
changelog


Fixes #214 

Changes proposed in this pull request:
- 
- 
- 

- [x] added an entry to the unreleased section of `CHANGES.md` 
