### PR TITLE
Fix waitForRule's default satisfied value

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/WaitForRule.java
@@ -54,8 +54,8 @@ public class WaitForRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        boolean satisfied = false;
-        // No trading history, no need to wait
+        boolean satisfied = true;
+        // No trading history, no need to wait. Therefore it have to return true.
         if (tradingRecord != null) {
             Order lastOrder = tradingRecord.getLastOrder(orderType);
             if (lastOrder != null) {

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/WaitForRule.java
@@ -55,7 +55,7 @@ public class WaitForRule extends AbstractRule {
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = true;
-        // No trading history, no need to wait. Therefore it have to return true.
+        // No trading history, no need to wait. Therefore it has to return true.
         if (tradingRecord != null) {
             Order lastOrder = tradingRecord.getLastOrder(orderType);
             if (lastOrder != null) {

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/WaitForRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/WaitForRuleTest.java
@@ -47,8 +47,8 @@ public class WaitForRuleTest {
         // Waits for 3 bars since last buy order
         rule = new WaitForRule(Order.OrderType.BUY, 3);
 
-        assertFalse(rule.isSatisfied(0, null));
-        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertTrue(rule.isSatisfied(0, null));
+        assertTrue(rule.isSatisfied(1, tradingRecord));
 
         tradingRecord.enter(10);
         assertFalse(rule.isSatisfied(10, tradingRecord));
@@ -66,6 +66,7 @@ public class WaitForRuleTest {
         assertFalse(rule.isSatisfied(18, tradingRecord));
         assertFalse(rule.isSatisfied(19, tradingRecord));
         assertTrue(rule.isSatisfied(20, tradingRecord));
+        assertTrue(rule.isSatisfied(21, tradingRecord));
     }
 
     @Test
@@ -73,14 +74,14 @@ public class WaitForRuleTest {
         // Waits for 2 bars since last sell order
         rule = new WaitForRule(Order.OrderType.SELL, 2);
 
-        assertFalse(rule.isSatisfied(0, null));
-        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertTrue(rule.isSatisfied(0, null));
+        assertTrue(rule.isSatisfied(1, tradingRecord));
 
         tradingRecord.enter(10);
-        assertFalse(rule.isSatisfied(10, tradingRecord));
-        assertFalse(rule.isSatisfied(11, tradingRecord));
-        assertFalse(rule.isSatisfied(12, tradingRecord));
-        assertFalse(rule.isSatisfied(13, tradingRecord));
+        assertTrue(rule.isSatisfied(10, tradingRecord));
+        assertTrue(rule.isSatisfied(11, tradingRecord));
+        assertTrue(rule.isSatisfied(12, tradingRecord));
+        assertTrue(rule.isSatisfied(13, tradingRecord));
 
         tradingRecord.exit(15);
         assertFalse(rule.isSatisfied(15, tradingRecord));
@@ -95,5 +96,6 @@ public class WaitForRuleTest {
         assertFalse(rule.isSatisfied(20, tradingRecord));
         assertFalse(rule.isSatisfied(21, tradingRecord));
         assertTrue(rule.isSatisfied(22, tradingRecord));
+        assertTrue(rule.isSatisfied(23, tradingRecord));
     }
 }


### PR DESCRIPTION
### Summary

I found that WaitForRule just satisfies when it meets a certain condition.
Because of that, I couldn't use the rule to buy like the following.

```
//This rule couldn't run because WaitForRule sets false at first.
Rule entrySignal = new AndRule(new WaitForRule(Order.OrderType.SELL, 2),
                    new UnderIndicatorRule(differencePercentageIndicator, -0.05));
```

So I fixed it.

Moreover, WaitForRule has a comment. 'No trading history, no need to wait.'
That means it has to return true. 

### Test
WaitForRuleTest.java