### PR TITLE
Refactored profit and return calculations for all analysis criterions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Contributors
     nimo23
     edlins
     milczarekIT (Bartosz Milczarek)
+    kennethjor (Kenneth Jørgensen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 
 ### Changed
+- **Trade**: Changed the way Nums are created.
+- **AverageProfitableTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **BuyAndHoldCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **ExpectedShortfallCriterion**: Removed unnecessary primitive boxing.
+- **NumberOfBreakEvenTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **NumberOfLosingTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **NumberOfWinningTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **ProfitLossPercentageCriterion**: Changed to calculate trade profits using Trade's entry and exit prices.
+- **TotalLossCriterion**: Changed to calculate trade profits using Trade's getProfit().
+- **TotalProfitCriterion**: Changed to calculate trade profits using Trade's getProfit().
 
 ### Removed/Deprecated
 
@@ -20,6 +30,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** Added BarSeriesUtils: common helpers and shortcuts for BarSeries methods.
 - :tada: **Enhancement** Improvements for PreviousValueIndicator: more descriptive toString() method, validation of n-th previous bars in
  constructor of PreviousValueIndicator 
+- :tada: **Enhancement** added getGrossProfit() and getGrossProfit(BarSeries) on Trade.
+- :tada: **Enhancement** added getPricePerAsset(BarSeries) on Order.
 
 ## 0.13 (released November 5, 2019)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Order.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Order.java
@@ -214,6 +214,17 @@ public class Order implements Serializable {
     }
 
     /**
+     * @return the pricePerAsset for the order, or, if <code>NaN</code>, the close
+     *         price from the supplied {@link BarSeries}.
+     */
+    public Num getPricePerAsset(BarSeries barSeries) {
+        if (pricePerAsset.isNaN()) {
+            return barSeries.getBar(index).getClosePrice();
+        }
+        return pricePerAsset;
+    }
+
+    /**
      * @return the pricePerAsset for the order, net transaction costs
      */
     public Num getNetPrice() {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
@@ -30,10 +30,10 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Average profit criterion.
+ * Calculates the average return per bar criterion.
  *
- * The {@link TotalProfitCriterion total profit} over the
- * {@link NumberOfBarsCriterion number of bars}.
+ * The {@link TotalProfitCriterion total profit} raised to the power of 1
+ * divided by {@link NumberOfBarsCriterion number of bars}.
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterion.java
@@ -29,9 +29,9 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Average profitable trades criterion.
+ * Calculates the percentage of trades which are profitable.
  *
- * The number of profitable trades.
+ * Defined as <code># of winning trades / total # of trades</code>.
  */
 public class AverageProfitableTradesCriterion extends AbstractAnalysisCriterion {
 
@@ -42,22 +42,10 @@ public class AverageProfitableTradesCriterion extends AbstractAnalysisCriterion 
 
     private boolean isProfitableTrade(BarSeries series, Trade trade) {
         if (trade.isClosed()) {
-            final Num result = calculateResult(series, trade);
-            return result.isGreaterThan(series.numOf(1));
+            Num zero = series.numOf(0);
+            return trade.getProfit().isGreaterThan(zero);
         }
         return false;
-    }
-
-    private Num calculateResult(BarSeries series, Trade trade) {
-        int entryIndex = trade.getEntry().getIndex();
-        int exitIndex = trade.getExit().getIndex();
-        if (trade.getEntry().isBuy()) {
-            // buy-then-sell trade
-            return series.getBar(exitIndex).getClosePrice().dividedBy(series.getBar(entryIndex).getClosePrice());
-        } else {
-            // sell-then-buy trade
-            return series.getBar(entryIndex).getClosePrice().dividedBy(series.getBar(exitIndex).getClosePrice());
-        }
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldCriterion.java
@@ -24,12 +24,16 @@
 package org.ta4j.core.analysis.criteria;
 
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.Order;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
  * Buy and hold criterion.
+ *
+ * Calculates the return if a buy-and-hold strategy was used, buying on the
+ * first bar and selling on the last bar.
  *
  * @see <a href=
  *      "http://en.wikipedia.org/wiki/Buy_and_hold">http://en.wikipedia.org/wiki/Buy_and_hold</a>
@@ -38,24 +42,28 @@ public class BuyAndHoldCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return series.getBar(series.getEndIndex()).getClosePrice()
-                .dividedBy(series.getBar(series.getBeginIndex()).getClosePrice());
+        return createBuyAndHoldTrade(series).getGrossReturn(series);
     }
 
     @Override
     public Num calculate(BarSeries series, Trade trade) {
-        int entryIndex = trade.getEntry().getIndex();
-        int exitIndex = trade.getExit().getIndex();
-
-        if (trade.getEntry().isBuy()) {
-            return series.getBar(exitIndex).getClosePrice().dividedBy(series.getBar(entryIndex).getClosePrice());
-        } else {
-            return series.getBar(entryIndex).getClosePrice().dividedBy(series.getBar(exitIndex).getClosePrice());
-        }
+        return createBuyAndHoldTrade(series, trade.getEntry().getIndex(), trade.getExit().getIndex())
+                .getGrossReturn(series);
     }
 
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    private Trade createBuyAndHoldTrade(BarSeries series) {
+        return createBuyAndHoldTrade(series, series.getBeginIndex(), series.getEndIndex());
+    }
+
+    private Trade createBuyAndHoldTrade(BarSeries series, int beginIndex, int endIndex) {
+        Trade trade = new Trade(Order.OrderType.BUY);
+        trade.operate(beginIndex, series.getBar(beginIndex).getClosePrice(), series.numOf(1));
+        trade.operate(endIndex, series.getBar(endIndex).getClosePrice(), series.numOf(1));
+        return trade;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterion.java
@@ -35,23 +35,24 @@ import java.util.List;
 /**
  * Expected Shortfall criterion.
  *
+ * Measures the expected shortfall of the strategy log-return time-series.
+ *
  * @see <a href=
  *      "https://en.wikipedia.org/wiki/Expected_shortfall">https://en.wikipedia.org/wiki/Expected_shortfall</a>
  *
- *      Measures the expected shortfall of the strategy log-return time-series
  */
 public class ExpectedShortfallCriterion extends AbstractAnalysisCriterion {
     /**
      * Confidence level as absolute value (e.g. 0.95)
      */
-    private final Double confidence;
+    private final double confidence;
 
     /**
      * Constructor
      *
      * @param confidence the confidence level
      */
-    public ExpectedShortfallCriterion(Double confidence) {
+    public ExpectedShortfallCriterion(double confidence) {
         this.confidence = confidence;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
@@ -32,8 +32,8 @@ import org.ta4j.core.num.Num;
 /**
  * A linear transaction cost criterion.
  *
- * That criterion calculate the transaction cost according to an initial traded
- * amount and a linear function defined by a and b (a * x + b).
+ * Calculates the transaction cost according to an initial traded amount and a
+ * linear function defined by a and b (a * x + b).
  */
 public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 /**
  * Number of bars criterion.
  *
- * Returns the number of bars during the provided trade(s).
+ * Returns the total number of bars in all the trades.
  */
 public class NumberOfBarsCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenTradesCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenTradesCriterion.java
@@ -35,25 +35,21 @@ public class NumberOfBreakEvenTradesCriterion extends AbstractAnalysisCriterion 
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfLosingTrades = tradingRecord.getTrades().stream().filter(Trade::isClosed)
-                .filter(trade -> isBreakEvenTrade(series, trade)).count();
-        return series.numOf(numberOfLosingTrades);
+        long numberOfBreakEvenTrades = tradingRecord.getTrades().stream().filter(Trade::isClosed)
+                .filter(this::isBreakEvenTrade).count();
+        return series.numOf(numberOfBreakEvenTrades);
     }
 
-    private boolean isBreakEvenTrade(BarSeries series, Trade trade) {
+    private boolean isBreakEvenTrade(Trade trade) {
         if (trade.isClosed()) {
-            Num exitPrice = series.getBar(trade.getExit().getIndex()).getClosePrice();
-            Num entryPrice = series.getBar(trade.getEntry().getIndex()).getClosePrice();
-
-            Num profit = exitPrice.minus(entryPrice).multipliedBy(trade.getExit().getAmount());
-            return profit.isZero();
+            return trade.getProfit().isZero();
         }
         return false;
     }
 
     @Override
     public Num calculate(BarSeries series, Trade trade) {
-        return isBreakEvenTrade(series, trade) ? series.numOf(1) : series.numOf(0);
+        return isBreakEvenTrade(trade) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingTradesCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingTradesCriterion.java
@@ -36,24 +36,20 @@ public class NumberOfLosingTradesCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfLosingTrades = tradingRecord.getTrades().stream().filter(Trade::isClosed)
-                .filter(trade -> isLosingTrade(series, trade)).count();
+                .filter(this::isLosingTrade).count();
         return series.numOf(numberOfLosingTrades);
     }
 
-    private boolean isLosingTrade(BarSeries series, Trade trade) {
+    private boolean isLosingTrade(Trade trade) {
         if (trade.isClosed()) {
-            Num exitPrice = series.getBar(trade.getExit().getIndex()).getClosePrice();
-            Num entryPrice = series.getBar(trade.getEntry().getIndex()).getClosePrice();
-
-            Num profit = exitPrice.minus(entryPrice).multipliedBy(trade.getExit().getAmount());
-            return profit.isNegative();
+            return trade.getProfit().isNegative();
         }
         return false;
     }
 
     @Override
     public Num calculate(BarSeries series, Trade trade) {
-        return isLosingTrade(series, trade) ? series.numOf(1) : series.numOf(0);
+        return isLosingTrade(trade) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningTradesCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningTradesCriterion.java
@@ -36,24 +36,20 @@ public class NumberOfWinningTradesCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfLosingTrades = tradingRecord.getTrades().stream().filter(Trade::isClosed)
-                .filter(trade -> isWinningTrade(series, trade)).count();
+                .filter(this::isWinningTrade).count();
         return series.numOf(numberOfLosingTrades);
     }
 
-    private boolean isWinningTrade(BarSeries series, Trade trade) {
+    private boolean isWinningTrade(Trade trade) {
         if (trade.isClosed()) {
-            Num exitPrice = series.getBar(trade.getExit().getIndex()).getClosePrice();
-            Num entryPrice = series.getBar(trade.getEntry().getIndex()).getClosePrice();
-
-            Num profit = exitPrice.minus(entryPrice).multipliedBy(trade.getExit().getAmount());
-            return profit.isPositive();
+            return trade.getProfit().isPositive();
         }
         return false;
     }
 
     @Override
     public Num calculate(BarSeries series, Trade trade) {
-        return isWinningTrade(series, trade) ? series.numOf(1) : series.numOf(0);
+        return isWinningTrade(trade) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ProfitLossPercentageCriterion.java
@@ -29,7 +29,8 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Profit and loss in percentage criterion.
+ * Profit and loss in percentage criterion, defined as the trade profit over the
+ * purchase price.
  *
  * The profit or loss in percentage over the provided {@link Trade trade(s)}.
  * https://www.investopedia.com/ask/answers/how-do-you-calculate-percentage-gain-or-loss-investment/
@@ -52,10 +53,8 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Trade trade) {
         if (trade.isClosed()) {
-            Num entryPrice = series.getBar(trade.getEntry().getIndex()).getClosePrice();
-            Num exitPrice = series.getBar(trade.getExit().getIndex()).getClosePrice();
-
-            return exitPrice.minus(entryPrice).dividedBy(entryPrice).multipliedBy(series.numOf(100));
+            Num entryPrice = trade.getEntry().getPricePerAsset();
+            return trade.getProfit().dividedBy(entryPrice).multipliedBy(series.numOf(100));
         }
         return series.numOf(0);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
@@ -31,10 +31,8 @@ import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
- * Reward risk ratio criterion.
- *
- * (i.e. the {@link TotalProfitCriterion total profit} over the
- * {@link MaximumDrawdownCriterion maximum drawdown}.
+ * Reward risk ratio criterion, defined as the {@link TotalProfitCriterion total
+ * profit} over the {@link MaximumDrawdownCriterion maximum drawdown}.
  */
 public class RewardRiskRatioCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalLossCriterion.java
@@ -46,10 +46,7 @@ public class TotalLossCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Trade trade) {
         if (trade.isClosed()) {
-            Num exitPrice = series.getBar(trade.getExit().getIndex()).getClosePrice();
-            Num entryPrice = series.getBar(trade.getEntry().getIndex()).getClosePrice();
-
-            Num loss = exitPrice.minus(entryPrice).multipliedBy(trade.getExit().getAmount());
+            Num loss = trade.getProfit();
             return loss.isNegative() ? loss : series.numOf(0);
 
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/TotalProfitCriterion.java
@@ -60,23 +60,9 @@ public class TotalProfitCriterion extends AbstractAnalysisCriterion {
      * @return the profit of the trade
      */
     private Num calculateProfit(BarSeries series, Trade trade) {
-        Num profit = series.numOf(1);
         if (trade.isClosed()) {
-            // use price of entry/exit order, if NaN use close price of underlying time
-            // series
-            Num exitClosePrice = trade.getExit().getNetPrice().isNaN()
-                    ? series.getBar(trade.getExit().getIndex()).getClosePrice()
-                    : trade.getExit().getNetPrice();
-            Num entryClosePrice = trade.getEntry().getNetPrice().isNaN()
-                    ? series.getBar(trade.getEntry().getIndex()).getClosePrice()
-                    : trade.getEntry().getNetPrice();
-
-            if (trade.getEntry().isBuy()) {
-                profit = exitClosePrice.dividedBy(entryClosePrice);
-            } else {
-                profit = entryClosePrice.dividedBy(exitClosePrice);
-            }
+            return trade.getGrossReturn(series);
         }
-        return profit;
+        return series.numOf(1);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/OrderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/OrderTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.ta4j.core.Order.OrderType;
 import org.ta4j.core.cost.CostModel;
 import org.ta4j.core.cost.LinearTransactionCostModel;
+import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
@@ -80,5 +81,12 @@ public class OrderTest {
         assertNumEquals(expectedRawPrice, order.getPricePerAsset());
         assertNumEquals(expectedNetPrice, order.getNetPrice());
         assertTrue(transactionCostModel.equals(order.getCostModel()));
+    }
+
+    @Test
+    public void testReturnBarSeriesCloseOnNaN() {
+        MockBarSeries series = new MockBarSeries(DoubleNum::valueOf, 100, 95, 100, 80, 85, 130);
+        Order order = new Order(1, OrderType.BUY, NaN);
+        assertNumEquals(DoubleNum.valueOf(95), order.getPricePerAsset(series));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
@@ -26,6 +26,7 @@ package org.ta4j.core;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Order.OrderType;
+import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.cost.CostModel;
@@ -193,7 +194,7 @@ public class TradeTest {
     }
 
     @Test
-    public void testGetProfitForBuyStartingType() {
+    public void testGetProfitForLongTrades() {
         Trade trade = new Trade(OrderType.BUY);
 
         trade.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
@@ -205,7 +206,7 @@ public class TradeTest {
     }
 
     @Test
-    public void testGetProfitForSellStartingType() {
+    public void testGetProfitForShortTrades() {
         Trade trade = new Trade(OrderType.SELL);
 
         trade.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
@@ -214,6 +215,44 @@ public class TradeTest {
         final Num profit = trade.getProfit();
 
         assertEquals(DoubleNum.valueOf(4.0), profit);
+    }
+
+    @Test
+    public void testGetGrossReturnForLongTrades() {
+        Trade trade = new Trade(OrderType.BUY);
+
+        trade.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+        trade.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
+
+        final Num profit = trade.getGrossReturn();
+
+        assertEquals(DoubleNum.valueOf(1.2), profit);
+    }
+
+    @Test
+    public void testGetGrossReturnForShortTrades() {
+        Trade trade = new Trade(OrderType.SELL);
+
+        trade.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
+        trade.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+
+        final Num profit = trade.getGrossReturn();
+
+        assertEquals(DoubleNum.valueOf(1.2), profit);
+    }
+
+    @Test
+    public void testGetGrossReturnForLongTradesUsingBarCloseOnNaN() {
+        MockBarSeries series = new MockBarSeries(DoubleNum::valueOf, 100, 95, 100, 80, 85, 130);
+        Trade trade = new Trade(new Order(1, OrderType.BUY, NaN, NaN), new Order(2, OrderType.SELL, NaN, NaN));
+        assertNumEquals(DoubleNum.valueOf(100.0 / 95.0), trade.getGrossReturn(series));
+    }
+
+    @Test
+    public void testGetGrossReturnForShortTradesUsingBarCloseOnNaN() {
+        MockBarSeries series = new MockBarSeries(DoubleNum::valueOf, 100, 95, 100, 80, 85, 130);
+        Trade trade = new Trade(new Order(1, OrderType.SELL, NaN, NaN), new Order(2, OrderType.BUY, NaN, NaN));
+        assertNumEquals(DoubleNum.valueOf(95.0 / 100.0), trade.getGrossReturn(series));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitCriterionTest.java
@@ -68,6 +68,14 @@ public class AverageProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
+    public void calculateWithAShortTrade() {
+        series = new MockBarSeries(numFunction, 100d, 105d, 110d, 100d, 95d, 105d);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(2, series));
+        AnalysisCriterion averageProfit = getCriterion();
+        assertNumEquals(numOf(100d / 110).pow(numOf(1d / 3)), averageProfit.calculate(series, tradingRecord));
+    }
+
+    @Test
     public void calculateWithNoBarsShouldReturn1() {
         series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         AnalysisCriterion averageProfit = getCriterion();

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AverageProfitableTradesCriterionTest.java
@@ -53,6 +53,17 @@ public class AverageProfitableTradesCriterionTest extends AbstractCriterionTest 
     }
 
     @Test
+    public void calculateWithShortTrades() {
+        BarSeries series = new MockBarSeries(numFunction, 100d, 95d, 102d, 105d, 97d, 113d);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(2, series),
+                Order.sellAt(3, series), Order.buyAt(4, series));
+
+        AnalysisCriterion average = getCriterion();
+
+        assertNumEquals(0.5, average.calculate(series, tradingRecord));
+    }
+
+    @Test
     public void calculateWithOneTrade() {
         BarSeries series = new MockBarSeries(numFunction, 100d, 95d, 102d, 105d, 97d, 113d);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterionTest.java
@@ -58,7 +58,7 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateShouldWork() {
+    public void calculateWithGainsAndLosses() {
         MockBarSeries series = new MockBarSeries(numFunction, 1, 2, 3, 6, 5, 20, 3);
         AnalysisCriterion mdd = getCriterion();
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenTradesCriterionTest.java
@@ -52,7 +52,7 @@ public class NumberOfBreakEvenTradesCriterionTest extends AbstractCriterionTest 
     }
 
     @Test
-    public void calculateWithTwoTrades() {
+    public void calculateWithTwoLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(3, series),
                 Order.buyAt(1, series), Order.sellAt(5, series));
@@ -61,11 +61,20 @@ public class NumberOfBreakEvenTradesCriterionTest extends AbstractCriterionTest 
     }
 
     @Test
-    public void calculateWithOneTrade() {
+    public void calculateWithOneLongTrade() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(3, series));
 
         assertNumEquals(1, getCriterion().calculate(series, trade));
+    }
+
+    @Test
+    public void calculateWithTwoShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(3, series),
+                Order.sellAt(1, series), Order.buyAt(5, series));
+
+        assertNumEquals(2, getCriterion().calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfLosingTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfLosingTradesCriterionTest.java
@@ -52,7 +52,7 @@ public class NumberOfLosingTradesCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateWithTwoTrades() {
+    public void calculateWithTwoLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(1, series), Order.sellAt(3, series),
                 Order.buyAt(3, series), Order.sellAt(4, series));
@@ -61,11 +61,20 @@ public class NumberOfLosingTradesCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateWithOneTrade() {
+    public void calculateWithOneLongTrade() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         Trade trade = new Trade(Order.buyAt(1, series), Order.sellAt(3, series));
 
         assertNumEquals(1, getCriterion().calculate(series, trade));
+    }
+
+    @Test
+    public void calculateWithTwoShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
+                Order.sellAt(3, series), Order.buyAt(5, series));
+
+        assertNumEquals(2, getCriterion().calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfWinningTradesCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfWinningTradesCriterionTest.java
@@ -52,7 +52,7 @@ public class NumberOfWinningTradesCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateWithTwoTrades() {
+    public void calculateWithTwoLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
@@ -61,11 +61,20 @@ public class NumberOfWinningTradesCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateWithOneTrade() {
+    public void calculateWithOneLongTrade() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(2, series));
 
         assertNumEquals(1, getCriterion().calculate(series, trade));
+    }
+
+    @Test
+    public void calculateWithTwoShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 110, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
+                Order.sellAt(2, series), Order.buyAt(4, series));
+
+        assertNumEquals(2, getCriterion().calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ProfitLossPercentageCriterionTest.java
@@ -44,7 +44,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithGainTrades() {
+    public void calculateWithWinningLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
@@ -53,7 +53,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithLossTrades() {
+    public void calculateWithLosingLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
@@ -63,13 +63,31 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateWithOneWinningAndOneLosingTrades() {
+    public void calculateWithOneWinningAndOneLosingLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 195, 100, 80, 85, 70);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
 
         AnalysisCriterion profit = getCriterion();
         assertNumEquals(95 + -30, profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithWinningShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 90, 100, 95, 95, 100);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
+                Order.sellAt(2, series), Order.buyAt(3, series));
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(10 + 5, profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithLosingShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 110, 100, 105, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
+                Order.sellAt(2, series), Order.buyAt(3, series));
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals(-10 - 5, profit.calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalLossCriterionTest.java
@@ -49,8 +49,8 @@ public class TotalLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
 
-        AnalysisCriterion profit = getCriterion();
-        assertNumEquals(0, profit.calculate(series, tradingRecord));
+        AnalysisCriterion loss = getCriterion();
+        assertNumEquals(0, loss.calculate(series, tradingRecord));
     }
 
     @Test
@@ -59,18 +59,18 @@ public class TotalLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
 
-        AnalysisCriterion profit = getCriterion();
-        assertNumEquals(-35, profit.calculate(series, tradingRecord));
+        AnalysisCriterion loss = getCriterion();
+        assertNumEquals(-35, loss.calculate(series, tradingRecord));
     }
 
     @Test
-    public void calculateProfitWithTradesThatStartSelling() {
-        MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
+    public void calculateProfitWithShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 95, 100, 70, 80, 85, 100);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
                 Order.sellAt(2, series), Order.buyAt(5, series));
 
-        AnalysisCriterion profit = getCriterion();
-        assertNumEquals(-35, profit.calculate(series, tradingRecord));
+        AnalysisCriterion loss = getCriterion();
+        assertNumEquals(-35, loss.calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/TotalProfitCriterionTest.java
@@ -45,7 +45,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithGainTrades() {
+    public void calculateWithWinningLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
@@ -55,7 +55,7 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithLossTrades() {
+    public void calculateWithLosingLongTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
@@ -65,13 +65,23 @@ public class TotalProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateProfitWithTradesThatStartSelling() {
+    public void calculateProfitWithWinningShortTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
                 Order.sellAt(2, series), Order.buyAt(5, series));
 
         AnalysisCriterion profit = getCriterion();
         assertNumEquals((1 / 0.95) * (1 / 0.7), profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateProfitWithLosingShortTrades() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 100, 80, 85, 130);
+        TradingRecord tradingRecord = new BaseTradingRecord(Order.sellAt(0, series), Order.buyAt(1, series),
+                Order.sellAt(2, series), Order.buyAt(5, series));
+
+        AnalysisCriterion profit = getCriterion();
+        assertNumEquals((1 / 1.05) * (1 / 1.3), profit.calculate(series, tradingRecord));
     }
 
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:
* Implemented `getGrossReturn` for return calculations on trades.
* Moved the fallback on the bars' close price found in `TotalProfitCriterion` to be handled by `Trade` and `Order`.
* A lot of analysis criterions had their own internal calculations for profits and returns. Some of these were taking into account short trades, some weren't. I have replaced all of these with the `getProfit` and `getGrossReturn` on `Trade`.
* This also means all the analysis calculations now use the entry and exit numbers on the trades themselves, not the bars on which they occurred. In live trading, this is rarely the case!
* Implemented unit tests for short trades where missing.
* It also means all these calculations take trading costs into account.
* Updated a number of the javadoc entries in the analysis package to provide better descriptions.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
