### PR TITLE
[324] Fixed getEndIndex method for base bar if maxBarCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **PivotPointIndicator**: fixed possible npe if first bar is not in same period
 - **`IchimokuChikouSpanIndicator`**: fixed calculations - applied correct formula.
 - **CloseLocationValueIndicator**: fixed special case, return zero instead of NaN if high price == low price
+- **BaseBarSeries**: fixed `getEndIndex()` method if series has a `maxBarCount`
 
 ### Changed
 - **PrecisionNum**: improve performance for methods isZero/isPositive/isPositiveOrZero/isNegative/isNegativeOrZero.

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -352,7 +352,7 @@ public class BaseBarSeries implements BarSeries {
 
     @Override
     public int getEndIndex() {
-        return seriesEndIndex;
+        return seriesEndIndex - removedBarsCount;
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core;
 
+import org.hamcrest.core.IsEqual;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
@@ -44,6 +45,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
@@ -234,7 +236,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         // After
         assertEquals(0, defaultSeries.getBeginIndex());
-        assertEquals(5, defaultSeries.getEndIndex());
+        assertEquals(2, defaultSeries.getEndIndex());
         assertEquals(3, defaultSeries.getBarCount());
     }
 
@@ -325,5 +327,22 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
     public void wrongBarTypeBigDecimal() {
         BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(PrecisionNum::valueOf).build();
         series.addBar(new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), 1, 1, 1, 1, 1, 1, 1, DoubleNum::valueOf));
+    }
+
+    @Test
+    public void SubSeriesOfMaxBarCountSeriesTest() {
+        final BarSeries series = new BaseBarSeriesBuilder()
+                .withNumTypeOf(numFunction)
+                .withName("Series with maxBar count")
+                .withMaxBarCount(20)
+                .build();
+        final int timespan = 5;
+
+        IntStream.range(0, 100).forEach(i -> {
+            series.addBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(i),5,7,1,5,5);
+            int start = series.getEndIndex() - (timespan + 1);
+            int end = series.getEndIndex();
+            assertEquals(series.getSubSeries(start, end).getBarCount(), end - Math.max(series.getBeginIndex(), start));
+        });
     }
 }


### PR DESCRIPTION
Fixes #324.

Changes proposed in this pull request:
- if a `BaseBarSeries` has a maxBarCount the `BaseBarSeries #getEndIndex()` should return a valid end index
- added unit test for subseries creation based on `BaseBarSeries` with maxBarCount

- [x] added an entry to the unreleased section of `CHANGES.md` 
