### PR TITLE
Feature for AndRule and OrRule to accept multiple rules

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/Rule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Rule.java
@@ -28,9 +28,12 @@ import org.ta4j.core.trading.rules.NotRule;
 import org.ta4j.core.trading.rules.OrRule;
 import org.ta4j.core.trading.rules.XorRule;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * A rule for strategy building.
- * </p>
+ * <p></p>
  * A trading rule may be composed of a combination of other rules.
  *
  * A {@link Strategy trading strategy} is a pair of complementary (entry and exit) rules.
@@ -38,19 +41,27 @@ import org.ta4j.core.trading.rules.XorRule;
 public interface Rule {
 
     /**
-     * @param rule another trading rule
-     * @return a rule which is the AND combination of this rule with the provided one
+     * @param rules other trading rules
+     * @return a rule which is the AND combination of this rule with the provided others
      */
-    default Rule and(Rule rule) {
-    	return new AndRule(this, rule);
+    default Rule and(Rule ... rules) {
+
+        Rule[] newRules = Arrays.copyOf(rules, rules.length + 1);
+        newRules[rules.length] = this;
+
+        return new AndRule(newRules);
     }
 
     /**
-     * @param rule another trading rule
-     * @return a rule which is the OR combination of this rule with the provided one
+     * @param rules other trading rules
+     * @return a rule which is the OR combination of this rule with the provided others
      */
-    default Rule or(Rule rule) {
-    	return new OrRule(this, rule);
+    default Rule or(Rule ... rules) {
+
+        Rule[] newRules = Arrays.copyOf(rules, rules.length + 1);
+        newRules[rules.length] = this;
+
+    	return new OrRule(newRules);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndOrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndOrRule.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *   The MIT License (MIT)
+ *
+ *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization
+ *   & respective authors (see AUTHORS)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *   this software and associated documentation files (the "Software"), to deal in
+ *   the Software without restriction, including without limitation the rights to
+ *   use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *   the Software, and to permit persons to whom the Software is furnished to do so,
+ *   subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *   FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *   COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *******************************************************************************/
+package org.ta4j.core.trading.rules;
+
+import lombok.extern.slf4j.Slf4j;
+import org.ta4j.core.Rule;
+import org.ta4j.core.TradingRecord;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
+public abstract class AndOrRule extends AbstractRule {
+
+    private Rule[] rules;
+    private int satisfiedCount = 0;
+
+
+    protected void init(int satisfiedCount, Rule ... rules) {
+        this.rules = rules;
+        this.satisfiedCount = satisfiedCount;
+    }
+
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        int satisfiedCount = this.satisfiedCount;
+
+        boolean satisfied = false;
+        for (int i = 0; i < rules.length && !satisfied; i++) {
+            if(rules[i].isSatisfied(index, tradingRecord)) {
+                satisfiedCount--;
+                if(satisfiedCount <= 0) {
+                    satisfied = true;
+                }
+            }
+        }
+
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndOrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndOrRule.java
@@ -23,17 +23,9 @@
  *******************************************************************************/
 package org.ta4j.core.trading.rules;
 
-import lombok.extern.slf4j.Slf4j;
 import org.ta4j.core.Rule;
 import org.ta4j.core.TradingRecord;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-@Slf4j
 public abstract class AndOrRule extends AbstractRule {
 
     private Rule[] rules;

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/AndRule.java
@@ -24,34 +24,20 @@
 package org.ta4j.core.trading.rules;
 
 import org.ta4j.core.Rule;
-import org.ta4j.core.TradingRecord;
 
 /**
- * An AND combination of two {@link Rule rules}.
+ * An AND combination of multiple {@link Rule rules}.
  * </p>
- * Satisfied when the two provided rules are satisfied as well.<br>
- * Warning: the second rule is not tested if the first rule is not satisfied.
+ * Satisfied when the multiple provided rules are satisfied as well.<br>
+ * Warning: If the previous condition is satisfied, the following condition is not tested.
  */
-public class AndRule extends AbstractRule {
-
-    private Rule rule1;
-    
-    private Rule rule2;
+public class AndRule extends AndOrRule {
 
     /**
      * Constructor
-     * @param rule1 a trading rule
-     * @param rule2 another trading rule
+     * @param rules trading rules
      */
-    public AndRule(Rule rule1, Rule rule2) {
-        this.rule1 = rule1;
-        this.rule2 = rule2;
-    }
-
-    @Override
-    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = rule1.isSatisfied(index, tradingRecord) && rule2.isSatisfied(index, tradingRecord);
-        traceIsSatisfied(index, satisfied);
-        return satisfied;
+    public AndRule(Rule ... rules) {
+        init(rules.length, rules);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/OrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/OrRule.java
@@ -24,34 +24,20 @@
 package org.ta4j.core.trading.rules;
 
 import org.ta4j.core.Rule;
-import org.ta4j.core.TradingRecord;
 
 /**
- * An OR combination of two {@link Rule rules}.
+ * An OR combination of multiple {@link Rule rules}.
  * </p>
- * Satisfied when one of the two provided rules is satisfied.<br>
- * Warning: the second rule is not tested if the first rule is satisfied.
+ * Satisfied when one of the multiple provided rules is satisfied.<br>
+ * Warning: If the previous condition is satisfied, the following condition is not tested.
  */
-public class OrRule extends AbstractRule {
-
-    private Rule rule1;
-    
-    private Rule rule2;
+public class OrRule extends AndOrRule {
 
     /**
-     * Constructor.
-     * @param rule1 a trading rule
-     * @param rule2 another trading rule
+     * Constructor
+     * @param rules trading rules
      */
-    public OrRule(Rule rule1, Rule rule2) {
-        this.rule1 = rule1;
-        this.rule2 = rule2;
-    }
-
-    @Override
-    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = rule1.isSatisfied(index, tradingRecord) || rule2.isSatisfied(index, tradingRecord);
-        traceIsSatisfied(index, satisfied);
-        return satisfied;
+    public OrRule(Rule ... rules) {
+        init(1, rules);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/AndRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/AndRuleTest.java
@@ -52,6 +52,16 @@ public class AndRuleTest {
         assertTrue(BooleanRule.TRUE.and(satisfiedRule).isSatisfied(10));
         assertFalse(unsatisfiedRule.and(BooleanRule.TRUE).isSatisfied(10));
         assertFalse(BooleanRule.TRUE.and(unsatisfiedRule).isSatisfied(10));
+
+        assertTrue(new AndRule(satisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new AndRule(BooleanRule.TRUE, satisfiedRule, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new AndRule(BooleanRule.TRUE, BooleanRule.TRUE, satisfiedRule).isSatisfied(20));
+        assertFalse(new AndRule(unsatisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE).isSatisfied(20));
+        assertFalse(new AndRule(BooleanRule.TRUE, unsatisfiedRule, BooleanRule.TRUE).isSatisfied(20));
+        assertFalse(new AndRule(BooleanRule.TRUE, BooleanRule.TRUE, unsatisfiedRule).isSatisfied(20));
+
+        assertTrue(satisfiedRule.and(BooleanRule.TRUE, BooleanRule.TRUE).isSatisfied(30));
+        assertFalse(satisfiedRule.and(BooleanRule.TRUE, BooleanRule.FALSE).isSatisfied(30));
     }
 }
         

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/OrRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/OrRuleTest.java
@@ -52,6 +52,25 @@ public class OrRuleTest {
         assertTrue(BooleanRule.TRUE.or(satisfiedRule).isSatisfied(10));
         assertTrue(unsatisfiedRule.or(BooleanRule.TRUE).isSatisfied(10));
         assertTrue(BooleanRule.TRUE.or(unsatisfiedRule).isSatisfied(10));
+
+        assertTrue(new OrRule(satisfiedRule, BooleanRule.FALSE, BooleanRule.FALSE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.FALSE, satisfiedRule, BooleanRule.FALSE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.FALSE, BooleanRule.FALSE, satisfiedRule).isSatisfied(20));
+
+        assertTrue(new OrRule(satisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.TRUE, satisfiedRule, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.TRUE, BooleanRule.TRUE, satisfiedRule).isSatisfied(20));
+
+        assertFalse(new OrRule(unsatisfiedRule, BooleanRule.FALSE, BooleanRule.FALSE).isSatisfied(20));
+        assertFalse(new OrRule(BooleanRule.FALSE, unsatisfiedRule, BooleanRule.FALSE).isSatisfied(20));
+        assertFalse(new OrRule(BooleanRule.FALSE, BooleanRule.FALSE, unsatisfiedRule).isSatisfied(20));
+
+        assertTrue(new OrRule(unsatisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.TRUE, unsatisfiedRule, BooleanRule.TRUE).isSatisfied(20));
+        assertTrue(new OrRule(BooleanRule.TRUE, BooleanRule.TRUE, unsatisfiedRule).isSatisfied(20));
+
+        assertTrue(satisfiedRule.or(BooleanRule.FALSE, BooleanRule.FALSE).isSatisfied(30));
+        assertFalse(unsatisfiedRule.or(BooleanRule.FALSE, BooleanRule.FALSE).isSatisfied(30));
     }
 }
         


### PR DESCRIPTION
### Summary
This feature is to accept multiple rules for AndRule and OrRule.
It will be useful to combine multiple rules like the following.

```
Rule entryRule = new OrRule(satisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE);
Rule exitRule = new AndRule(satisfiedRule, BooleanRule.TRUE, BooleanRule.TRUE);
Rule complexRule = new OrRule(satisfiedRule.and(rule1, rule2, rule3), satisfiedRule2.and(rule1,rule2));
```

### Test
AndRuleTest
OrRuleTest