### PR TITLE
Enhancement/trailing stop loss rule not only for close price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** Implemented TotalProfit2Criterion for calculating the total profit of your trades 
 - :tada: **Enhancement** Implemented TotalLossCriterion for calculating the total loss of your trades
 - :tada: **Enhancement** Added ADX indicator based strategy to ta4j-examples  
+- :tada: **Enhancement** TrailingStopLossRule: added possibility of calculations of TrailingStopLossRule also for open, high, low price. Added getter 
+for currentStopLossLimitActivation
 
 ### Removed/Deprecated
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
@@ -23,22 +23,16 @@
  *******************************************************************************/
 package org.ta4j.core.indicators.helpers;
 
+import org.ta4j.core.Bar;
 import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.num.Num;
 
 /**
  * High price indicator.
  * </p>
  */
-public class HighPriceIndicator extends CachedIndicator<Num> {
+public class HighPriceIndicator extends PriceIndicator {
 
     public HighPriceIndicator(TimeSeries series) {
-        super(series);
-    }
-
-    @Override
-    protected Num calculate(int index) {
-        return getTimeSeries().getBar(index).getHighPrice();
+        super(series, Bar::getHighPrice);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
@@ -23,22 +23,17 @@
  *******************************************************************************/
 package org.ta4j.core.indicators.helpers;
 
+import org.ta4j.core.Bar;
 import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.num.Num;
 
 /**
  * Low price indicator.
  * </p>
  */
-public class LowPriceIndicator extends CachedIndicator<Num> {
+public class LowPriceIndicator extends PriceIndicator {
 
     public LowPriceIndicator(TimeSeries series) {
-        super(series);
+        super(series, Bar::getLowPrice);
     }
 
-    @Override
-    protected Num calculate(int index) {
-        return getTimeSeries().getBar(index).getLowPrice();
-    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
@@ -23,21 +23,16 @@
  *******************************************************************************/
 package org.ta4j.core.indicators.helpers;
 
+import org.ta4j.core.Bar;
 import org.ta4j.core.TimeSeries;
-import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.num.Num;
+
 /**
  * Open price indicator.
  * </p>
  */
-public class OpenPriceIndicator extends CachedIndicator<Num> {
+public class OpenPriceIndicator extends PriceIndicator {
 
     public OpenPriceIndicator(TimeSeries series) {
-        super(series);
-    }
-
-    @Override
-    protected Num calculate(int index) {
-        return getTimeSeries().getBar(index).getOpenPrice();
+        super(series, Bar::getOpenPrice);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PriceIndicator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *   The MIT License (MIT)
  *
- *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization 
+ *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization
  *   & respective authors (see AUTHORS)
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -25,14 +25,26 @@ package org.ta4j.core.indicators.helpers;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.TimeSeries;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
 
 /**
- * Close price indicator.
- * </p>
+ * Base class for price indicators
  */
-public class ClosePriceIndicator extends PriceIndicator {
+public abstract class PriceIndicator extends CachedIndicator<Num> {
 
-    public ClosePriceIndicator(TimeSeries series) {
-        super(series, Bar::getClosePrice);
+    private final Function<Bar, Num> priceFunction;
+
+    public PriceIndicator(TimeSeries series, Function<Bar, Num> priceFunction) {
+        super(series);
+        this.priceFunction = priceFunction;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+        final Bar bar = getTimeSeries().getBar(index);
+        return priceFunction.apply(bar);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
 
 /**
  * Abstract test class to extend TimeSeries, Indicator an other test cases.
- * The extending class will be called twice. First time with {@link BigDecimalNum#valueOf},
+ * The extending class will be called twice. First time with {@link PrecisionNum#valueOf},
  * second time with {@link DoubleNum#valueOf} as <code>Function<Number, Num></></code> parameter.
  * This should ensure that the defined test case is valid for both data types.
  *


### PR DESCRIPTION
Changes proposed in this pull request:
- TrailingStopLossRule: added possibility of calculations of TrailingStopLossRule also for open, high, low price
- TrailingStopLossRule: Added getter for currentStopLossLimitActivation

- [X] added an entry to the unreleased section of `CHANGES.md` 
