### PR TITLE
add update lastet bar method in time series

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -373,6 +373,15 @@ public class BaseTimeSeries implements TimeSeries {
     }
 
     @Override
+    public void updateBar(Bar bar) {
+        if (bars.isEmpty()) {
+            addBar(bar);
+        } else {
+            bars.set(bars.size() - 1, bar);
+        }
+    }
+
+    @Override
     public void addTrade(Number price, Number amount) {
         addTrade(numOf(price), numOf(amount));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -319,13 +319,17 @@ public class BaseTimeSeries implements TimeSeries {
      * @apiNote to add bar data directly use #addBar(Duration, ZonedDateTime, Num, Num, Num, Num, Num)
      */
     @Override
-    public void addBar(Bar bar) {
+    public void addBar(Bar bar, boolean replace) {
         Objects.requireNonNull(bar);
         if(!checkBar(bar)){
             throw new IllegalArgumentException(String.format("Cannot add Bar with data type: %s to series with data" +
                     "type: %s",bar.getClosePrice().getClass(), numOf(1).getClass()));
         }
         if (!bars.isEmpty()) {
+            if (replace) {
+                bars.set(bars.size() - 1, bar);
+                return;
+            }
             final int lastBarIndex = bars.size() - 1;
             ZonedDateTime seriesEndTime = bars.get(lastBarIndex).getEndTime();
             if (!bar.getEndTime().isAfter(seriesEndTime)) {
@@ -370,15 +374,6 @@ public class BaseTimeSeries implements TimeSeries {
     public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
                        Num closePrice, Num volume, Num amount) {
         this.addBar(new BaseBar(timePeriod, endTime, openPrice,highPrice,lowPrice,closePrice,volume, amount));
-    }
-
-    @Override
-    public void updateBar(Bar bar) {
-        if (bars.isEmpty()) {
-            addBar(bar);
-        } else {
-            bars.set(bars.size() - 1, bar);
-        }
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
@@ -148,7 +148,22 @@ public interface TimeSeries extends Serializable {
      * @see TimeSeries#setMaximumBarCount(int)
      * @apiNote use #addBar(Duration, ZonedDateTime, Num, Num, Num, Num, Num) to add bar data directly
      */
-    void addBar(Bar bar);
+    default void addBar(Bar bar) {
+        addBar(bar, false);
+    }
+
+    /**
+     * Adds a bar at the end of the series.
+     * <p>
+     * Begin index set to 0 if it wasn't initialized.<br>
+     * End index set to 0 if it wasn't initialized, or incremented if it matches the end of the series.<br>
+     * Exceeding bars are removed.
+     * @param bar the bar to be added
+     * @param replace true to replace the latest bar. Some exchange provide continuous new bar data in the time period. (eg. 1s in 1m Duration)<br>
+     * @see TimeSeries#setMaximumBarCount(int)
+     * @apiNote use #addBar(Duration, ZonedDateTime, Num, Num, Num, Num, Num) to add bar data directly
+     */
+    void addBar(Bar bar, boolean replace);
 
     /**
      * Adds a bar at the end of the series.
@@ -234,12 +249,6 @@ public interface TimeSeries extends Serializable {
      */
     void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
                 Num volume, Num amount);
-
-    /**
-     * Update the latest bar. Some exchange provide continuous new bar data in the time period. (eg. 1s in 1m Duration)<br>
-     * @param bar new bar to replace the latest
-     */
-    void updateBar(Bar bar);
 
     /**
      * Adds a trade at the end of bar period.

--- a/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TimeSeries.java
@@ -236,6 +236,12 @@ public interface TimeSeries extends Serializable {
                 Num volume, Num amount);
 
     /**
+     * Update the latest bar. Some exchange provide continuous new bar data in the time period. (eg. 1s in 1m Duration)<br>
+     * @param bar new bar to replace the latest
+     */
+    void updateBar(Bar bar);
+
+    /**
      * Adds a trade at the end of bar period.
      * @param tradeVolume the traded volume
      * @param tradePrice the price


### PR DESCRIPTION
Some exchange provide continuous new bar data in the time period (eg. 1s in 1m Duration). So add update the latest bar method to support real time time series.

According to issue #149 and PR #181, the latest bar indicator is uncached, so update latest bar should not cause issues.