### PR TITLE
Improve toString() method for PreviousValueIndicator, validation of n-th previous bars in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** Added TimeRangeRule for trading within time ranges.
 - :tada: **Enhancement** Added floor() and ceil() to Num.class
 - :tada: **Enhancement** Added getters getLow() and getUp() in CrossedDownIndicatorRule
+- :tada: **Enhancement** Improvements for PreviousValueIndicator: more descriptive toString() method, validation of n-th previous bars in
+ constructor of PreviousValueIndicator 
 
 ## 0.13 (released November 5, 2019)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
@@ -37,7 +37,7 @@ public class PreviousValueIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the indicator of which the previous value should be
      *                  calculated
      */
@@ -47,13 +47,16 @@ public class PreviousValueIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the indicator of which the previous value should be
      *                  calculated
      * @param n         parameter defines the previous n-th value
      */
     public PreviousValueIndicator(Indicator<Num> indicator, int n) {
         super(indicator);
+        if (n < 1) {
+            throw new IllegalArgumentException("n must be positive number, but was: " + n);
+        }
         this.n = n;
         this.indicator = indicator;
     }
@@ -61,5 +64,11 @@ public class PreviousValueIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         int previousValue = Math.max(0, (index - n));
         return this.indicator.getValue(previousValue);
+    }
+
+    @Override
+    public String toString() {
+        final String nInfo = n == 1 ? "" : "(" + n + ")";
+        return getClass().getSimpleName() + nInfo + "[" + this.indicator + "]";
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
@@ -25,14 +25,15 @@ package org.ta4j.core.indicators.helpers;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.EMAIndicator;
 
 import java.time.ZonedDateTime;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PreviousValueIndicatorTest {
 
@@ -95,7 +96,7 @@ public class PreviousValueIndicatorTest {
 
     @Test
     public void shouldBeNthPreviousValueFromIndicator() {
-        for (int i = 0; i < this.series.getBarCount(); i++) {
+        for (int i = 1; i < this.series.getBarCount(); i++) {
             testWithN(i);
         }
     }
@@ -119,5 +120,30 @@ public class PreviousValueIndicatorTest {
         for (int i = n; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), emaIndicator.getValue(i - n));
         }
+    }
+
+    @Test
+    public void testToStringMethodWithN1() {
+        prevValueIndicator = new PreviousValueIndicator(openPriceIndicator);
+
+        final String prevValueIndicatorAsString = prevValueIndicator.toString();
+
+        assertTrue(prevValueIndicatorAsString.startsWith("PreviousValueIndicator["));
+        assertTrue(prevValueIndicatorAsString.endsWith("]"));
+    }
+
+    @Test
+    public void testToStringMethodWithNGreaterThen1() {
+        prevValueIndicator = new PreviousValueIndicator(openPriceIndicator, 2);
+
+        final String prevValueIndicatorAsString = prevValueIndicator.toString();
+
+        assertTrue(prevValueIndicatorAsString.startsWith("PreviousValueIndicator(2)["));
+        assertTrue(prevValueIndicatorAsString.endsWith("]"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPreviousValueIndicatorWithNonPositiveN() {
+        prevValueIndicator = new PreviousValueIndicator(openPriceIndicator, 0);
     }
 }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- More descriptive toString() method for PreviousValueIndicator
- Validation of n-th previous bars in constructor of PreviousValueIndicator

- [X] added an entry to the unreleased section of `CHANGES.md` 
