### PR TITLE
BaseBar:  cleanup constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BaseTimeSeriesBuilder** moved from inner class to own class
 
 ### Added
+- :tada: **Enhancement** Added common constructors in BaseBar for BigDecimal, Double and String values
+- :tada: **Enhancement** Added constructor in BaseBar with trades property
 - :tada: **Enhancement** Added BaseBarBuilder and ConvertibleBaseBarBuilder - BaseBar builder classes
 - :tada: **Enhancement** Added BarAggregator and TimeSeriesAggregator to allow aggregates bars and time series 
 - :tada: **Enhancement** Added LWMA Linearly Weighted Moving Average Indicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Breaking
 - :boom: **Breaking** Refactored from Max/Min to High/Low in Bar class
+- :boom: **Breaking** Removed redundant constructors from BaseBar class
 
 ### Fixed
 - **Fixed `java.lang.ClassCastException` in**: `PrecisionNum.equals()`.

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -24,6 +24,8 @@
 package org.ta4j.core;
 
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.PrecisionNum;
 
 import java.math.BigDecimal;
 import java.time.Duration;

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 
 /**
  * Base implementation of a {@link Bar}.
- * </p>
  */
 public class BaseBar implements Bar {
 
@@ -65,6 +64,7 @@ public class BaseBar implements Bar {
      * Constructor.
      * @param timePeriod the time period
      * @param endTime the end time of the bar period
+     * @param numFunction the numbers precision
      */
     public BaseBar(Duration timePeriod, ZonedDateTime endTime, Function<Number, Num> numFunction) {
         checkTimeArguments(timePeriod, endTime);
@@ -77,6 +77,7 @@ public class BaseBar implements Bar {
 
     /**
      * Constructor.
+     * @param timePeriod the time period
      * @param endTime the end time of the bar period
      * @param openPrice the open price of the bar period
      * @param highPrice the highest price of the bar period
@@ -84,16 +85,45 @@ public class BaseBar implements Bar {
      * @param closePrice the close price of the bar period
      * @param volume the volume of the bar period
      */
-    public BaseBar(ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume, Function<Number, Num> numFunction) {
-        this(endTime, numFunction.apply(openPrice),
-                numFunction.apply(highPrice),
-                numFunction.apply(lowPrice),
-                numFunction.apply(closePrice),
-                numFunction.apply(volume), numFunction.apply(0));
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume) {
+    	this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, 0.0);
     }
-
+    
     /**
      * Constructor.
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume, double amount) {
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, DoubleNum::valueOf);
+    }
+    
+    /**
+     * Constructor.
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
+     * @param trades the trades count of the bar period
+     * @param numFunction the numbers precision
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice, double closePrice, double volume, double amount, int trades, Function<Number, Num> numFunction) {
+        this(timePeriod, endTime, numFunction.apply(openPrice), numFunction.apply(highPrice), numFunction.apply(lowPrice), numFunction.apply(closePrice), numFunction.apply(volume), numFunction.apply(amount), trades);
+    }
+    
+    /**
+     * Constructor.
+     * @param timePeriod the time period
      * @param endTime the end time of the bar period
      * @param openPrice the open price of the bar period
      * @param highPrice the highest price of the bar period
@@ -101,35 +131,45 @@ public class BaseBar implements Bar {
      * @param closePrice the close price of the bar period
      * @param volume the volume of the bar period
      */
-    public BaseBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume, Function<Number, Num> numFunction) {
-        this(endTime, numFunction.apply(new BigDecimal(openPrice)),
-                numFunction.apply(new BigDecimal(highPrice)),
-                numFunction.apply(new BigDecimal(lowPrice)),
-                numFunction.apply(new BigDecimal(closePrice)),
-                numFunction.apply(new BigDecimal(volume)), numFunction.apply(0));
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, BigDecimal openPrice, BigDecimal highPrice, BigDecimal lowPrice, BigDecimal closePrice, BigDecimal volume) {
+    	this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, BigDecimal.ZERO);
     }
-
+    
     /**
      * Constructor.
-     * @param endTime the end time of the bar
-     * @param openPrice the open price of the bar
-     * @param highPrice the highest price of the bar
-     * @param lowPrice the lowest price of the bar
-     * @param closePrice the close price of the bar
-     * @param volume the volume of the bar
-     * @param value the value of the bar
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
      */
-    public BaseBar(ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume, String value, Function<Number, Num> numFunction) {
-        this(endTime, numFunction.apply(new BigDecimal(openPrice)),
-                numFunction.apply(new BigDecimal(highPrice)),
-                numFunction.apply(new BigDecimal(lowPrice)),
-                numFunction.apply(new BigDecimal(closePrice)),
-                numFunction.apply(new BigDecimal(volume)),
-                numFunction.apply(new BigDecimal(value)));
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, BigDecimal openPrice, BigDecimal highPrice, BigDecimal lowPrice, BigDecimal closePrice, BigDecimal volume, BigDecimal amount) {
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, PrecisionNum::valueOf);
+    }
+    
+    /**
+     * Constructor.
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
+     * @param trades the trades count of the bar period
+     * @param numFunction the numbers precision
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, BigDecimal openPrice, BigDecimal highPrice, BigDecimal lowPrice, BigDecimal closePrice, BigDecimal volume, BigDecimal amount, int trades, Function<Number, Num> numFunction) {
+    	this(timePeriod, endTime, numFunction.apply(openPrice), numFunction.apply(highPrice), numFunction.apply(lowPrice), numFunction.apply(closePrice), numFunction.apply(volume), numFunction.apply(amount), trades);
     }
 
     /**
      * Constructor.
+     * @param timePeriod the time period
      * @param endTime the end time of the bar period
      * @param openPrice the open price of the bar period
      * @param highPrice the highest price of the bar period
@@ -137,11 +177,50 @@ public class BaseBar implements Bar {
      * @param closePrice the close price of the bar period
      * @param volume the volume of the bar period
      */
-    public BaseBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount) {
-        this(Duration.ofDays(1), endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount);
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume) {
+    	this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, "0");
+    }
+    
+    /**
+     * Constructor.
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume, String amount) {
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, "0", PrecisionNum::valueOf);
+    }
+    
+    /**
+     * Constructor.
+     * @param timePeriod the time period
+     * @param endTime the end time of the bar period
+     * @param openPrice the open price of the bar period
+     * @param highPrice the highest price of the bar period
+     * @param lowPrice the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume the volume of the bar period
+     * @param amount the amount of the bar period
+     * @param trades the trades count of the bar period
+     * @param numFunction the numbers precision
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, String openPrice, String highPrice, String lowPrice, String closePrice, String volume, String amount, String trades, Function<Number, Num> numFunction) {
+    	this(timePeriod, endTime,
+    	     numFunction.apply(new BigDecimal(openPrice)),
+    	     numFunction.apply(new BigDecimal(highPrice)),
+    	     numFunction.apply(new BigDecimal(lowPrice)),
+    	     numFunction.apply(new BigDecimal(closePrice)),
+    	     numFunction.apply(new BigDecimal(volume)),
+    	     numFunction.apply(new BigDecimal(amount)),
+    	     Integer.valueOf(trades));
     }
 
-
+    
     /**
      * Constructor.
      * @param timePeriod the time period
@@ -154,16 +233,7 @@ public class BaseBar implements Bar {
      * @param amount the amount of the bar period
      */
     public BaseBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount) {
-        checkTimeArguments(timePeriod, endTime);
-        this.timePeriod = timePeriod;
-        this.endTime = endTime;
-        this.beginTime = endTime.minus(timePeriod);
-        this.openPrice = openPrice;
-        this.highPrice = highPrice;
-        this.lowPrice = lowPrice;
-        this.closePrice = closePrice;
-        this.volume = volume;
-        this.amount = amount;
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0);
     }
 
     /**
@@ -251,7 +321,7 @@ public class BaseBar implements Bar {
     }
 
     /**
-     * @return the whole traded amount of the period
+     * @return the whole traded amount (tradePrice x tradeVolume) of the period
      */
     public Num getAmount() {
         return amount;
@@ -298,11 +368,11 @@ public class BaseBar implements Bar {
         }
         closePrice = price;
         if (highPrice == null || highPrice.isLessThan(price)) {
-		        highPrice = price;
-	      }
-	      if (lowPrice == null || lowPrice.isGreaterThan(price)) {
-		        lowPrice = price;
-	      }
+            highPrice = price;
+        }
+        if (lowPrice == null || lowPrice.isGreaterThan(price)) {
+            lowPrice = price;
+        }
     }
 
     @Override
@@ -325,25 +395,25 @@ public class BaseBar implements Bar {
         }
     }
 
-   @Override
-	public int hashCode() {
-		return Objects.hash(beginTime, endTime, timePeriod, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
-	}
+    @Override
+    public int hashCode() {
+            return Objects.hash(beginTime, endTime, timePeriod, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (!(obj instanceof BaseBar)) return false;
-		final BaseBar other = (BaseBar) obj;
-		return Objects.equals(beginTime, other.beginTime) 
-		    && Objects.equals(endTime, other.endTime)
-		    && Objects.equals(timePeriod, other.timePeriod)
-		    && Objects.equals(openPrice, other.openPrice) 
-		    && Objects.equals(highPrice, other.highPrice) 
-		    && Objects.equals(lowPrice, other.lowPrice)
-		    && Objects.equals(closePrice, other.closePrice) 
-		    && Objects.equals(volume, other.volume)
-		    && Objects.equals(amount, other.amount) 
-		    && trades == other.trades;
-	}
+    @Override
+    public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (!(obj instanceof BaseBar)) return false;
+            final BaseBar other = (BaseBar) obj;
+            return Objects.equals(beginTime, other.beginTime) 
+		&& Objects.equals(endTime, other.endTime)
+		&& Objects.equals(timePeriod, other.timePeriod)
+		&& Objects.equals(openPrice, other.openPrice) 
+		&& Objects.equals(highPrice, other.highPrice) 
+		&& Objects.equals(lowPrice, other.lowPrice)
+		&& Objects.equals(closePrice, other.closePrice) 
+		&& Objects.equals(volume, other.volume)
+		&& Objects.equals(amount, other.amount) 
+		&& trades == other.trades;
+    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTimeSeries.java
@@ -406,23 +406,21 @@ public class BaseTimeSeries implements TimeSeries {
 
     @Override
     public void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume) {
-        this.addBar(new BaseBar(endTime, openPrice, highPrice, lowPrice, closePrice, volume, numOf(0)));
+        this.addBar(new BaseBar(Duration.ofDays(1), endTime, openPrice, highPrice, lowPrice, closePrice, volume, numOf(0)));
     }
 
     @Override
     public void addBar(ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount) {
-        this.addBar(new BaseBar(endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount));
+        this.addBar(new BaseBar(Duration.ofDays(1), endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount));
     }
 
     @Override
-    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
-            Num closePrice, Num volume) {
+    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume) {
         this.addBar(new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, numOf(0)));
     }
 
     @Override
-    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
-            Num closePrice, Num volume, Num amount) {
+    public void addBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice, Num volume, Num amount) {
         this.addBar(new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount));
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -24,6 +24,7 @@
 package org.ta4j.core;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.function.Function;
@@ -76,7 +77,7 @@ public class TestUtilsTest extends AbstractIndicatorTest<TimeSeries, Num> {
         for (int i = 0; i < 1000; i++) {
             random = Math.random();
             time = time.plusDays(i);
-            series.addBar(new BaseBar(time, random, random, random, random, random, numFunction));
+            series.addBar(new BaseBar(Duration.ofDays(1), time, random, random, random, random, random, random, 0, numFunction));
         }
         return series;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TimeSeriesTest.java
@@ -37,6 +37,7 @@ import org.ta4j.core.num.Num;
 import org.ta4j.core.trading.rules.FixedRule;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -97,15 +98,15 @@ public class TimeSeriesTest extends AbstractIndicatorTest<TimeSeries,Num> {
     public void replaceBarTest() {
         TimeSeries series = new BaseTimeSeriesBuilder().withNumTypeOf(numFunction).build();
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()), 1d,numFunction), true);
-        assertEquals(series.getBarCount(),1);
+        assertEquals(1, series.getBarCount());
         TestUtils.assertNumEquals(series.getLastBar().getClosePrice(), series.numOf(1));
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(1), 2d,numFunction), false);
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(2), 3d,numFunction), false);
-        assertEquals(series.getBarCount(), 3);
+        assertEquals(3, series.getBarCount());
         TestUtils.assertNumEquals(series.getLastBar().getClosePrice(), series.numOf(3));
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(3), 4d,numFunction), true);
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(4), 5d,numFunction), true);
-        assertEquals(series.getBarCount(), 3);
+        assertEquals(3, series.getBarCount());
         TestUtils.assertNumEquals(series.getLastBar().getClosePrice(), series.numOf(5));
     }
 
@@ -315,12 +316,12 @@ public class TimeSeriesTest extends AbstractIndicatorTest<TimeSeries,Num> {
     @Test(expected = IllegalArgumentException.class)
     public void wrongBarTypeDouble(){
         TimeSeries series = new BaseTimeSeriesBuilder().withNumTypeOf(DoubleNum.class).build();
-        series.addBar(new BaseBar(ZonedDateTime.now(), 1, 1, 1, 1, 1, PrecisionNum::valueOf));
+        series.addBar(new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), 1, 1, 1, 1, 1, 1, 1, PrecisionNum::valueOf));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void wrongBarTypeBigDecimal(){
         TimeSeries series = new BaseTimeSeriesBuilder().withNumTypeOf(PrecisionNum::valueOf).build();
-        series.addBar(new BaseBar(ZonedDateTime.now(),1,1,1,1,1, DoubleNum::valueOf));
+        series.addBar(new BaseBar(Duration.ofDays(1), ZonedDateTime.now(),1,1,1,1,1, 1, 1, DoubleNum::valueOf));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
@@ -26,6 +26,7 @@ package org.ta4j.core.mocks;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.num.Num;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.function.Function;
 
@@ -42,27 +43,27 @@ public class MockBar extends BaseBar {
     }
 
     public MockBar(double closePrice, double volume, Function<Number, Num> numFunction) {
-        super(ZonedDateTime.now(), 0, 0, 0, closePrice, volume, numFunction);
+        super(Duration.ofDays(1), ZonedDateTime.now(), 0, 0, 0, closePrice, volume, 0, 0, numFunction);
     }
 
     public MockBar(ZonedDateTime endTime, double closePrice, Function<Number, Num> numFunction) {
-        super(endTime, 0, 0, 0, closePrice, 0, numFunction);
+        super(Duration.ofDays(1), endTime, 0, 0, 0, closePrice, 0, 0, 0, numFunction);
     }
 
     public MockBar(ZonedDateTime endTime, double closePrice, double volume, Function<Number, Num> numFunction) {
-        super(endTime, 0, 0, 0, closePrice, volume, numFunction);
+        super(Duration.ofDays(1), endTime, 0, 0, 0, closePrice, volume, 0, 0, numFunction);
     }
 
     public MockBar(double openPrice, double closePrice, double maxPrice, double minPrice, Function<Number, Num> numFunction) {
-        super(ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, 1,numFunction);
+        super(Duration.ofDays(1), ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, 1, 0, 0, numFunction);
     }
 
     public MockBar(double openPrice, double closePrice, double maxPrice, double minPrice, double volume, Function<Number, Num> numFunction) {
-        super(ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, volume,numFunction);
+        super(Duration.ofDays(1), ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, volume, 0, 0, numFunction);
     }
 
     public MockBar(ZonedDateTime endTime, double openPrice, double closePrice, double maxPrice, double minPrice, double amount, double volume, int trades, Function<Number, Num> numFunction) {
-        super(endTime, openPrice, maxPrice, minPrice, closePrice, volume,numFunction);
+        super(Duration.ofDays(1), endTime, openPrice, maxPrice, minPrice, closePrice, volume, 0, 0, numFunction);
         this.trades = trades;
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/num/PrecisionNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/PrecisionNumTest.java
@@ -130,20 +130,20 @@ public class PrecisionNumTest {
         double[] deltas = { 20.8, 30.1, -15.3, 10.2, -16.7, -9.8 };
         Num superPrecisionNum = FIRST_SUPER_PRECISION_NUM;
         for (int i = 0; i < NUMBARS; i++) {
-            bar = new BaseBar(endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
-                    .toString(), "0", superPrecisionFunc);
+            bar = new BaseBar(Duration.ofDays(1), endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
+                    .toString(), "0", "0", "0", superPrecisionFunc);
             superPrecisionBarList.add(bar);
-            bar = new BaseBar(endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
-                    .toString(), "0", precisionFunc);
+            bar = new BaseBar(Duration.ofDays(1), endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
+                    .toString(), "0", "0", "0", precisionFunc);
             precisionBarList.add(bar);
-            bar = new BaseBar(endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
-                    .toString(), "0", precision32Func);
+            bar = new BaseBar(Duration.ofDays(1), endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
+                    .toString(), "0", "0", "0", precision32Func);
             precision32BarList.add(bar);
-            bar = new BaseBar(endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
-                    .toString(), "0", doubleFunc);
+            bar = new BaseBar(Duration.ofDays(1), endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
+                    .toString(), "0", "0", "0", doubleFunc);
             doubleBarList.add(bar);
-            bar = new BaseBar(endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
-                    .toString(), "0", lowPrecisionFunc);
+            bar = new BaseBar(Duration.ofDays(1), endTime, superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum.toString(), superPrecisionNum
+                    .toString(),"0", "0", "0", lowPrecisionFunc);
             lowPrecisionBarList.add(bar);
             endTime = endTime.plus(timePeriod);
             superPrecisionNum = superPrecisionNum.plus(PrecisionNum.valueOf(deltas[i % 6]));

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingTimeSeries.java
@@ -32,6 +32,7 @@ import org.ta4j.core.trading.rules.OverIndicatorRule;
 import org.ta4j.core.trading.rules.UnderIndicatorRule;
 import ta4jexamples.loaders.CsvTradesLoader;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 
 /**
@@ -107,7 +108,7 @@ public class TradingBotOnMovingTimeSeries {
         Num maxPrice = openPrice.plus(maxRange.multipliedBy(PrecisionNum.valueOf(Math.random())));
         Num closePrice = randDecimal(minPrice, maxPrice);
         LAST_BAR_CLOSE_PRICE = closePrice;
-        return new BaseBar(ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, PrecisionNum.valueOf(1), PrecisionNum.valueOf(1));
+        return new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), openPrice, maxPrice, minPrice, closePrice, PrecisionNum.valueOf(1), PrecisionNum.valueOf(1));
     }
 
     public static void main(String[] args) throws InterruptedException {

--- a/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
@@ -124,33 +124,33 @@ public class BuildTimeSeries {
 
         // create bars and add them to the series. The bars must have the same Num type as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        		Bar b1 = BaseBar.builder(DoubleNum::valueOf, Double.class)
-				.timePeriod(Duration.ofDays(1))
-				.endTime(endTime)
-				.openPrice(105.42)
-				.highPrice(112.99)
-				.lowPrice(104.01)
-				.closePrice(111.42)
-				.volume(1337.0)
-				.build();
-		Bar b2 = BaseBar.builder(DoubleNum::valueOf, Double.class)
-				.timePeriod(Duration.ofDays(1))
-				.endTime(endTime.plusDays(1))
-				.openPrice(111.43)
-				.highPrice(112.83)
-				.lowPrice(107.77)
-				.closePrice(107.99)
-				.volume(1234.0)
-				.build();
-		Bar b3 = BaseBar.builder(DoubleNum::valueOf, Double.class)
-				.timePeriod(Duration.ofDays(1))
-				.endTime(endTime.plusDays(2))
-				.openPrice(107.90)
-				.highPrice(117.50)
-				.lowPrice(107.90)
-				.closePrice(115.42)
-				.volume(4242.0)
-				.build();
+        Bar b1 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime)
+                .openPrice(105.42)
+		.highPrice(112.99)
+		.lowPrice(104.01)
+		.closePrice(111.42)
+                .volume(1337.0)
+                .build();
+        Bar b2 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(1))
+                .openPrice(111.43)
+		.highPrice(112.83)
+		.lowPrice(107.77)
+		.closePrice(107.99)
+                .volume(1234.0)
+                .build();
+        Bar b3 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(2))
+                .openPrice(107.90)
+		.highPrice(117.50)
+		.lowPrice(107.90)
+		.closePrice(115.42)
+                .volume(4242.0)
+                .build();
         //...
 
         series.addBar(b1);

--- a/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
@@ -124,9 +124,9 @@ public class BuildTimeSeries {
 
         // create bars and add them to the series. The bars must have the same Num type as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar b1 = new BaseBar(endTime, 105.42, 112.99, 104.01, 111.42, 1337, DoubleNum::valueOf);
-        Bar b2 = new BaseBar(endTime.plusDays(1), 111.43, 112.83, 107.77, 107.99, 1234, DoubleNum::valueOf);
-        Bar b3 = new BaseBar(endTime.plusDays(2), 107.90, 117.50, 107.90, 115.42, 4242, DoubleNum::valueOf);
+        Bar b1 = new BaseBar(Duration.ofDays(1), endTime, 105.42, 112.99, 104.01, 111.42, 1337, 0, 0, DoubleNum::valueOf);
+        Bar b2 = new BaseBar(Duration.ofDays(1), endTime.plusDays(1), 111.43, 112.83, 107.77, 107.99, 1234, 0, 0, DoubleNum::valueOf);
+        Bar b3 = new BaseBar(Duration.ofDays(1), endTime.plusDays(2), 107.90, 117.50, 107.90, 115.42, 4242, 0, 0, DoubleNum::valueOf);
         //...
 
         series.addBar(b1);

--- a/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/timeSeries/BuildTimeSeries.java
@@ -124,9 +124,33 @@ public class BuildTimeSeries {
 
         // create bars and add them to the series. The bars must have the same Num type as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar b1 = new BaseBar(Duration.ofDays(1), endTime, 105.42, 112.99, 104.01, 111.42, 1337, 0, 0, DoubleNum::valueOf);
-        Bar b2 = new BaseBar(Duration.ofDays(1), endTime.plusDays(1), 111.43, 112.83, 107.77, 107.99, 1234, 0, 0, DoubleNum::valueOf);
-        Bar b3 = new BaseBar(Duration.ofDays(1), endTime.plusDays(2), 107.90, 117.50, 107.90, 115.42, 4242, 0, 0, DoubleNum::valueOf);
+        		Bar b1 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+				.timePeriod(Duration.ofDays(1))
+				.endTime(endTime)
+				.openPrice(105.42)
+				.highPrice(112.99)
+				.lowPrice(104.01)
+				.closePrice(111.42)
+				.volume(1337.0)
+				.build();
+		Bar b2 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+				.timePeriod(Duration.ofDays(1))
+				.endTime(endTime.plusDays(1))
+				.openPrice(111.43)
+				.highPrice(112.83)
+				.lowPrice(107.77)
+				.closePrice(107.99)
+				.volume(1234.0)
+				.build();
+		Bar b3 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+				.timePeriod(Duration.ofDays(1))
+				.endTime(endTime.plusDays(2))
+				.openPrice(107.90)
+				.highPrice(117.50)
+				.lowPrice(107.90)
+				.closePrice(115.42)
+				.volume(4242.0)
+				.build();
         //...
 
         series.addBar(b1);


### PR DESCRIPTION
Changes proposed in this pull request:
- removed all redundant constructors from BaseBar()
- adapt the used BaseBar constructors in some "src/test" and "ta4jexamples"
- added default constructors for double, BigDecimal, String
- added property "trades" in constructor

- [x] added an entry to the unreleased section of `CHANGES.md` 
