### PR TITLE
Trading cost models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Changed
 
 ### Added
+- :tada: **Enhancement** Implemented trading cost models (linear transaction and borrowing cost models)
 - :tada: **Enhancement** Implemented Value at Risk Analysis Criterion
 - :tada: **Enhancement** Implemented Expected Shortfall Analysis Criterion
 - :tada: **Enhancement** Implemented Returns class to analyze the time series of return rates. Supports logarithmic and arithmetic returns

--- a/ta4j-core/src/main/java/org/ta4j/core/Order.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Order.java
@@ -23,6 +23,8 @@
  *******************************************************************************/
 package org.ta4j.core;
 
+import org.ta4j.core.cost.CostModel;
+import org.ta4j.core.cost.ZeroCostModel;
 import org.ta4j.core.num.Num;
 
 import java.io.Serializable;
@@ -35,7 +37,7 @@ import java.util.Objects;
  * <ul>
  *     <li>the index (in the {@link TimeSeries time series}) it is executed
  *     <li>a {@link OrderType type} (BUY or SELL)
- *     <li>a price (optional)
+ *     <li>a pricePerAsset (optional)
  *     <li>an amount to be (or that was) ordered (optional)
  * </ul>
  * A {@link Trade trade} is a pair of complementary orders.
@@ -77,11 +79,20 @@ public class Order implements Serializable {
     /** The index the order was executed */
     private int index;
 
-    /** The price for the order */
-    private Num price;
+    /** The pricePerAsset for the order */
+    private Num pricePerAsset;
+
+    /** The net price for the order, net transaction costs */
+    private Num netPrice;
     
     /** The amount to be (or that was) ordered */
     private Num amount;
+
+    /** Cost of executing the order */
+    private Num cost;
+
+    /** Model for the costs */
+    private CostModel costModel;
 
     /**
      * Constructor.
@@ -90,24 +101,7 @@ public class Order implements Serializable {
      * @param type the type of the order
      */
     protected Order(int index, TimeSeries series, OrderType type) {
-        this.type = type;
-        this.index = index;
-        this.amount = series.numOf(1);
-        this.price = series.getBar(index).getClosePrice();
-    }
-
-    /**
-     * Constructor.
-     * @param index the index the order is executed
-     * @param type the type of the order
-     * @param price the price for the order
-     * @param amount the amount to be (or that was) ordered
-     */
-    protected Order(int index, OrderType type, Num price, Num amount) {
-        this.type = type;
-        this.index = index;
-        this.price = price;
-        this.amount = amount;
+        this(index, series, type, series.numOf(1));
     }
 
     /**
@@ -118,10 +112,59 @@ public class Order implements Serializable {
      * @param amount the amount to be (or that was) ordered
      */
     protected Order(int index, TimeSeries series, OrderType type, Num amount) {
+        this(index, series, type, amount, new ZeroCostModel());
+    }
+
+    /**
+     * Constructor.
+     * @param index the index the order is executed
+     * @param series the time series
+     * @param type the type of the order
+     * @param amount the amount to be (or that was) ordered
+     */
+    protected Order(int index, TimeSeries series, OrderType type, Num amount, CostModel transactionCostModel) {
         this.type = type;
         this.index = index;
-        this.price = series.getBar(index).getClosePrice();
         this.amount = amount;
+
+        setPricesAndCost(series.getBar(index).getClosePrice(), amount, transactionCostModel);
+    }
+
+    /**
+     * Constructor.
+     * @param index the index the order is executed
+     * @param type the type of the order
+     * @param pricePerAsset the pricePerAsset for the order
+     */
+    protected Order(int index, OrderType type, Num pricePerAsset) {
+        this(index, type, pricePerAsset, pricePerAsset.numOf(1));
+    }
+
+    /**
+     * Constructor.
+     * @param index the index the order is executed
+     * @param type the type of the order
+     * @param pricePerAsset the pricePerAsset for the order
+     * @param amount the amount to be (or that was) ordered
+     */
+    protected Order(int index, OrderType type, Num pricePerAsset, Num amount) {
+        this(index, type, pricePerAsset, amount, new ZeroCostModel());
+    }
+
+    /**
+     * Constructor.
+     * @param index the index the order is executed
+     * @param type the type of the order
+     * @param pricePerAsset the pricePerAsset for the order
+     * @param amount the amount to be (or that was) ordered
+     * @param transactionCostModel Cost model for order execution cost
+     */
+    protected Order(int index, OrderType type, Num pricePerAsset, Num amount, CostModel transactionCostModel) {
+        this.type = type;
+        this.index = index;
+        this.amount = amount;
+
+        setPricesAndCost(pricePerAsset, amount, transactionCostModel);
     }
 
     /**
@@ -129,6 +172,57 @@ public class Order implements Serializable {
      */
     public OrderType getType() {
         return type;
+    }
+
+
+    public Num getCost() { return cost; }
+
+    /**
+     * @return the index the order is executed
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * @return the pricePerAsset for the order
+     */
+    public Num getPricePerAsset() { return pricePerAsset; }
+
+    /**
+     * @return the pricePerAsset for the order, net transaction costs
+     */
+    public Num getNetPrice() { return netPrice; }
+
+    /**
+     * @return the amount to be (or that was) ordered
+     */
+    public Num getAmount() {
+        return amount;
+    }
+
+    public CostModel getCostModel() { return costModel; }
+
+
+    /**
+     * Sets the raw and net prices of the order
+     * @param pricePerAsset raw price of the asset
+     * @param amount amount of assets ordered
+     * @param transactionCostModel model of transaction cost
+     */
+    private void setPricesAndCost(Num pricePerAsset, Num amount, CostModel transactionCostModel) {
+        this.costModel = transactionCostModel;
+        this.pricePerAsset = pricePerAsset;
+        this.cost = transactionCostModel.calculate(this.pricePerAsset, amount);
+
+        Num costPerAsset = cost.dividedBy(amount);
+        // add transaction costs to the pricePerAsset at the order
+        if (type.equals(OrderType.BUY)) {
+            this.netPrice = this.pricePerAsset.plus(costPerAsset);
+        }
+        else {
+            this.netPrice = this.pricePerAsset.minus(costPerAsset);
+        }
     }
 
     /**
@@ -145,30 +239,9 @@ public class Order implements Serializable {
         return type == OrderType.SELL;
     }
 
-    /**
-     * @return the index the order is executed
-     */
-    public int getIndex() {
-        return index;
-    }
-
-    /**
-     * @return the price for the order
-     */
-    public Num getPrice() {
-        return price;
-    }
-
-    /**
-     * @return the amount to be (or that was) ordered
-     */
-    public Num getAmount() {
-        return amount;
-    }
-
     @Override
     public int hashCode() {
-        return Objects.hash(type, index, price, amount);
+        return Objects.hash(type, index, pricePerAsset, amount);
     }
 
     @Override
@@ -186,12 +259,13 @@ public class Order implements Serializable {
         if (this.index != other.index) {
             return false;
         }
-        return (this.price == other.price || (this.price != null && this.price.equals(other.price))) && (this.amount == other.amount || (this.amount != null && this.amount.equals(other.amount)));
+        return (this.pricePerAsset == other.pricePerAsset || (this.pricePerAsset != null && this.pricePerAsset.equals(other.pricePerAsset)))
+                && (this.amount == other.amount || (this.amount != null && this.amount.equals(other.amount)));
     }
 
     @Override
     public String toString() {
-        return "Order{" + "type=" + type + ", index=" + index + ", price=" + price + ", amount=" + amount + '}';
+        return "Order{" + "type=" + type + ", index=" + index + ", price=" + pricePerAsset + ", amount=" + amount + '}';
     }
     
     /**
@@ -201,6 +275,16 @@ public class Order implements Serializable {
      */
     public static Order buyAt(int index, TimeSeries series) {
         return new Order(index, series, OrderType.BUY);
+    }
+
+    /**
+     * @param index the index the order is executed
+     * @param price the price for the order
+     * @param amount the amount to be (or that was) bought
+     * @return a BUY order
+     */
+    public static Order buyAt(int index, Num price, Num amount, CostModel transactionCostModel) {
+        return new Order(index, OrderType.BUY, price, amount, transactionCostModel);
     }
 
     /**
@@ -226,6 +310,16 @@ public class Order implements Serializable {
     /**
      * @param index the index the order is executed
      * @param series the time series
+     * @param amount the amount to be (or that was) bought
+     * @return a BUY order
+     */
+    public static Order buyAt(int index, TimeSeries series, Num amount, CostModel transactionCostModel) {
+        return new Order(index, series, OrderType.BUY, amount, transactionCostModel);
+    }
+
+    /**
+     * @param index the index the order is executed
+     * @param series the time series
      * @return a SELL order
      */
     public static Order sellAt(int index, TimeSeries series) {
@@ -244,6 +338,16 @@ public class Order implements Serializable {
 
     /**
      * @param index the index the order is executed
+     * @param price the price for the order
+     * @param amount the amount to be (or that was) sold
+     * @return a SELL order
+     */
+    public static Order sellAt(int index, Num price, Num amount, CostModel transactionCostModel) {
+        return new Order(index, OrderType.SELL, price, amount, transactionCostModel);
+    }
+
+    /**
+     * @param index the index the order is executed
      * @param series the time series
      * @param amount the amount to be (or that was) bought
      * @return a SELL order
@@ -253,9 +357,19 @@ public class Order implements Serializable {
     }
 
     /**
-     * @return the value of an order
+     * @param index the index the order is executed
+     * @param series the time series
+     * @param amount the amount to be (or that was) bought
+     * @return a SELL order
+     */
+    public static Order sellAt(int index, TimeSeries series, Num amount, CostModel transactionCostModel) {
+        return new Order(index, series, OrderType.SELL, amount, transactionCostModel);
+    }
+
+    /**
+     * @return the value of an order (without transaction cost)
      */
     public Num getValue() {
-        return price.multipliedBy(amount);
+        return pricePerAsset.multipliedBy(amount);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
@@ -53,10 +53,10 @@ public class ProfitLossCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(TimeSeries series, Trade trade) {
         if (trade.isClosed()) {
-            Num exitClosePrice = trade.getExit().getPrice().isNaN() ?
-                    series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getPrice();
-            Num entryClosePrice = trade.getEntry().getPrice().isNaN() ?
-                    series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getPrice();
+            Num exitClosePrice = trade.getExit().getNetPrice().isNaN() ?
+                    series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getNetPrice();
+            Num entryClosePrice = trade.getEntry().getNetPrice().isNaN() ?
+                    series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getNetPrice();
 
             return exitClosePrice.minus(entryClosePrice).multipliedBy(trade.getExit().getAmount());
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalProfitCriterion.java
@@ -62,10 +62,10 @@ public class TotalProfitCriterion extends AbstractAnalysisCriterion {
         Num profit = series.numOf(1);
         if (trade.isClosed()) {
             // use price of entry/exit order, if NaN use close price of underlying time series
-            Num exitClosePrice = trade.getExit().getPrice().isNaN() ?
-                    series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getPrice();
-            Num entryClosePrice = trade.getEntry().getPrice().isNaN() ?
-                    series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getPrice();
+            Num exitClosePrice = trade.getExit().getNetPrice().isNaN() ?
+                    series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getNetPrice();
+            Num entryClosePrice = trade.getEntry().getNetPrice().isNaN() ?
+                    series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getNetPrice();
 
 
 

--- a/ta4j-core/src/main/java/org/ta4j/core/cost/CostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/cost/CostModel.java
@@ -1,0 +1,32 @@
+package org.ta4j.core.cost;
+
+import org.ta4j.core.Trade;
+import org.ta4j.core.num.Num;
+
+import java.io.Serializable;
+
+
+public interface CostModel extends Serializable {
+
+    /**
+     * @param trade the trade
+     * @param finalIndex final index of consideration for open trades
+     * @return Calculates the trading cost of a single trade
+     */
+    Num calculate(Trade trade, int finalIndex);
+
+    /**
+     * @param trade the trade
+     * @return Calculates the trading cost of a single trade
+     */
+    Num calculate(Trade trade);
+
+    /**
+     * @param price the price per asset
+     * @param amount number of traded assets
+     * @return Calculates the trading cost for a certain traded amount
+     */
+    Num calculate(Num price, Num amount);
+
+    boolean equals(CostModel model);
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/cost/LinearBorrowingCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/cost/LinearBorrowingCostModel.java
@@ -1,0 +1,84 @@
+package org.ta4j.core.cost;
+
+import org.ta4j.core.Order;
+import org.ta4j.core.Trade;
+import org.ta4j.core.num.Num;
+
+public class LinearBorrowingCostModel implements CostModel {
+
+    /**
+     * Slope of the linear model - fee per period
+     */
+    private double feePerPeriod;
+
+    /**
+     * Constructor.
+     * (feePerPeriod * nPeriod)
+     * @param feePerPeriod the coefficient (e.g. 0.0001 for 1bp per period)
+     */
+    public LinearBorrowingCostModel(double feePerPeriod) {
+        this.feePerPeriod = feePerPeriod;
+    }
+
+    public Num calculate(Num price, Num amount) {
+        // borrowing costs depend on borrowed period
+        return price.numOf(0);
+    }
+
+    /**
+     * Calculates the borrowing cost of a closed trade.
+     * @param trade the trade
+     * @return the absolute order cost
+     */
+    public Num calculate(Trade trade) {
+        if (trade.isOpened()) { throw new IllegalArgumentException("Trade is not closed. Final index of observation needs to be provided."); }
+        return calculate(trade, trade.getExit().getIndex());
+    }
+
+    /**
+     * Calculates the borrowing cost of a trade.
+     * @param trade the trade
+     * @param currentIndex final bar index to be considered (for open trades)
+     * @return the absolute order cost
+     */
+    public Num calculate(Trade trade, int currentIndex) {
+        Order entryOrder = trade.getEntry();
+        Order exitOrder = trade.getExit();
+        Num borrowingCost = trade.getEntry().getNetPrice().numOf(0);
+
+        // borrowing costs apply for short positions only
+        if (entryOrder != null && entryOrder.getType().equals(Order.OrderType.SELL) && entryOrder.getAmount() != null) {
+            int tradingPeriods = 0;
+            if (trade.isClosed()) {
+                tradingPeriods = exitOrder.getIndex() - entryOrder.getIndex();
+            } else if (trade.isOpened()) {
+                tradingPeriods = currentIndex - entryOrder.getIndex();
+            }
+            borrowingCost = getHoldingCostForPeriods(tradingPeriods, trade.getEntry().getValue());
+        }
+        return borrowingCost;
+    }
+
+    /**
+     * @param tradingPeriods number of periods
+     * @param tradedValue value of the trade initial trade position
+     * @return the absolute borrowing cost
+     */
+    private Num getHoldingCostForPeriods(int tradingPeriods, Num tradedValue) {
+        return tradedValue
+                .multipliedBy(tradedValue.numOf(tradingPeriods)
+                        .multipliedBy(tradedValue.numOf(feePerPeriod)));
+    }
+
+    /**
+     * Evaluate if two models are equal
+     * @param otherModel model to compare with
+     */
+    public boolean equals(CostModel otherModel) {
+        boolean equality = false;
+        if (this.getClass().equals(otherModel.getClass())) {
+            equality = ((LinearBorrowingCostModel) otherModel).feePerPeriod == this.feePerPeriod;
+        }
+        return equality;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/cost/LinearTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/cost/LinearTransactionCostModel.java
@@ -1,0 +1,71 @@
+package org.ta4j.core.cost;
+
+import org.ta4j.core.Order;
+import org.ta4j.core.Trade;
+import org.ta4j.core.num.Num;
+
+public class LinearTransactionCostModel implements CostModel {
+
+    /**
+     * Slope of the linear model - fee per trade
+     */
+    private double feePerTrade;
+
+    /**
+     * Constructor.
+     * (feePerTrade * x)
+     * @param feePerTrade the feePerTrade coefficient (e.g. 0.005 for 0.5% per {@link Order order})
+     */
+    public LinearTransactionCostModel(double feePerTrade) {
+        this.feePerTrade = feePerTrade;
+    }
+
+    /**
+     * Calculates the transaction cost of a trade.
+     * @param trade the trade
+     * @param currentIndex current bar index (irrelevant for the LinearTransactionCostModel)
+     * @return the absolute order cost
+     */
+    public Num calculate(Trade trade, int currentIndex) {
+        return this.calculate(trade);
+    }
+
+    /**
+     * Calculates the transaction cost of a trade.
+     * @param trade the trade
+     * @return the absolute order cost
+     */
+    public Num calculate(Trade trade) {
+        Num totalTradeCost = null;
+        Order entryOrder = trade.getEntry();
+        if (entryOrder != null) {
+            // transaction costs of entry order
+            totalTradeCost = entryOrder.getCost();
+            if (trade.getExit() != null) {
+                totalTradeCost = totalTradeCost.plus(trade.getExit().getCost());
+            }
+        }
+        return totalTradeCost;
+    }
+
+    /**
+     * @param price execution price
+     * @param amount order amount
+     * @return the absolute order transaction cost
+     */
+    public Num calculate(Num price, Num amount) {
+        return amount.numOf(feePerTrade).multipliedBy(price).multipliedBy(amount);
+    }
+
+    /**
+     * Evaluate if two models are equal
+     * @param otherModel model to compare with
+     */
+    public boolean equals(CostModel otherModel) {
+        boolean equality = false;
+        if (this.getClass().equals(otherModel.getClass())) {
+            equality = ((LinearTransactionCostModel) otherModel).feePerTrade == this.feePerTrade;
+        }
+        return equality;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/cost/ZeroCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/cost/ZeroCostModel.java
@@ -1,0 +1,38 @@
+package org.ta4j.core.cost;
+
+import org.ta4j.core.Trade;
+import org.ta4j.core.num.Num;
+
+
+public class ZeroCostModel implements CostModel {
+
+    /**
+     * Constructor for a trading cost-free model.
+     *
+     */
+    public ZeroCostModel() {}
+
+    public Num calculate(Trade trade) {
+        return calculate(trade, 0);
+    }
+
+    public Num calculate(Trade trade, int currentIndex) {
+        return trade.getEntry().getPricePerAsset().numOf(0);
+    }
+
+    public Num calculate(Num price, Num amount) {
+        return price.numOf(0);
+    }
+
+    /**
+     * Evaluate if two models are equal
+     * @param otherModel model to compare with
+     */
+    public boolean equals(CostModel otherModel) {
+        boolean equality = false;
+        if (this.getClass().equals(otherModel.getClass())) {
+            equality = true;
+        }
+        return equality;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/StopGainRule.java
@@ -76,7 +76,7 @@ public class StopGainRule extends AbstractRule {
         if (tradingRecord != null) {
             Trade currentTrade = tradingRecord.getCurrentTrade();
             if (currentTrade.isOpened()) {
-                Num entryPrice = currentTrade.getEntry().getPrice();
+                Num entryPrice = currentTrade.getEntry().getNetPrice();
                 Num currentPrice = closePrice.getValue(index);
                 Num threshold = entryPrice.multipliedBy(gainRatioThreshold);
                 if (currentTrade.getEntry().isBuy()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/StopLossRule.java
@@ -75,7 +75,7 @@ public class StopLossRule extends AbstractRule {
         if (tradingRecord != null) {
             Trade currentTrade = tradingRecord.getCurrentTrade();
             if (currentTrade.isOpened()) {
-                Num entryPrice = currentTrade.getEntry().getPrice();
+                Num entryPrice = currentTrade.getEntry().getNetPrice();
                 Num currentPrice = closePrice.getValue(index);
                 Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
                 if (currentTrade.getEntry().isBuy()) {

--- a/ta4j-core/src/test/java/org/ta4j/core/OrderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/OrderTest.java
@@ -26,9 +26,14 @@ package org.ta4j.core;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Order.OrderType;
+import org.ta4j.core.cost.CostModel;
+import org.ta4j.core.cost.LinearTransactionCostModel;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.Num;
 
 import static org.junit.Assert.*;
 import static org.ta4j.core.num.NaN.NaN;
+import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class OrderTest {
 
@@ -59,5 +64,21 @@ public class OrderTest {
 
         assertNotEquals(opEquals1.toString(), opNotEquals1.toString());
         assertNotEquals(opEquals1.toString(), opNotEquals2.toString());
+    }
+
+    @Test
+    public void initializeWithCostsTest() {
+        CostModel transactionCostModel = new LinearTransactionCostModel(0.05);
+        Order order = new Order(0, OrderType.BUY, DoubleNum.valueOf(100),  DoubleNum.valueOf(20), transactionCostModel);
+        Num expectedCost = DoubleNum.valueOf(100);
+        Num expectedValue = DoubleNum.valueOf(2000);
+        Num expectedRawPrice = DoubleNum.valueOf(100);
+        Num expectedNetPrice = DoubleNum.valueOf(105);
+
+        assertNumEquals(expectedCost, order.getCost());
+        assertNumEquals(expectedValue,order.getValue());
+        assertNumEquals(expectedRawPrice, order.getPricePerAsset());
+        assertNumEquals(expectedNetPrice, order.getNetPrice());
+        assertTrue(transactionCostModel.equals(order.getCostModel()));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesManagerTest.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.ta4j.core.num.NaN.NaN;
 
 
 public class TimeSeriesManagerTest extends AbstractIndicatorTest {
@@ -104,11 +103,11 @@ public class TimeSeriesManagerTest extends AbstractIndicatorTest {
         List<Trade> trades = manager.run(strategy).getTrades();
         assertEquals(2, trades.size());
 
-        assertEquals(Order.buyAt(2, seriesForRun.getBar(2).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(4, seriesForRun.getBar(4).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(2, seriesForRun.getBar(2).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(4, seriesForRun.getBar(4).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
-        assertEquals(Order.buyAt(6, seriesForRun.getBar(6).getClosePrice(), NaN), trades.get(1).getEntry());
-        assertEquals(Order.sellAt(7, seriesForRun.getBar(7).getClosePrice(), NaN), trades.get(1).getExit());
+        assertEquals(Order.buyAt(6, seriesForRun.getBar(6).getClosePrice(), numOf(1)), trades.get(1).getEntry());
+        assertEquals(Order.sellAt(7, seriesForRun.getBar(7).getClosePrice(), numOf(1)), trades.get(1).getExit());
     }
 
     @Test
@@ -117,8 +116,8 @@ public class TimeSeriesManagerTest extends AbstractIndicatorTest {
         List<Trade> trades = manager.run(aStrategy, 0, 3).getTrades();
         assertEquals(1, trades.size());
 
-        assertEquals(Order.buyAt(1, seriesForRun.getBar(1).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(3, seriesForRun.getBar(3).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(1, seriesForRun.getBar(1).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(3, seriesForRun.getBar(3).getClosePrice(), numOf(1)), trades.get(0).getExit());
     }
 
     @Test
@@ -127,8 +126,8 @@ public class TimeSeriesManagerTest extends AbstractIndicatorTest {
         List<Trade> trades = manager.run(aStrategy, OrderType.SELL, 0, 3).getTrades();
         assertEquals(1, trades.size());
 
-        assertEquals(Order.sellAt(1, seriesForRun.getBar(1).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.buyAt(3, seriesForRun.getBar(3).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.sellAt(1, seriesForRun.getBar(1).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.buyAt(3, seriesForRun.getBar(3).getClosePrice(), numOf(1)), trades.get(0).getExit());
     }
 
     @Test
@@ -136,16 +135,16 @@ public class TimeSeriesManagerTest extends AbstractIndicatorTest {
 
         List<Trade> trades = manager.run(strategy, 0, 3).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(2, seriesForRun.getBar(2).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(4, seriesForRun.getBar(4).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(2, seriesForRun.getBar(2).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(4, seriesForRun.getBar(4).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
         trades = manager.run(strategy, 4, 4).getTrades();
         assertTrue(trades.isEmpty());
 
         trades = manager.run(strategy, 5, 8).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(6, seriesForRun.getBar(6).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(7, seriesForRun.getBar(7).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(6, seriesForRun.getBar(6).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(7, seriesForRun.getBar(7).getClosePrice(), numOf(1)), trades.get(0).getExit());
     }
 
     @Test
@@ -160,23 +159,23 @@ public class TimeSeriesManagerTest extends AbstractIndicatorTest {
 
         List<Trade> trades = manager.run(aStrategy, 0, 1).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(0, series.getBar(0).getClosePrice(), NaN),trades.get(0).getEntry());
-        assertEquals(Order.sellAt(2, series.getBar(2).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(0, series.getBar(0).getClosePrice(), numOf(1)),trades.get(0).getEntry());
+        assertEquals(Order.sellAt(2, series.getBar(2).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
         trades = manager.run(aStrategy, 2, 3).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(3, series.getBar(3).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(4, series.getBar(4).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(3, series.getBar(3).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(4, series.getBar(4).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
         trades = manager.run(aStrategy, 4, 6).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(5, series.getBar(5).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(6, series.getBar(6).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(5, series.getBar(5).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(6, series.getBar(6).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
         trades = manager.run(aStrategy, 7, 7).getTrades();
         assertEquals(1, trades.size());
-        assertEquals(Order.buyAt(7, series.getBar(7).getClosePrice(), NaN), trades.get(0).getEntry());
-        assertEquals(Order.sellAt(9, series.getBar(9).getClosePrice(), NaN), trades.get(0).getExit());
+        assertEquals(Order.buyAt(7, series.getBar(7).getClosePrice(), numOf(1)), trades.get(0).getEntry());
+        assertEquals(Order.sellAt(9, series.getBar(9).getClosePrice(), numOf(1)), trades.get(0).getExit());
 
         trades = manager.run(aStrategy, 8, 8).getTrades();
         assertTrue(trades.isEmpty());

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
@@ -25,6 +25,7 @@ package org.ta4j.core.analysis;
 
 import org.junit.Test;
 import org.ta4j.core.*;
+import org.ta4j.core.cost.LinearBorrowingCostModel;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockTimeSeries;
@@ -76,7 +77,7 @@ public class CashFlowTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
         assertNumEquals("0.5", cashFlow.getValue(3));
         assertNumEquals("0.6", cashFlow.getValue(4));
         assertNumEquals("0.6", cashFlow.getValue(5));
-        assertNumEquals("0.09", cashFlow.getValue(6));
+        assertNumEquals("-2.8", cashFlow.getValue(6));
     }
 
 
@@ -90,9 +91,9 @@ public class CashFlowTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
         assertNumEquals(1, cashFlow.getValue(0));
         assertNumEquals(1, cashFlow.getValue(1));
         assertNumEquals(1, cashFlow.getValue(2));
-        assertNumEquals("0.5", cashFlow.getValue(3));
-        assertNumEquals("0.5", cashFlow.getValue(4));
-        assertNumEquals("0.5", cashFlow.getValue(5));
+        assertNumEquals(0, cashFlow.getValue(3));
+        assertNumEquals(0, cashFlow.getValue(4));
+        assertNumEquals(0, cashFlow.getValue(5));
     }
 
     @Test
@@ -108,9 +109,9 @@ public class CashFlowTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
         assertNumEquals(1, cashFlow.getValue(0));
         assertNumEquals(2, cashFlow.getValue(1));
         assertNumEquals(4, cashFlow.getValue(2));
-        assertNumEquals(2, cashFlow.getValue(3));
-        assertNumEquals(1, cashFlow.getValue(4));
-        assertNumEquals(2, cashFlow.getValue(5));
+        assertNumEquals(0, cashFlow.getValue(3));
+        assertNumEquals(-8, cashFlow.getValue(4));
+        assertNumEquals(-8, cashFlow.getValue(5));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
@@ -99,15 +99,19 @@ public class ReturnsTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
         TimeSeries doubleSeries = new MockTimeSeries(numFunction,1.2d, 1.1d);
         TimeSeries precisionSeries = new MockTimeSeries(PrecisionNum::valueOf,1.2d, 1.1d);
 
-        TradingRecord fullRecord = new BaseTradingRecord();
-        fullRecord.enter(doubleSeries.getBeginIndex());
-        fullRecord.exit(doubleSeries.getEndIndex());
+        TradingRecord fullRecordDouble = new BaseTradingRecord();
+        fullRecordDouble.enter(doubleSeries.getBeginIndex(), doubleSeries.getBar(0).getClosePrice(), doubleSeries.numOf(1));
+        fullRecordDouble.exit(doubleSeries.getEndIndex(), doubleSeries.getBar(1).getClosePrice(), doubleSeries.numOf(1));
+
+        TradingRecord fullRecordPrecision = new BaseTradingRecord();
+        fullRecordPrecision.enter(precisionSeries.getBeginIndex(), precisionSeries.getBar(0).getClosePrice(), precisionSeries.numOf(1));
+        fullRecordPrecision.exit(precisionSeries.getEndIndex(), precisionSeries.getBar(1).getClosePrice(), precisionSeries.numOf(1));
 
         // Return calculation DoubleNum vs PrecisionNum
-        Num arithDouble = new Returns(doubleSeries, fullRecord, Returns.ReturnType.ARITHMETIC).getValue(1);
-        Num arithPrecision = new Returns(precisionSeries, fullRecord, Returns.ReturnType.ARITHMETIC).getValue(1);
-        Num logDouble = new Returns(doubleSeries, fullRecord, Returns.ReturnType.LOG).getValue(1);
-        Num logPrecision = new Returns(precisionSeries, fullRecord, Returns.ReturnType.LOG).getValue(1);
+        Num arithDouble = new Returns(doubleSeries, fullRecordDouble, Returns.ReturnType.ARITHMETIC).getValue(1);
+        Num arithPrecision = new Returns(precisionSeries, fullRecordPrecision, Returns.ReturnType.ARITHMETIC).getValue(1);
+        Num logDouble = new Returns(doubleSeries, fullRecordDouble, Returns.ReturnType.LOG).getValue(1);
+        Num logPrecision = new Returns(precisionSeries, fullRecordPrecision, Returns.ReturnType.LOG).getValue(1);
 
         assertNumEquals(arithDouble, DoubleNum.valueOf(-0.08333333333333326));
         assertNumEquals(arithPrecision, PrecisionNum.valueOf(1.1).dividedBy(PrecisionNum.valueOf(1.2)).minus(PrecisionNum.valueOf(1)));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
@@ -86,7 +86,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
                 Order.buyAt(0,series), Order.sellAt(1,series),
                 Order.buyAt(3,series), Order.sellAt(4,series),
                 Order.sellAt(5,series), Order.buyAt(6,series));
-        assertNumEquals(.91, mdd.calculate(series, tradingRecord));
+        assertNumEquals(3.8d, mdd.calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/cost/LinearBorrowingCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/cost/LinearBorrowingCostModelTest.java
@@ -1,0 +1,93 @@
+package org.ta4j.core.cost;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.Num;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+public class LinearBorrowingCostModelTest {
+
+    private CostModel borrowingModel;
+
+    @Before
+    public void setUp() throws Exception {
+        borrowingModel = new LinearBorrowingCostModel(0.01);
+    }
+
+    @Test
+    public void calculateZeroTest() {
+        // Price - Amount calculation Test
+        Num price = DoubleNum.valueOf(100);
+        Num amount = DoubleNum.valueOf(2);
+        Num cost = borrowingModel.calculate(price, amount);
+
+        assertNumEquals(DoubleNum.valueOf(0), cost);
+    }
+
+    @Test
+    public void calculateBuyTrade() {
+        // Holding a bought stock should not incur borrowing costs
+        int holdingPeriod = 2;
+        Order entry = Order.buyAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        Order exit = Order.sellAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1));
+
+        Trade trade = new Trade(entry, exit, new ZeroCostModel(), borrowingModel);
+
+        Num costsFromTrade = trade.getHoldingCost();
+        Num costsFromModel = borrowingModel.calculate(trade, holdingPeriod);
+
+        assertNumEquals(costsFromModel, costsFromTrade);
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(0));
+    }
+
+    @Test
+    public void calculateSellTrade() {
+        // Short selling incurs borrowing costs
+        int holdingPeriod = 2;
+        Order entry = Order.sellAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        Order exit = Order.buyAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1));
+
+        Trade trade = new Trade(entry, exit, new ZeroCostModel(), borrowingModel);
+
+        Num costsFromTrade = trade.getHoldingCost();
+        Num costsFromModel = borrowingModel.calculate(trade, holdingPeriod);
+
+        assertNumEquals(costsFromModel, costsFromTrade);
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(2));
+    }
+
+    @Test
+    public void calculateOpenSellTrade() {
+        // Short selling incurs borrowing costs. Since trade is still open, accounted for until current index
+        int currentIndex = 4;
+        Trade trade = new Trade(Order.OrderType.SELL, new ZeroCostModel(), borrowingModel);
+        trade.operate(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+
+        Num costsFromTrade = trade.getHoldingCost(currentIndex);
+        Num costsFromModel = borrowingModel.calculate(trade, currentIndex);
+
+        assertNumEquals(costsFromModel, costsFromTrade);
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(4));
+    }
+
+    @Test
+    public void testEquality() {
+        LinearBorrowingCostModel model = new LinearBorrowingCostModel(0.1);
+        CostModel modelSameClass = new LinearBorrowingCostModel(0.2);
+        CostModel modelSameFee = new LinearBorrowingCostModel(0.1);
+        CostModel modelOther = new ZeroCostModel();
+
+        boolean equality = model.equals(modelSameFee);
+        boolean inequality_1 = model.equals(modelSameClass);
+        boolean inequality_2 = model.equals(modelOther);
+
+        assertTrue(equality);
+        assertFalse(inequality_1);
+        assertFalse(inequality_2);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/cost/LinearTransactionCostModelTest.java
@@ -1,0 +1,97 @@
+package org.ta4j.core.cost;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.Num;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.ta4j.core.Order;
+import org.ta4j.core.Trade;
+
+public class LinearTransactionCostModelTest {
+
+    private CostModel transactionModel;
+
+    @Before
+    public void setUp() throws Exception {
+        transactionModel = new LinearTransactionCostModel(0.01);
+    }
+
+    @Test
+    public void calculateSingleOrderCost() {
+        // Price - Amount calculation Test
+        Num price = DoubleNum.valueOf(100);
+        Num amount = DoubleNum.valueOf(2);
+        Num cost = transactionModel.calculate(price, amount);
+
+        assertNumEquals(DoubleNum.valueOf(2), cost);
+    }
+
+    @Test
+    public void calculateBuyTrade() {
+        // Calculate the transaction costs of a closed long trade
+        int holdingPeriod = 2;
+        Order entry = Order.buyAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1), transactionModel);
+        Order exit = Order.sellAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1), transactionModel);
+
+        Trade trade = new Trade(entry, exit, transactionModel, new ZeroCostModel());
+
+        Num costFromBuy = entry.getCost();
+        Num costFromSell = exit.getCost();
+        Num costsFromModel = transactionModel.calculate(trade, holdingPeriod);
+
+        assertNumEquals(costsFromModel, costFromBuy.plus(costFromSell));
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(2.1));
+        assertNumEquals(costFromBuy, DoubleNum.valueOf(1));
+    }
+
+    @Test
+    public void calculateSellTrade() {
+        // Calculate the transaction costs of a closed short trade
+        int holdingPeriod = 2;
+        Order entry = Order.sellAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1), transactionModel);
+        Order exit = Order.buyAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1), transactionModel);
+
+        Trade trade = new Trade(entry, exit, transactionModel, new ZeroCostModel());
+
+        Num costFromBuy = entry.getCost();
+        Num costFromSell = exit.getCost();
+        Num costsFromModel = transactionModel.calculate(trade, holdingPeriod);
+
+        assertNumEquals(costsFromModel, costFromBuy.plus(costFromSell));
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(2.1));
+        assertNumEquals(costFromBuy, DoubleNum.valueOf(1));
+    }
+
+    @Test
+    public void calculateOpenSellTrade() {
+        // Calculate the transaction costs of an open trade
+        int currentIndex = 4;
+        Trade trade = new Trade(Order.OrderType.BUY, transactionModel, new ZeroCostModel());
+        trade.operate(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+
+        Num costsFromModel = transactionModel.calculate(trade, currentIndex);
+
+        assertNumEquals(costsFromModel, DoubleNum.valueOf(1));
+    }
+
+    @Test
+    public void testEquality() {
+        LinearTransactionCostModel model = new LinearTransactionCostModel(0.1);
+        CostModel modelSameClass = new LinearTransactionCostModel(0.2);
+        CostModel modelSameFee = new LinearTransactionCostModel(0.1);
+        CostModel modelOther = new ZeroCostModel();
+
+        boolean equality = model.equals(modelSameFee);
+        boolean inequality_1 = model.equals(modelSameClass);
+        boolean inequality_2 = model.equals(modelOther);
+
+        assertTrue(equality);
+        assertFalse(inequality_1);
+        assertFalse(inequality_2);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/cost/ZeroCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/cost/ZeroCostModelTest.java
@@ -1,0 +1,50 @@
+package org.ta4j.core.cost;
+
+import org.junit.Test;
+import org.ta4j.core.Order;
+import org.ta4j.core.Trade;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.Num;
+
+import static org.junit.Assert.*;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+public class ZeroCostModelTest {
+
+    @Test
+    public void calculatePerTrade() {
+        // calculate costs per trade
+        ZeroCostModel model = new ZeroCostModel();
+
+        int holdingPeriod = 2;
+        Order entry = Order.buyAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1), model);
+        Order exit = Order.sellAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1), model);
+
+        Trade trade = new Trade(entry, exit, model, model);
+        Num cost = model.calculate(trade, holdingPeriod);
+
+        assertNumEquals(cost, DoubleNum.valueOf(0));
+
+    }
+
+    @Test
+    public void calculatePerPrice() {
+        // calculate costs per trade
+        ZeroCostModel model = new ZeroCostModel();
+        Num cost = model.calculate(DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+
+        assertNumEquals(cost, DoubleNum.valueOf(0));
+    }
+
+    @Test
+    public void testEquality() {
+        ZeroCostModel model = new ZeroCostModel();
+        CostModel modelSame = new ZeroCostModel();
+        CostModel modelOther = new LinearTransactionCostModel(0.1);
+        boolean equality = model.equals(modelSame);
+        boolean inequality = model.equals(modelOther);
+
+        assertTrue(equality);
+        assertFalse(inequality);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopGainRuleTest.java
@@ -57,7 +57,7 @@ public class StopGainRuleTest extends AbstractIndicatorTest {
     
     @Test
     public void isSatisfied() {
-        final Num tradedAmount = numOf(0);
+        final Num tradedAmount = numOf(1);
         
         // 30% stop-gain
         StopGainRule rule = new StopGainRule(closePrice, numOf(30));

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *   The MIT License (MIT)
+ *
+ *   Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2018 Ta4j Organization 
+ *   & respective authors (see AUTHORS)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *   this software and associated documentation files (the "Software"), to deal in
+ *   the Software without restriction, including without limitation the rights to
+ *   use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *   the Software, and to permit persons to whom the Software is furnished to do so,
+ *   subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *   FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *   COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *******************************************************************************/
+package ta4jexamples.analysis;
+
+import org.ta4j.core.*;
+import org.ta4j.core.cost.CostModel;
+import org.ta4j.core.cost.LinearBorrowingCostModel;
+import org.ta4j.core.cost.LinearTransactionCostModel;
+import org.ta4j.core.indicators.SMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.trading.rules.OverIndicatorRule;
+import org.ta4j.core.trading.rules.UnderIndicatorRule;
+import ta4jexamples.loaders.CsvTradesLoader;
+
+import java.text.DecimalFormat;
+
+/**
+ * This class displays an example of the transaction cost calculation.
+ */
+public class TradeCost {
+
+    public static void main(String[] args) {
+
+        // Getting the time series
+        TimeSeries series = CsvTradesLoader.loadBitstampSeries();
+        // Building the short selling trading strategy
+        Strategy strategy = buildShortSellingMomentumStrategy(series);
+
+        // Setting the trading cost models
+        double feePerTrade = 0.0005;
+        double borrowingFee = 0.00001;
+        CostModel transactionCostModel = new LinearTransactionCostModel(feePerTrade);
+        CostModel borrowingCostModel = new LinearBorrowingCostModel(borrowingFee);
+
+        // Running the strategy
+        TimeSeriesManager seriesManager = new TimeSeriesManager(series, transactionCostModel, borrowingCostModel);
+        Order.OrderType entryOrder = Order.OrderType.SELL;
+        TradingRecord tradingRecord = seriesManager.run(strategy, entryOrder);
+
+        DecimalFormat df = new DecimalFormat("##.##");
+        System.out.println("------------ Borrowing Costs ------------");
+        tradingRecord.getTrades().forEach(trade -> System.out.println("Borrowing cost for " +
+                df.format(trade.getExit().getIndex()-trade.getEntry().getIndex()) + " periods is: " +
+                df.format(trade.getHoldingCost().doubleValue())));
+        System.out.println("------------ Transaction Costs ------------");
+        tradingRecord.getTrades().forEach(trade -> System.out.println("Transaction cost for selling: " +
+                df.format(trade.getEntry().getCost().doubleValue()) + " -- Transaction cost for buying: " +
+                df.format(trade.getExit().getCost().doubleValue())));
+    }
+
+    private static Strategy buildShortSellingMomentumStrategy(TimeSeries series) {
+        Indicator<Num> closingPrices = new ClosePriceIndicator(series);
+        SMAIndicator shortEma = new SMAIndicator(closingPrices, 10);
+        SMAIndicator longEma = new SMAIndicator(closingPrices, 50);
+        Rule shortOverLongRule = new OverIndicatorRule(shortEma, longEma);
+        Rule shortUnderLongRule = new UnderIndicatorRule(shortEma, longEma);
+
+        String strategyName = "Momentum short-selling strategy";
+        return new BaseStrategy(strategyName, shortOverLongRule, shortUnderLongRule);
+    }
+}

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
@@ -143,7 +143,7 @@ public class TradingBotOnMovingTimeSeries {
                 if (entered) {
                     Order entry = tradingRecord.getLastEntry();
                     System.out.println("Entered on " + entry.getIndex()
-                            + " (price=" + entry.getPrice().doubleValue()
+                            + " (price=" + entry.getNetPrice().doubleValue()
                             + ", amount=" + entry.getAmount().doubleValue() + ")");
                 }
             } else if (strategy.shouldExit(endIndex)) {
@@ -153,7 +153,7 @@ public class TradingBotOnMovingTimeSeries {
                 if (exited) {
                     Order exit = tradingRecord.getLastExit();
                     System.out.println("Exited on " + exit.getIndex()
-                            + " (price=" + exit.getPrice().doubleValue()
+                            + " (price=" + exit.getNetPrice().doubleValue()
                             + ", amount=" + exit.getAmount().doubleValue() + ")");
                 }
             }

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
@@ -1,0 +1,11 @@
+package ta4jexamples.analysis;
+
+import org.junit.Test;
+
+public class TradeCostTest {
+
+    @Test
+    public void test() {
+        TradeCost.main(null);
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Modelling of trading costs. Inclusion of two models
- LinearTransactionCostModel: Calculates the transaction cost as a linear function of the traded value (amount * price). Transaction costs arise at order level, hence they are part of the `Order` class.
- LinearBorrowingCostModel: Calculates holding costs (for borrowing assets) as a linear function of the traded amount and the holding period. Holding costs arise at trade level, hence they are part of the `Trade` class.
- Added a demonstrative example

Issue: https://github.com/ta4j/ta4j/issues/327