### PR TITLE
Fixed ClassCastException in PrecisionNum.equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :boom: **Breaking** Refactored from Max/Min to High/Low
 
 ### Fixed
+- **Fixed `java.lang.ClassCastException` in**: `PrecisionNum.equals()`.
 
 ### Changed
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
@@ -643,10 +643,10 @@ public final class PrecisionNum implements Num {
      */
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof Num)) {
+        if (!(obj instanceof PrecisionNum)) {
             return false;
         }
-        return !((Num) obj).isNaN() && this.delegate.compareTo(((PrecisionNum) obj).delegate) == 0;
+        return this.delegate.compareTo(((PrecisionNum) obj).delegate) == 0;
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
+import static org.ta4j.core.TestUtils.assertNumNotEquals;
 
 public class SeriesBuilderTest extends AbstractIndicatorTest {
 
@@ -75,9 +76,9 @@ public class SeriesBuilderTest extends AbstractIndicatorTest {
         assertNumEquals(seriesB.numOf(12), PrecisionNum.valueOf(12));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void testWrongNumType(){
         TimeSeries series = seriesBuilder.withNumTypeOf(PrecisionNum.class).build();
-        assertNumEquals(series.numOf(12), DoubleNum.valueOf(12));
+        assertNumNotEquals(series.numOf(12), DoubleNum.valueOf(12));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/num/PrecisionNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/PrecisionNumTest.java
@@ -39,6 +39,7 @@ import org.ta4j.core.TimeSeries;
 import org.ta4j.core.indicators.RSIIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 
+import static org.junit.Assert.assertFalse;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 import static org.ta4j.core.TestUtils.assertIndicatorEquals;
 import static org.ta4j.core.TestUtils.assertIndicatorNotEquals;
@@ -300,6 +301,15 @@ public class PrecisionNumTest {
     @Test(expected = NumberFormatException.class)
     public void testValueOfForDoubleNaNShouldThrowNumberFormatException() {
         PrecisionNum.valueOf(Double.NaN);
+    }
+
+    @Test
+    public void testEqualsPrecisionNumWithDoubleNum() {
+        final DoubleNum doubleNum = DoubleNum.valueOf(3.0);
+
+        final PrecisionNum precisionNum = PrecisionNum.valueOf(3.0);
+
+        assertFalse(precisionNum.equals(doubleNum));
     }
 
 }


### PR DESCRIPTION
Fixes #.
Fixed ClassCastException in PrecisionNum.equals


- [X] added an entry to the unreleased section of `CHANGES.md` 
