### PR TITLE
[378] fixed ProfitLossCriterion for short trades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Fixed `java.lang.NullPointerException` in**: `AverageProfitableTradesCriterion.calculate(TimeSeries, Trade)` for opened trade.
 - **StopGainRule**: now correctly handles stops for sell orders
 - **StopLossRule**: now correctly handles stops for sell orders
+- **ProfitLossCriterion*: fixed to work properly for short trades
 
 ### Changed
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossCriterion.java
@@ -52,15 +52,7 @@ public class ProfitLossCriterion extends AbstractAnalysisCriterion {
      */
     @Override
     public Num calculate(TimeSeries series, Trade trade) {
-        if (trade.isClosed()) {
-            Num exitClosePrice = trade.getExit().getNetPrice().isNaN() ?
-                    series.getBar(trade.getExit().getIndex()).getClosePrice() : trade.getExit().getNetPrice();
-            Num entryClosePrice = trade.getEntry().getNetPrice().isNaN() ?
-                    series.getBar(trade.getEntry().getIndex()).getClosePrice() : trade.getEntry().getNetPrice();
-
-            return exitClosePrice.minus(entryClosePrice).multipliedBy(trade.getExit().getAmount());
-        }
-        return series.numOf(0);
+        return trade.getProfit();
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossCriterionTest.java
@@ -39,6 +39,28 @@ public class ProfitLossCriterionTest  extends AbstractCriterionTest {
         assertNumEquals(-250 - 1500, profit.calculate(series, tradingRecord));
     }
 
+    @Test
+    public void calculateShortOnlyWithGainTrades() {
+        MockTimeSeries series = new MockTimeSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.sellAt(0,series, series.numOf(50)), Order.buyAt(2,series, series.numOf(50)),
+                Order.sellAt(3,series, series.numOf(50)), Order.buyAt(5,series, series.numOf(50)));
+
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(-(500 + 250), profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateShortOnlyWithLossTrades() {
+        MockTimeSeries series = new MockTimeSeries(numFunction, 100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(
+                Order.sellAt(0,series, series.numOf(50)), Order.buyAt(1,series, series.numOf(50)),
+                Order.sellAt(2,series, series.numOf(50)), Order.buyAt(5,series, series.numOf(50)));
+
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(250 + 1500, profit.calculate(series, tradingRecord));
+    }
+
 
     @Test
     public void betterThan() {


### PR DESCRIPTION
Fixes #378.

Changes proposed in this pull request:
-  fixed ProfitLossCriterion for short trades

- [x] added an entry to the unreleased section of `CHANGES.md` 
