### PR TITLE
Update NaN.java

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -50,6 +50,16 @@ public class NaN implements Num {
 
     private NaN() {
     }
+    
+    /**
+     * Returns a {@code Num} version of the given {@code Num}.
+     *
+     * @param val the number
+     * @return the {@code Num}
+     */
+    public static NaN valueOf(NaN val) {
+        return val;
+    }
 
     @Override
     public int compareTo(Num o) {

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -52,13 +52,13 @@ public class NaN implements Num {
     }
     
     /**
-     * Returns a {@code Num} version of the given {@code Num}.
+     * Returns a {@code Num} version of the given {@code Number}.
      *
      * @param val the number
-     * @return the {@code Num}
+     * @return {@link #NaN}
      */
-    public static NaN valueOf(NaN val) {
-        return val;
+    public static Num valueOf(Number val) {
+        return NaN;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -52,12 +52,12 @@ public class NaN implements Num {
     }
     
     /**
-     * Returns a {@code Num} version of the given {@code Number}.
+     * Returns a {@code Num} version of the given {@code Num}.
      *
      * @param val the number
      * @return {@link #NaN}
      */
-    public static Num valueOf(Number val) {
+    public static Num valueOf(Num val) {
         return NaN;
     }
 


### PR DESCRIPTION
Add method valueOf()

Changes proposed in this pull request:
- added method valueOf() (needed for Builder, be consistent with DoubleNum, DecimalNum)

With valueOf() it is possible to use the Builder, for example:

`BaseBar.builder(NaN::valueOf, NaN.class).timePeriod(..).openPrice(NaN).build();`

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
