### PR TITLE
Clean PrecisionNum

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
@@ -136,7 +136,7 @@ public final class PrecisionNum implements Num {
      * @return the {@code Num}
      */
     public static PrecisionNum valueOf(String val) {
-        if (val.toUpperCase().equals("NAN")) {
+        if (val.equalsIgnoreCase("NAN")) {
             throw new NumberFormatException();
         }
         return new PrecisionNum(val);
@@ -150,7 +150,7 @@ public final class PrecisionNum implements Num {
      * @return the {@code Num}
      */
     public static PrecisionNum valueOf(String val, int precision) {
-        if (val.toUpperCase().equals("NAN")) {
+        if (val.equalsIgnoreCase("NAN")) {
             throw new NumberFormatException();
         }
         return new PrecisionNum(val, precision);

--- a/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
@@ -441,8 +441,7 @@ public final class PrecisionNum implements Num {
             try {
                 estimate = (BigDecimal) format.parse(estimateString);
             } catch (ParseException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                log.error("PrecicionNum ParseException:", e);
             }
         }
         BigDecimal delta;
@@ -744,7 +743,7 @@ public final class PrecisionNum implements Num {
         // use double pow(double, double)
         double xpowb = Math.pow(delegate.doubleValue(), bDouble);
         // use PrecisionNum.multiply(PrecisionNum)
-        BigDecimal result = xpowa.multiply(new BigDecimal(xpowb));
+        BigDecimal result = xpowa.multiply(BigDecimal.valueOf(xpowb));
         return new PrecisionNum(result.toString());
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- use log.error instead of printstacktrace..
- use "BigDecimal.valueOf(double)" instead of "new BigDecimal(double)"
- minor cleanings..
- [ ] added an entry to the unreleased section of `CHANGES.md` 
