### PR TITLE
remove doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 - **TradingBotOnMovingTimeSeries**: fixed calculations and ArithmeticException Overflow
 - **Fixed wrong indexing in**: `Indicator.toDouble()`.
+- **PrecisionNum.sqrt()**: using DecimalFormat.parse().
 
 ### Changed
 - **ALL INDICATORS**: `Decimal` replaced by `Num`.
@@ -28,6 +29,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **StochasticRSIIndicator**: comments and params names changes to reduce confusion
 - **ConvergenceDivergenceIndicator**: remove unused method
 - **ChopIndicatorTest**: spelling, TODO: add better tests
+- **Various Indicators**: remove double math operations, change `Math.sqrt(double)` to `Num.sqrt()`, other small improvements
 
 ### Added
 - **BaseTimeSeries.SeriesBuilder**: simplifies creation of BaseTimeSeries.
@@ -42,7 +44,6 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BollingerBandWidthIndicator**: added missing constructor documentation.
 - **BollingerBandsLowerIndicator**: added missing constructor documentation.
 - **BollingerBandsMiddleIndicator**: added missing constructor documentation.
-- **PrecisionNum**: `Num` implementation to support arbitrary precision
 - **TrailingStopLossRule**: new rule that is satisfied if trailing stop loss is reached
 - **Num**: added Num sqrt(int) and Num sqrt()
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -39,7 +39,7 @@ public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
     
     private final ATRIndicator atr;
     
-    private final double k;
+    private final Num k;
 
     /**
      * Constructor.
@@ -59,11 +59,11 @@ public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
         super(series);
         low = new LowestValueIndicator(new MinPriceIndicator(series), barCount);
         atr = new ATRIndicator(series, barCount);
-        this.k = k;
+        this.k = numOf(k);
     }
 
     @Override
     protected Num calculate(int index) {
-        return low.getValue(index).plus(atr.getValue(index).multipliedBy(numOf(k)));
+        return low.getValue(index).plus(atr.getValue(index).multipliedBy(k));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -41,15 +41,15 @@ import org.ta4j.core.indicators.helpers.MinPriceIndicator;
                 MaxHi(n) = The highest high over past n bars
 
                 ++ usually this index is between 0 and 100, but could be scaled differently by the 'scaleTo' arg of the constructor
- * @implNote precision may be lost because of the double calculations using log10
+ * @apiNote Minimal deviations in last decimal places possible. During the calculations this indicator converts {@link Num Decimal/BigDecimal} to to {@link Double double}
  */
 public class ChopIndicator extends CachedIndicator<Num> {
     private final ATRIndicator atrIndicator;
     private final int timeFrame;
-    private final double LOG10n;
+    private final Num LOG10n;
     private final HighestValueIndicator hvi;
     private final LowestValueIndicator lvi;
-    private final double scaleUpTo;
+    private final Num scaleUpTo;
 
     /**
      * Constructor.
@@ -57,25 +57,25 @@ public class ChopIndicator extends CachedIndicator<Num> {
      * @param ciTimeFrame time-frame often something like '14'
      * @param scaleTo maximum value to scale this oscillator, usually '1' or '100'
      */
-    public ChopIndicator( TimeSeries timeseries, int ciTimeFrame, int scaleTo ) {
-        super( timeseries );
-        this.atrIndicator = new ATRIndicator( timeseries, 1 );	// ATR(1) = Average True Range (Period of 1)
-        hvi = new HighestValueIndicator( new MaxPriceIndicator(timeseries), ciTimeFrame );
-        lvi = new LowestValueIndicator( new MinPriceIndicator(timeseries), ciTimeFrame );
+    public ChopIndicator(TimeSeries timeseries, int ciTimeFrame, int scaleTo) {
+        super(timeseries);
+        this.atrIndicator = new ATRIndicator(timeseries, 1); // ATR(1) = Average True Range (Period of 1)
+        hvi = new HighestValueIndicator(new MaxPriceIndicator(timeseries), ciTimeFrame);
+        lvi = new LowestValueIndicator(new MinPriceIndicator(timeseries), ciTimeFrame);
         this.timeFrame = ciTimeFrame;
-        this.LOG10n = Math.log10( ciTimeFrame );
-        this.scaleUpTo = scaleTo;
+        this.LOG10n = numOf(Math.log10(ciTimeFrame));
+        this.scaleUpTo = numOf(scaleTo);
     }
 
     @Override
     public Num calculate(int index) {
         Num summ = atrIndicator.getValue(index);
-        for( int i = 1; i<timeFrame; ++i ) {
+        for(int i = 1; i < timeFrame; ++i ) {
             summ = summ.plus(atrIndicator.getValue(index - i));
         }
         Num a = summ.dividedBy((hvi.getValue(index).minus(lvi.getValue(index))));
         // TODO: implement Num.log10(Num)
-        Num chop = numOf(scaleUpTo).multipliedBy(numOf(Math.log10(a.doubleValue()))).dividedBy(numOf(LOG10n));
+        Num chop = scaleUpTo.multipliedBy(numOf(Math.log10(a.doubleValue()))).dividedBy(LOG10n);
         return chop;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
@@ -48,7 +48,7 @@ public class HMAIndicator extends CachedIndicator<Num> {
         WMAIndicator origWma = new WMAIndicator(indicator, barCount);
         
         Indicator<Num> indicatorForSqrtWma = new DifferenceIndicator(new MultiplierIndicator(halfWma, 2), origWma);
-        sqrtWma = new WMAIndicator(indicatorForSqrtWma, (int) Math.sqrt(barCount));
+        sqrtWma = new WMAIndicator(indicatorForSqrtWma, numOf(barCount).sqrt().intValue());
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RandomWalkIndexHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RandomWalkIndexHighIndicator.java
@@ -55,7 +55,7 @@ public class RandomWalkIndexHighIndicator extends CachedIndicator<Num> {
         maxPrice = new MaxPriceIndicator(series);
         minPrice = new MinPriceIndicator(series);
         averageTrueRange = new ATRIndicator(series, barCount);
-        sqrtBarCount = numOf(Math.sqrt(barCount));
+        sqrtBarCount = numOf(barCount).sqrt();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RandomWalkIndexLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RandomWalkIndexLowIndicator.java
@@ -55,7 +55,7 @@ private final MaxPriceIndicator maxPrice;
         maxPrice = new MaxPriceIndicator(series);
         minPrice = new MinPriceIndicator(series);
         averageTrueRange = new ATRIndicator(series, barCount);
-        sqrtBarCount = series.numOf(Math.sqrt(barCount));
+        sqrtBarCount = numOf(barCount).sqrt();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -29,7 +29,6 @@ import org.ta4j.core.num.Num;
 /**
  * Ulcer index indicator.
  * <p/>
- * @apiNote Minimal deviations in last decimal places possible. During the calculations this indicator converts {@link Num Decimal/BigDecimal} to to {@link Double double}
  * @see <a href="http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:ulcer_index">
  *     http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:ulcer_index</a>
  * @see <a href="https://en.wikipedia.org/wiki/Ulcer_index">https://en.wikipedia.org/wiki/Ulcer_index</a>
@@ -66,7 +65,7 @@ public class UlcerIndexIndicator extends CachedIndicator<Num> {
             squaredAverage = squaredAverage.plus(percentageDrawdown.pow(2));
         }
         squaredAverage = squaredAverage.dividedBy(numOf(numberOfObservations));
-        return numOf(Math.sqrt(squaredAverage.doubleValue()));
+        return squaredAverage.sqrt();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -131,48 +131,48 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	/** The type of the strict convergence or strict divergence **/
 	private final ConvergenceDivergenceStrictType strictType;
 	
-    /** The minimum strength for convergence or divergence. **/
-    private Num minStrength;
+	/** The minimum strength for convergence or divergence. **/
+	private Num minStrength;
 	
 	/** The minimum slope for convergence or divergence. **/
 	private Num minSlope;
     
-	    /**
-     * Constructor. <br/>
-     * <br/>
-     * 
-     * The <b>"minStrength"</b> is the minimum required strenght for convergence or divergence
-     * and must be a number between "0.1" and "1.0": <br/>
-     * <br/>
-     * 0.1: very weak <br/>
-     * 0.8: strong (recommended) <br/>
-     * 1.0: very strong <br/>
-     * 
-     * <br/>
-     * 
-     * The <b>"minSlope"</b> is the minimum required slope for convergence or divergence
-     * and must be a number between "0.1" and "1.0": <br/>
-     * <br/>
-     * 0.1: very unstrict<br/>
-     * 0.3: strict (recommended) <br/>
-     * 1.0: very strict <br/>
-     * 
-     * @param ref the indicator
-     * @param other the other indicator
-     * @param barCount the time frame
-     * @param type of convergence or divergence
-     * @param minStrength the minimum required strenght for convergence or divergence
-     * @param minSlope the minimum required slope for convergence or divergence
-     */
+	/**
+	Constructor. <br/>
+	 * <br/>
+	 * 
+	 * The <b>"minStrength"</b> is the minimum required strength for convergence or divergence
+	 * and must be a number between "0.1" and "1.0": <br/>
+	 * <br/>
+	 * 0.1: very weak <br/>
+	 * 0.8: strong (recommended) <br/>
+	 * 1.0: very strong <br/>
+	 * 
+	 * <br/>
+	 * 
+	 * The <b>"minSlope"</b> is the minimum required slope for convergence or divergence
+	 * and must be a number between "0.1" and "1.0": <br/>
+	 * <br/>
+	 * 0.1: very unstrict<br/>
+	 * 0.3: strict (recommended) <br/>
+	 * 1.0: very strict <br/>
+	 * 
+	 * @param ref the indicator
+	 * @param other the other indicator
+	 * @param barCount the time frame
+	 * @param type of convergence or divergence
+	 * @param minStrength the minimum required strength for convergence or divergence
+	 * @param minSlope the minimum required slope for convergence or divergence
+	 */
 	public ConvergenceDivergenceIndicator(Indicator<Num> ref, Indicator<Num> other, int barCount,
-            ConvergenceDivergenceType type, double minStrength, double minSlope) {
+			ConvergenceDivergenceType type, double minStrength, double minSlope) {
 		super(ref);
 		this.ref = ref;
 		this.other = other;
 		this.barCount = barCount;
 		this.type = type;
 		this.strictType = null;
-        this.minStrength = numOf(minStrength).abs();
+		this.minStrength = numOf(minStrength).abs();
 		this.minSlope = numOf(minSlope);
 	}
 	
@@ -192,7 +192,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		this.barCount = barCount;
 		this.type = type;
 		this.strictType = null;
-        this.minStrength = numOf(0.8).abs();
+		this.minStrength = numOf(0.8).abs();
 		this.minSlope = numOf(0.3);
 	}
 	
@@ -212,19 +212,19 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		this.barCount = barCount;
 		this.type = null;
 		this.strictType = strictType;
-        this.minStrength = null;
+		this.minStrength = null;
 		this.minSlope = null;
 	}
 
 	@Override
 	protected Boolean calculate(int index) {
 
-        if (minStrength != null && minStrength.isZero()) {
+		if (minStrength != null && minStrength.isZero()) {
 			return false;
 		}
 
-        if (minStrength != null && minStrength.isGreaterThan(numOf(1))) {
-            minStrength = numOf(1);
+		if (minStrength != null && minStrength.isGreaterThan(numOf(1))) {
+			minStrength = numOf(1);
 		}
 
 		if (type != null) {
@@ -310,7 +310,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
      */
 	private Boolean calculatePositiveConvergence(int index) {
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
+		boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
 
 		Num slope = calculateSlopeRel(index);
 		boolean isPositive = slope.isGreaterThanOrEqual(minSlope.abs());
@@ -325,7 +325,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
      */
     private Boolean calculateNegativeConvergence(int index) {
     		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
+    		boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
 		
     		Num slope = calculateSlopeRel(index);
     		boolean isNegative = slope.isLessThanOrEqual(minSlope.abs().multipliedBy(numOf(-1)));
@@ -340,7 +340,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	private Boolean calculatePositiveDivergence(int index) {
 		
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
+		boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
 
 		if (isDivergent) {
 			// If "isDivergent" and "ref" is positive, then "other" must be negative.
@@ -359,7 +359,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	private Boolean calculateNegativeDivergence(int index) {
 		
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
+		boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
 
 		if (isDivergent) {
 			// If "isDivergent" and "ref" is positive, then "other" must be negative.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -131,48 +131,48 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	/** The type of the strict convergence or strict divergence **/
 	private final ConvergenceDivergenceStrictType strictType;
 	
-	/** The minimum strenght for convergence or divergence. **/
-	private Num minStrenght;
+    /** The minimum strength for convergence or divergence. **/
+    private Num minStrength;
 	
 	/** The minimum slope for convergence or divergence. **/
 	private Num minSlope;
     
-	/**
-	 * Constructor. <br/>
-	 * <br/>
-	 * 
-	 * The <b>"minStrenght"</b> is the minimum required strenght for convergence or divergence
-	 * and must be a number between "0.1" and "1.0": <br/>
-	 * <br/>
-	 * 0.1: very weak <br/>
-	 * 0.8: strong (recommended) <br/>
-	 * 1.0: very strong <br/>
-	 * 
-	 * <br/>
-	 * 
-	 * The <b>"minSlope"</b> is the minimum required slope for convergence or divergence
-	 * and must be a number between "0.1" and "1.0": <br/>
-	 * <br/>
-	 * 0.1: very unstrict<br/>
-	 * 0.3: strict (recommended) <br/>
-	 * 1.0: very strict <br/>
-	 * 
-	 * @param ref the indicator
-	 * @param other the other indicator
-	 * @param barCount the time frame
-	 * @param type of convergence or divergence
-	 * @param minStrenght the minimum required strenght for convergence or divergence
-	 * @param minSlope the minimum required slope for convergence or divergence
-	 */
+	    /**
+     * Constructor. <br/>
+     * <br/>
+     * 
+     * The <b>"minStrength"</b> is the minimum required strenght for convergence or divergence
+     * and must be a number between "0.1" and "1.0": <br/>
+     * <br/>
+     * 0.1: very weak <br/>
+     * 0.8: strong (recommended) <br/>
+     * 1.0: very strong <br/>
+     * 
+     * <br/>
+     * 
+     * The <b>"minSlope"</b> is the minimum required slope for convergence or divergence
+     * and must be a number between "0.1" and "1.0": <br/>
+     * <br/>
+     * 0.1: very unstrict<br/>
+     * 0.3: strict (recommended) <br/>
+     * 1.0: very strict <br/>
+     * 
+     * @param ref the indicator
+     * @param other the other indicator
+     * @param barCount the time frame
+     * @param type of convergence or divergence
+     * @param minStrength the minimum required strenght for convergence or divergence
+     * @param minSlope the minimum required slope for convergence or divergence
+     */
 	public ConvergenceDivergenceIndicator(Indicator<Num> ref, Indicator<Num> other, int barCount,
-			ConvergenceDivergenceType type, double minStrenght, double minSlope) {
+            ConvergenceDivergenceType type, double minStrength, double minSlope) {
 		super(ref);
 		this.ref = ref;
 		this.other = other;
 		this.barCount = barCount;
 		this.type = type;
 		this.strictType = null;
-		this.minStrenght = numOf(minStrenght).abs();
+        this.minStrength = numOf(minStrength).abs();
 		this.minSlope = numOf(minSlope);
 	}
 	
@@ -192,7 +192,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		this.barCount = barCount;
 		this.type = type;
 		this.strictType = null;
-		this.minStrenght = numOf(0.8).abs();
+        this.minStrength = numOf(0.8).abs();
 		this.minSlope = numOf(0.3);
 	}
 	
@@ -212,19 +212,19 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 		this.barCount = barCount;
 		this.type = null;
 		this.strictType = strictType;
-		this.minStrenght = null;
+        this.minStrength = null;
 		this.minSlope = null;
 	}
 
 	@Override
 	protected Boolean calculate(int index) {
 
-		if (minStrenght != null && minStrenght.isZero()) {
+        if (minStrength != null && minStrength.isZero()) {
 			return false;
 		}
 
-		if (minStrenght != null && minStrenght.isGreaterThan(numOf(1))) {
-			minStrenght = numOf(1);
+        if (minStrength != null && minStrength.isGreaterThan(numOf(1))) {
+            minStrength = numOf(1);
 		}
 
 		if (type != null) {
@@ -310,7 +310,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
      */
 	private Boolean calculatePositiveConvergence(int index) {
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-		boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrenght);
+        boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
 
 		Num slope = calculateSlopeRel(index);
 		boolean isPositive = slope.isGreaterThanOrEqual(minSlope.abs());
@@ -325,7 +325,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
      */
     private Boolean calculateNegativeConvergence(int index) {
     		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-    		boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrenght);
+        boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
 		
     		Num slope = calculateSlopeRel(index);
     		boolean isNegative = slope.isLessThanOrEqual(minSlope.abs().multipliedBy(numOf(-1)));
@@ -340,7 +340,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	private Boolean calculatePositiveDivergence(int index) {
 		
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-		boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrenght.multipliedBy(numOf(-1)));
+        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
 
 		if (isDivergent) {
 			// If "isDivergent" and "ref" is positive, then "other" must be negative.
@@ -359,7 +359,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
 	private Boolean calculateNegativeDivergence(int index) {
 		
 		CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-		boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrenght.multipliedBy(numOf(-1)));
+        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
 
 		if (isDivergent) {
 			// If "isDivergent" and "ref" is positive, then "other" must be negative.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
@@ -160,7 +160,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
 		else if (simpleType != null) {
 			switch (simpleType) {
 			case sqrt:
-                return val.sqrt();
+				return val.sqrt();
 			case abs:
 				return val.abs();
 			case log:

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
@@ -160,7 +160,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
 		else if (simpleType != null) {
 			switch (simpleType) {
 			case sqrt:
-				return numOf(Math.sqrt(val.doubleValue()));
+                return val.sqrt();
 			case abs:
 				return val.abs();
 			case log:

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
@@ -30,7 +30,6 @@ import org.ta4j.core.num.Num;
 /**
  * Correlation coefficient indicator.
  * <p/>
- * @apiNote Minimal deviations in last decimal places possible. During the calculations this indicator converts {@link Num PrecisionNum} to double
  * @see <a href="http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:correlation_coeffici">
  * http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:correlation_coeffici</a>
  */
@@ -60,7 +59,7 @@ public class CorrelationCoefficientIndicator extends CachedIndicator<Num> {
         Num cov = covariance.getValue(index);
         Num var1 = variance1.getValue(index);
         Num var2 = variance2.getValue(index);
-        Num var1_2_sqrt = numOf(Math.sqrt(var1.multipliedBy(var2).doubleValue()));
+        Num var1_2_sqrt = var1.multipliedBy(var2).sqrt();
         return cov.dividedBy(var1_2_sqrt);
 
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -87,7 +87,7 @@ public class PearsonCorrelationIndicator extends RecursiveCachedIndicator<Num> {
 		
 		if (toSqrt.isGreaterThan(numOf(0))) {
 			// pearson = (n * Sxy - Sx * Sy) / sqrt((n * Sxx - Sx * Sx) * (n * Syy - Sy * Sy))
-			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(numOf(Math.sqrt(toSqrt.doubleValue())));
+            return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(toSqrt.sqrt());
 		}
 
 		return NaN;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -87,7 +87,7 @@ public class PearsonCorrelationIndicator extends RecursiveCachedIndicator<Num> {
 		
 		if (toSqrt.isGreaterThan(numOf(0))) {
 			// pearson = (n * Sxy - Sx * Sy) / sqrt((n * Sxx - Sx * Sx) * (n * Syy - Sy * Sy))
-            return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(toSqrt.sqrt());
+			return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(toSqrt.sqrt());
 		}
 
 		return NaN;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
@@ -29,7 +29,6 @@ import org.ta4j.core.num.Num;
 /**
  * Standard deviation indicator.
  * <p/>
- * @apiNote Minimal deviations in last decimal places possible. During the calculations this indicator converts {@link Num Decimal/BigDecimal} to to {@link Double double}
  * @see <a href="http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:standard_deviation_volatility">
  *     http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:standard_deviation_volatility</a>
  */
@@ -49,6 +48,6 @@ public class StandardDeviationIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return numOf(Math.sqrt(variance.getValue(index).doubleValue()));
+        return variance.getValue(index).sqrt();
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
@@ -52,6 +52,6 @@ public class StandardErrorIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         final int startIndex = Math.max(0, index - barCount + 1);
         final int numberOfObservations = index - startIndex + 1;
-        return sdev.getValue(index).dividedBy(numOf(Math.sqrt(numberOfObservations)));
+        return sdev.getValue(index).dividedBy(numOf(numberOfObservations).sqrt());
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -60,11 +60,11 @@ public class IIIIndicator extends CachedIndicator<Num> {
         if (index == getTimeSeries().getBeginIndex()) {
             return numOf(0);
         }
-        Num doubleClosePrice =  numOf(2).multipliedBy(closePriceIndicator.getValue(index));
+        Num closePrice = numOf(2).multipliedBy(closePriceIndicator.getValue(index));
         Num highmlow = maxPriceIndicator.getValue(index).minus(minPriceIndicator.getValue(index));
         Num highplow = maxPriceIndicator.getValue(index).plus(minPriceIndicator.getValue(index));
 
-        return (doubleClosePrice.minus(highplow)).dividedBy(highmlow.multipliedBy(volumeIndicator.getValue(index)));
+        return (closePrice.minus(highplow)).dividedBy(highmlow.multipliedBy(volumeIndicator.getValue(index)));
 
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
@@ -25,6 +25,8 @@ package org.ta4j.core.num;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -268,7 +270,7 @@ public final class PrecisionNum implements Num {
             return NaN;
 
         case 0:
-            return BigDecimalNum.valueOf(0);
+            return PrecisionNum.valueOf(0);
         }
 
         // Direct implementation of the example in:
@@ -290,7 +292,14 @@ public final class PrecisionNum implements Num {
             BigDecimal estimatedExponent = exponent.divide(new BigDecimal(2));
             String estimateString = String.format("%sE%s", estimatedMantissa, estimatedExponent);
             log.trace("x[0] =~ sqrt({}...*10^{}) =~ {}", mantissa, exponent, estimateString);
-            estimate = new BigDecimal(estimateString);
+            DecimalFormat format = new DecimalFormat();
+            format.setParseBigDecimal(true);
+            try {
+                estimate = (BigDecimal) format.parse(estimateString);
+            } catch (ParseException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
         }
         BigDecimal delta = null;
         BigDecimal test = null;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
@@ -65,9 +65,8 @@ public class PeriodicalGrowthRateIndicatorTest extends AbstractIndicatorTest<Ind
     @Test
     public void testGetTotalReturn() { 
         PeriodicalGrowthRateIndicator gri = new PeriodicalGrowthRateIndicator(this.closePrice, 5);
-        double expResult = 0.9564;
-        double result = gri.getTotalReturn();
-        assertEquals(expResult, result, 0.01);
+        Num result = gri.getTotalReturn();
+        assertNumEquals(0.9564, result);
     }
     
     @Test


### PR DESCRIPTION
Fixes #271 #217 .

Changes proposed in this pull request:
- <*>Indicator: store `double` params as `Nums`, remove `double` math
- <*>Indicator: replace `Math.sqrt()` with `Num.sqrt()`
- ConvergenceDivergenceIndicator: spelling
- PeriodicalGrowthRateIndicator: utilize ONE, return value of `Num`
- IIIIndicator: var name fix
- PrecisionNum: fix sqrt()



- [ ] added an entry to the unreleased section of `CHANGES.md` 
