### PR TITLE
Configured properly formatter validation in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: java
 
 services:
   - xvfb
-  
+
 jdk:
   - openjdk8
 
 script:
-  -  mvn -B test license:check formatter:format formatter:validate
+  - mvn -B test license:check formatter:validate


### PR DESCRIPTION
Fixes #.

PR https://github.com/ta4j/ta4j/pull/456 turned of formatter validation, so this PR is fixing it.

Changes proposed in this pull request:
- Restored travis config for formatter validation/checking


- [ ] added an entry to the unreleased section of `CHANGES.md` 
