### PR TITLE
Implemented backtesting example - SimpleMovingAverageBacktesting

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -206,4 +206,14 @@ public class BaseTradingRecord implements TradingRecord {
             currentTrade = new Trade(startingType);
         }
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("BaseTradingRecord:\n");
+        for(Order order : orders) {
+            sb.append(order.toString() + "\n");
+        }
+        return sb.toString();
+    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/Order.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Order.java
@@ -111,6 +111,20 @@ public class Order implements Serializable {
     }
 
     /**
+     * Constructor.
+     * @param index the index the order is executed
+     * @param series the time series
+     * @param type the type of the order
+     * @param amount the amount to be (or that was) ordered
+     */
+    protected Order(int index, TimeSeries series, OrderType type, Num amount) {
+        this.type = type;
+        this.index = index;
+        this.price = series.getBar(index).getClosePrice();
+        this.amount = amount;
+    }
+
+    /**
      * @return the type of the order (BUY or SELL)
      */
     public OrderType getType() {
@@ -202,6 +216,16 @@ public class Order implements Serializable {
     /**
      * @param index the index the order is executed
      * @param series the time series
+     * @param amount the amount to be (or that was) bought
+     * @return a BUY order
+     */
+    public static Order buyAt(int index, TimeSeries series, Num amount) {
+        return new Order(index, series, OrderType.BUY, amount);
+    }
+
+    /**
+     * @param index the index the order is executed
+     * @param series the time series
      * @return a SELL order
      */
     public static Order sellAt(int index, TimeSeries series) {
@@ -216,5 +240,15 @@ public class Order implements Serializable {
      */
     public static Order sellAt(int index, Num price, Num amount) {
         return new Order(index, OrderType.SELL, price, amount);
+    }
+
+    /**
+     * @param index the index the order is executed
+     * @param series the time series
+     * @param amount the amount to be (or that was) bought
+     * @return a SELL order
+     */
+    public static Order sellAt(int index, TimeSeries series, Num amount) {
+        return new Order(index, series, OrderType.SELL, amount);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
@@ -1,0 +1,47 @@
+package org.ta4j.core.analysis.criteria;
+
+import org.ta4j.core.TimeSeries;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+/**
+ * Profit and loss criterion.
+ * </p>
+ * The profit or loss over the provided {@link TimeSeries series}.
+ */
+public class ProfitLossCriterion extends AbstractAnalysisCriterion {
+
+    @Override
+    public Num calculate(TimeSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getTrades().stream()
+                .filter(trade -> trade.isClosed())
+                .map(trade -> calculateProfitLoss(series, trade))
+                .reduce(series.numOf(1), (profit1, profit2) -> profit1.plus(profit2));
+    }
+
+    @Override
+    public Num calculate(TimeSeries series, Trade trade) {
+        return calculateProfitLoss(series, trade);
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    /**
+     * Calculates the profit or loss of a sell trade.
+     * @param series a time series
+     * @param trade a trade
+     * @return the profit or loss of the trade
+     */
+    private Num calculateProfitLoss(TimeSeries series, Trade trade) {
+        Num exitClosePrice = trade.getExit().getPrice().isNaN() ?
+                series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getPrice();
+        Num entryClosePrice = trade.getEntry().getPrice().isNaN() ?
+                series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getPrice();
+
+        return exitClosePrice.minus(entryClosePrice).multipliedBy(trade.getExit().getAmount());
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
@@ -17,7 +17,7 @@ public class ProfitLossCriterion extends AbstractAnalysisCriterion {
         return tradingRecord.getTrades().stream()
                 .filter(trade -> trade.isClosed())
                 .map(trade -> calculateProfitLoss(series, trade))
-                .reduce(series.numOf(1), (profit1, profit2) -> profit1.plus(profit2));
+                .reduce(series.numOf(0), (profit1, profit2) -> profit1.plus(profit2));
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossCriterionTest.java
@@ -1,0 +1,53 @@
+package org.ta4j.core.analysis.criteria;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Order;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.mocks.MockTimeSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+public class ProfitLossCriterionTest  extends AbstractCriterionTest {
+
+    public ProfitLossCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new ProfitLossCriterion(), numFunction);
+    }
+
+    @Test
+    public void calculateOnlyWithGainTrades() {
+        MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.buyAt(0,series, series.numOf(50)), Order.sellAt(2,series, series.numOf(50)),
+                Order.buyAt(3,series, series.numOf(50)), Order.sellAt(5,series, series.numOf(50)));
+
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(500 + 250, profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateOnlyWithLossTrades() {
+        MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.buyAt(0,series, series.numOf(50)), Order.sellAt(1,series, series.numOf(50)),
+                Order.buyAt(2,series, series.numOf(50)), Order.sellAt(5,series, series.numOf(50)));
+
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(-250 - 1500, profit.calculate(series, tradingRecord));
+    }
+
+
+    @Test
+    public void betterThan() {
+        AnalysisCriterion criterion = getCriterion();
+        assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+}

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktesting.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktesting.java
@@ -1,0 +1,73 @@
+package ta4jexamples.backtesting;
+
+import org.ta4j.core.*;
+import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.indicators.SMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.BigDecimalNum;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.PrecisionNum;
+import org.ta4j.core.trading.rules.OverIndicatorRule;
+import org.ta4j.core.trading.rules.UnderIndicatorRule;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class SimpleMovingAverageBacktesting {
+
+    public static void main(String[] args) throws InterruptedException {
+        TimeSeries series = createTimeSeries();
+
+        Strategy strategy3DaySma = create3DaySmaStrategy(series);
+
+        TimeSeriesManager seriesManager = new TimeSeriesManager(series);
+        TradingRecord tradingRecord3DaySma = seriesManager.run(strategy3DaySma, Order.OrderType.BUY, PrecisionNum.valueOf(50));
+        System.out.println(tradingRecord3DaySma);
+
+        Strategy strategy2DaySma = create2DaySmaStrategy(series);
+        TradingRecord tradingRecord2DaySma = seriesManager.run(strategy2DaySma, Order.OrderType.BUY, PrecisionNum.valueOf(50));
+        System.out.println(tradingRecord2DaySma);
+
+        AnalysisCriterion criterion = new TotalProfitCriterion();
+        Num calculate3DaySma = criterion.calculate(series, tradingRecord3DaySma);
+        Num calculate2DaySma = criterion.calculate(series, tradingRecord2DaySma);
+
+        System.out.println(calculate3DaySma);
+        System.out.println(calculate2DaySma);
+    }
+
+    private static TimeSeries createTimeSeries() {
+        TimeSeries series = new BaseTimeSeries();
+        series.addBar(new BaseBar(CreateDay(1), 100.0, 100.0, 100.0, 100.0, 1060, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(2), 110.0, 110.0, 110.0, 110.0, 1070, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(3), 140.0, 140.0, 140.0, 140.0, 1080, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(4), 119.0, 119.0, 119.0, 119.0, 1090, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(5), 100.0, 100.0, 100.0, 100.0, 1100, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(6), 110.0, 110.0, 110.0, 110.0, 1110, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(7), 120.0, 120.0, 120.0, 120.0, 1120, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(CreateDay(8), 130.0, 130.0, 130.0, 130.0, 1130, PrecisionNum::valueOf));
+        return series;
+    }
+
+    private static ZonedDateTime CreateDay(int day) {
+        return ZonedDateTime.of(2018, 01, day, 12, 0, 0, 0, ZoneId.systemDefault());
+    }
+
+    private static Strategy create3DaySmaStrategy(TimeSeries series) {
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        SMAIndicator sma = new SMAIndicator(closePrice, 3);
+        return new BaseStrategy(
+                new UnderIndicatorRule(sma, closePrice),
+                new OverIndicatorRule(sma, closePrice)
+        );
+    }
+
+    private static Strategy create2DaySmaStrategy(TimeSeries series) {
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        SMAIndicator sma = new SMAIndicator(closePrice, 2);
+        return new BaseStrategy(
+                new UnderIndicatorRule(sma, closePrice),
+                new OverIndicatorRule(sma, closePrice)
+        );
+    }
+}

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktesting.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktesting.java
@@ -36,6 +36,7 @@ public class SimpleMovingAverageBacktesting {
         calculateCriterion(new NumberOfTradesCriterion(), series, tradingRecord3DaySmaUnder, tradingRecord3DaySmaOver);
         calculateCriterion(new RewardRiskRatioCriterion(), series, tradingRecord3DaySmaUnder, tradingRecord3DaySmaOver);
         calculateCriterion(new TotalProfitCriterion(), series, tradingRecord3DaySmaUnder, tradingRecord3DaySmaOver);
+        calculateCriterion(new ProfitLossCriterion(), series, tradingRecord3DaySmaUnder, tradingRecord3DaySmaOver);
     }
 
     private static void calculateCriterion(AnalysisCriterion criterion, TimeSeries series, TradingRecord tradingRecord3DaySmaUnder, TradingRecord tradingRecord3DaySmaOver) {

--- a/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestingTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestingTest.java
@@ -1,0 +1,11 @@
+package ta4jexamples.backtesting;
+
+import org.junit.Test;
+
+public class SimpleMovingAverageBacktestingTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        SimpleMovingAverageBacktesting.main(null);
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Created a backtesting example to give better understanding of how backtesting is working in Ta4j

A few backtesting questions:
1. In the `seriesManager.run`-method it is possible to set `amount`. How can I see the affect on the result?
2. Is there an easyer way to set a PrecisionNum the `PrecisionNum.valueOf(50)`?
3. In the TradingRecord, what is the difference between buyOrders/sellOrders and entryOrders/ExitOrders?
