### PR TITLE
DoubleNum.class: changed isEqual()-method

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -164,16 +164,16 @@ public class DoubleNum implements Num {
         return delegate <= 0;
     }
 
-    @Override
-    public boolean isEqual(Num other) {
-        return !other.isNaN() && delegate == ((DoubleNum) other).delegate;
-    }
-
     public Num log() {
         if (delegate <= 0) {
             return NaN;
         }
         return new DoubleNum(Math.log(delegate));
+    }
+    
+    @Override
+    public boolean isEqual(Num other) {
+        return !other.isNaN() && compareTo(other) == 0;
     }
 
     /**


### PR DESCRIPTION
Changes proposed in this pull request:
- changed isEqual()-method of DoubleNum.class

- [ ] added an entry to the unreleased section of `CHANGES.md` 


There were the "==" in isEqual()-method. Was this made intentionally? I changed it to use `Double.compare() == 0`. Maybe we should be careful: `-0.0 != +0.0` and `NaN != NaN`, I dont know if this matters with `Double.compare()` ?
