### PR TITLE
Add Strategy object to the list of parameters of a TradeStatement constructor

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BacktestExecutor.java
@@ -61,7 +61,7 @@ public class BacktestExecutor {
         final List<TradingStatement> tradingStatements = new ArrayList<>(strategies.size());
         for (Strategy strategy : strategies) {
             final TradingRecord tradingRecord = seriesManager.run(strategy, orderType, amount);
-            final TradingStatement tradingStatement = tradingStatementGenerator.generate(tradingRecord, seriesManager.getTimeSeries());
+            final TradingStatement tradingStatement = tradingStatementGenerator.generate(strategy, tradingRecord, seriesManager.getTimeSeries());
             tradingStatements.add(tradingStatement);
         }
         return tradingStatements;

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/PerformanceReportGenerator.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.tradereport;
 
+import org.ta4j.core.Strategy;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.criteria.ProfitLossCriterion;
@@ -39,7 +40,7 @@ import org.ta4j.core.num.Num;
 public class PerformanceReportGenerator implements ReportGenerator<PerformanceReport> {
 
     @Override
-    public PerformanceReport generate(TradingRecord tradingRecord, TimeSeries series) {
+    public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, TimeSeries series) {
         final Num totalProfitLoss = new ProfitLossCriterion().calculate(series, tradingRecord);
         final Num totalProfitLossPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
         final Num totalProfit = new TotalProfit2Criterion().calculate(series, tradingRecord);

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/ReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/ReportGenerator.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.tradereport;
 
+import org.ta4j.core.Strategy;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.TradingRecord;
 
@@ -40,5 +41,5 @@ public interface ReportGenerator<T> {
      * @param series        a time series, not null
      * @return generated report
      */
-    T generate(TradingRecord tradingRecord, TimeSeries series);
+    T generate(Strategy strategy, TradingRecord tradingRecord, TimeSeries series);
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradeStatsReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradeStatsReportGenerator.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.tradereport;
 
+import org.ta4j.core.Strategy;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.criteria.NumberOfBreakEvenTradesCriterion;
@@ -38,7 +39,7 @@ import org.ta4j.core.num.Num;
 public class TradeStatsReportGenerator implements ReportGenerator<TradeStatsReport> {
 
     @Override
-    public TradeStatsReport generate(TradingRecord tradingRecord, TimeSeries series) {
+    public TradeStatsReport generate(Strategy strategy, TradingRecord tradingRecord, TimeSeries series) {
         final Num profitTradeCount = new NumberOfWinningTradesCriterion().calculate(series, tradingRecord);
         final Num lossTradeCount = new NumberOfLosingTradesCriterion().calculate(series, tradingRecord);
         final Num breakEvenTradeCount = new NumberOfBreakEvenTradesCriterion().calculate(series, tradingRecord);

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradingStatement.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradingStatement.java
@@ -23,17 +23,25 @@
  */
 package org.ta4j.core.tradereport;
 
+import org.ta4j.core.Strategy;
+
 /**
  * This class represents trading statement report which contains trade and performance statistics
  */
 public class TradingStatement {
 
+    private final Strategy strategy;
     private final TradeStatsReport tradeStatsReport;
     private final PerformanceReport performanceReport;
 
-    public TradingStatement(TradeStatsReport tradeStatsReport, PerformanceReport performanceReport) {
+    public TradingStatement(Strategy strategy, TradeStatsReport tradeStatsReport, PerformanceReport performanceReport) {
+        this.strategy = strategy;
         this.tradeStatsReport = tradeStatsReport;
         this.performanceReport = performanceReport;
+    }
+
+    public Strategy getStrategy() {
+        return strategy;
     }
 
     public TradeStatsReport getTradeStatsReport() {

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradingStatementGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/TradingStatementGenerator.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.tradereport;
 
+import org.ta4j.core.Strategy;
 import org.ta4j.core.TimeSeries;
 import org.ta4j.core.TradingRecord;
 
@@ -37,9 +38,9 @@ public class TradingStatementGenerator implements ReportGenerator<TradingStateme
     private final TradeStatsReportGenerator tradeStatsReportGenerator = new TradeStatsReportGenerator();
 
     @Override
-    public TradingStatement generate(TradingRecord tradingRecord, TimeSeries series) {
-        final PerformanceReport performanceReport = performanceReportGenerator.generate(tradingRecord, series);
-        final TradeStatsReport tradeStatsReport = tradeStatsReportGenerator.generate(tradingRecord, series);
-        return new TradingStatement(tradeStatsReport, performanceReport);
+    public TradingStatement generate(Strategy strategy, TradingRecord tradingRecord, TimeSeries series) {
+        final PerformanceReport performanceReport = performanceReportGenerator.generate(strategy, tradingRecord, series);
+        final TradeStatsReport tradeStatsReport = tradeStatsReportGenerator.generate(strategy, tradingRecord, series);
+        return new TradingStatement(strategy, tradeStatsReport, performanceReport);
     }
 }


### PR DESCRIPTION
When you are running several backtest it is hard to map the results to a given Strategy without passing along the strategy object to TradingStatement

- [ ] Add Strategy object to the list of parameters of a TradeStatement constructor
