### PR TITLE
StopLossRule and StopGainRule now correctly handle sale orders. (issue  #373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Fixed `java.lang.ClassCastException` in**: `DoubleNum.equals()`.
 - **Fixed `java.lang.NullPointerException` in**: `NumberOfBarsCriterion.calculate(TimeSeries, Trade)` for opened trade.
 - **Fixed `java.lang.NullPointerException` in**: `AverageProfitableTradesCriterion.calculate(TimeSeries, Trade)` for opened trade.
+- **StopGainRule**: now correctly handles stops for sell orders
+- **StopLossRule**: now correctly handles stops for sell orders
 
 ### Changed
 

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopGainRuleTest.java
@@ -26,6 +26,7 @@ package org.ta4j.core.trading.rules;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Order;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -40,7 +41,6 @@ import static org.junit.Assert.assertTrue;
 
 public class StopGainRuleTest extends AbstractIndicatorTest {
 
-    private TradingRecord tradingRecord;
     private ClosePriceIndicator closePrice;
 
     public StopGainRuleTest(Function<Number, Num> numFunction) {
@@ -49,14 +49,14 @@ public class StopGainRuleTest extends AbstractIndicatorTest {
 
     @Before
     public void setUp() {
-        tradingRecord = new BaseTradingRecord();
         closePrice = new ClosePriceIndicator(new MockTimeSeries(numFunction,
-                100, 105, 110, 120, 150, 120, 160, 180
+                100, 105, 110, 120, 150, 120, 160, 180, 170, 135, 104
         ));
     }
     
     @Test
-    public void isSatisfied() {
+    public void isSatisfied_worksForBuy() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Order.OrderType.BUY);
         final Num tradedAmount = numOf(1);
         
         // 30% stop-gain
@@ -78,6 +78,33 @@ public class StopGainRuleTest extends AbstractIndicatorTest {
         assertFalse(rule.isSatisfied(5, tradingRecord));
         assertTrue(rule.isSatisfied(6, tradingRecord));
         assertTrue(rule.isSatisfied(7, tradingRecord));
+    }
+
+    @Test
+    public void isSatisfied_worksForSell() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Order.OrderType.SELL);
+        final Num tradedAmount = numOf(1);
+
+        // 30% stop-gain
+        StopGainRule rule = new StopGainRule(closePrice, numOf(10));
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+
+        // Enter at 178
+        tradingRecord.enter(7, numOf(178), tradedAmount);
+        assertFalse(rule.isSatisfied(7, tradingRecord));
+        assertFalse(rule.isSatisfied(8, tradingRecord));
+        assertTrue(rule.isSatisfied(9, tradingRecord));
+        // Exit
+        tradingRecord.exit(10);
+
+        // Enter at 119
+        tradingRecord.enter(3, numOf(119), tradedAmount);
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertTrue(rule.isSatisfied(1, tradingRecord));
+        assertTrue(rule.isSatisfied(10, tradingRecord));
     }
 }
         

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/StopLossRuleTest.java
@@ -26,6 +26,7 @@ package org.ta4j.core.trading.rules;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Order;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -39,7 +40,6 @@ import static org.junit.Assert.assertTrue;
 
 public class StopLossRuleTest extends AbstractIndicatorTest {
 
-    private TradingRecord tradingRecord;
     private ClosePriceIndicator closePrice;
 
     public StopLossRuleTest(Function<Number, Num> numFunction) {
@@ -48,22 +48,22 @@ public class StopLossRuleTest extends AbstractIndicatorTest {
 
     @Before
     public void setUp() {
-        tradingRecord = new BaseTradingRecord();
         closePrice = new ClosePriceIndicator(new MockTimeSeries(numFunction,
                 100, 105, 110, 120, 100, 150, 110, 100
         ));
     }
-    
+
     @Test
-    public void isSatisfied() {
+    public void isSatisfied_worksForBuy() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Order.OrderType.BUY);
         final Num tradedAmount = numOf(1);
-        
+
         // 5% stop-loss
         StopLossRule rule = new StopLossRule(closePrice, numOf(5));
-        
+
         assertFalse(rule.isSatisfied(0, null));
         assertFalse(rule.isSatisfied(1, tradingRecord));
-        
+
         // Enter at 114
         tradingRecord.enter(2, numOf(114), tradedAmount);
         assertFalse(rule.isSatisfied(2, tradingRecord));
@@ -71,12 +71,39 @@ public class StopLossRuleTest extends AbstractIndicatorTest {
         assertTrue(rule.isSatisfied(4, tradingRecord));
         // Exit
         tradingRecord.exit(5);
-        
+
         // Enter at 128
         tradingRecord.enter(5, numOf(128), tradedAmount);
         assertFalse(rule.isSatisfied(5, tradingRecord));
         assertTrue(rule.isSatisfied(6, tradingRecord));
         assertTrue(rule.isSatisfied(7, tradingRecord));
+    }
+
+    @Test
+    public void isSatisfied_worksForSell() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Order.OrderType.SELL);
+        final Num tradedAmount = numOf(1);
+
+        // 5% stop-loss
+        StopLossRule rule = new StopLossRule(closePrice, numOf(5));
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+
+        // Enter at 108
+        tradingRecord.enter(1, numOf(108), tradedAmount);
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertTrue(rule.isSatisfied(3, tradingRecord));
+        // Exit
+        tradingRecord.exit(4);
+
+        // Enter at 114
+        tradingRecord.enter(2, numOf(114), tradedAmount);
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertTrue(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(4, tradingRecord));
+        assertTrue(rule.isSatisfied(5, tradingRecord));
     }
 }
         


### PR DESCRIPTION
From my point of view the StopLossRule and StopGainRule did not function correctly for Sale orders.
Both rules when calculating the threshold ratio where using the percentage with a minus operation which resulted in thresholds ratio like 0.97 for 3%. To make it work correctly for sale orders the value of the threshold ratio should be 1.03 for 3%.

Changes proposed in this pull request:
- fixes for both rules
- tests to support the assumption and the fix

- [x] added an entry to the unreleased section of `CHANGES.md` 
