### PR TITLE
Rename Total[Loss/Profit]Criterions to respective [Net|Gross][Profit|Loss]Criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Breaking
 - **Breaking:** **PrecisionNum** renamed to **DecimalNum**
+- **Breaking:** **TotalLossCriterion** renamed to **NetLossCriterion**
+- **Breaking:** **TotalProfit2Criterion** renamed to **NetProfitCriterion**
+- **Breaking:** **TotalProfitCriterion** renamed to **GrossReturnCriterion**
+
+
 
 ### Fixed
 - **Fixed `TotalLossCriterion`**: problem with profit calculations on short trades.
@@ -34,6 +39,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
  constructor of PreviousValueIndicator 
 - :tada: **Enhancement** added getGrossProfit() and getGrossProfit(BarSeries) on Trade.
 - :tada: **Enhancement** added getPricePerAsset(BarSeries) on Order.
+- :tada: **Enhancement** added GrossLossCriterion.
+- :tada: **Enhancement** added GrossProfitCriterion.
 
 ## 0.13 (released November 5, 2019)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
@@ -32,12 +32,12 @@ import org.ta4j.core.num.Num;
 /**
  * Calculates the average return per bar criterion.
  *
- * The {@link TotalProfitCriterion total profit} raised to the power of 1
+ * The {@link GrossProfitCriterion total profit} raised to the power of 1
  * divided by {@link NumberOfBarsCriterion number of bars}.
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 
-    private AnalysisCriterion totalProfit = new TotalProfitCriterion();
+    private AnalysisCriterion totalProfit = new GrossProfitCriterion();
 
     private AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageProfitCriterion.java
@@ -32,12 +32,12 @@ import org.ta4j.core.num.Num;
 /**
  * Calculates the average return per bar criterion.
  *
- * The {@link GrossProfitCriterion total profit} raised to the power of 1
+ * The {@link GrossReturnCriterion total profit} raised to the power of 1
  * divided by {@link NumberOfBarsCriterion number of bars}.
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 
-    private AnalysisCriterion totalProfit = new GrossProfitCriterion();
+    private AnalysisCriterion totalProfit = new GrossReturnCriterion();
 
     private AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossLossCriterion.java
@@ -1,0 +1,74 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.analysis.criteria;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+/**
+ * Gross loss criterion.
+ *
+ * The gross loss (with commissions) of the provided {@link Trade trade(s)} over
+ * the provided {@link BarSeries series}.
+ */
+public class GrossLossCriterion extends AbstractAnalysisCriterion {
+
+	/**
+	 * Calculates the gross loss (with commissions) of all trades
+	 *
+	 * @param series        the BarSeries
+	 * @param tradingRecord the TradingRecord
+	 * @return the gross loss of the trade
+	 */
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getTrades().stream().filter(Trade::isClosed).map(trade -> calculate(series, trade))
+                .reduce(series.numOf(0), Num::plus);
+    }
+
+    /**
+     * Calculates the gross loss (with commissions) of the given trade
+     *
+     * @param series the BarSeries
+     * @param trade  the Trade
+     * @return the gross loss of the trade
+     */
+    @Override
+    public Num calculate(BarSeries series, Trade trade) {
+        if (trade.isClosed()) {
+            Num loss = trade.getGrossProfit();
+            return loss.isNegative() ? loss : series.numOf(0);
+
+        }
+        return series.numOf(0);
+
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossProfitCriterion.java
@@ -1,0 +1,74 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.analysis.criteria;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+/**
+ * Gross profit criterion.
+ *
+ * The gross profit (with commissions) of the provided {@link Trade trade(s)} over
+ * the provided {@link BarSeries series}.
+ */
+public class GrossProfitCriterion extends AbstractAnalysisCriterion {
+
+	/**
+	 * Calculates the gross loss (with commissions) of all trades
+	 *
+	 * @param series        the BarSeries
+	 * @param tradingRecord the TradingRecord
+	 * @return the gross loss of the trade
+	 */
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getTrades().stream().filter(Trade::isClosed).map(trade -> calculate(series, trade))
+                .reduce(series.numOf(0), Num::plus);
+    }
+
+    /**
+     * Calculates the gross profit (with commissions) of the given trade
+     *
+     * @param series the BarSeries
+     * @param trade  the Trade
+     * @return the gross profit of the trade
+     */
+    @Override
+    public Num calculate(BarSeries series, Trade trade) {
+        if (trade.isClosed()) {
+            Num profit = trade.getGrossProfit();
+            return profit.isPositive() ? profit : series.numOf(0);
+
+        }
+        return series.numOf(0);
+
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossProfitCriterion.java
@@ -29,19 +29,33 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Total profit criterion.
+ * Gross profit criterion.
  *
- * The total profit of the provided {@link Trade trade(s)} over the provided
- * {@link BarSeries series}.
+ * The gross profit (with commissions) of the provided {@link Trade trade(s)}
+ * over the provided {@link BarSeries series}.
  */
-public class TotalProfitCriterion extends AbstractAnalysisCriterion {
+public class GrossProfitCriterion extends AbstractAnalysisCriterion {
 
+	/**
+	 * Calculates the gross profit (with commissions) of all trades
+	 *
+	 * @param series        the BarSeries
+	 * @param tradingRecord the TradingRecord
+	 * @return the total profit of the trades
+	 */
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         return tradingRecord.getTrades().stream().map(trade -> calculateProfit(series, trade)).reduce(series.numOf(1),
                 Num::multipliedBy);
     }
 
+    /**
+     * Calculates the gross profit (with commissions) of the given trade
+     *
+     * @param series a bar series
+     * @param trade  a trade
+     * @return the total loss of the trade
+     */
     @Override
     public Num calculate(BarSeries series, Trade trade) {
         return calculateProfit(series, trade);
@@ -53,7 +67,7 @@ public class TotalProfitCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * Calculates the profit of a trade (Buy and sell).
+     * Calculates the gross profit of a trade (Buy and sell).
      *
      * @param series a bar series
      * @param trade  a trade

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/GrossReturnCriterion.java
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
  * The gross profit (with commissions) of the provided {@link Trade trade(s)}
  * over the provided {@link BarSeries series}.
  */
-public class GrossProfitCriterion extends AbstractAnalysisCriterion {
+public class GrossReturnCriterion extends AbstractAnalysisCriterion {
 
 	/**
 	 * Calculates the gross profit (with commissions) of all trades

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
@@ -42,7 +42,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
     private double a;
     private double b;
 
-    private GrossProfitCriterion profit;
+    private GrossReturnCriterion profit;
 
     /**
      * Constructor. (a * x)
@@ -68,7 +68,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
         this.initialAmount = initialAmount;
         this.a = a;
         this.b = b;
-        profit = new GrossProfitCriterion();
+        profit = new GrossReturnCriterion();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LinearTransactionCostCriterion.java
@@ -42,7 +42,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
     private double a;
     private double b;
 
-    private TotalProfitCriterion profit;
+    private GrossProfitCriterion profit;
 
     /**
      * Constructor. (a * x)
@@ -68,7 +68,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
         this.initialAmount = initialAmount;
         this.a = a;
         this.b = b;
-        profit = new TotalProfitCriterion();
+        profit = new GrossProfitCriterion();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NetLossCriterion.java
@@ -28,8 +28,21 @@ import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
-public class TotalLossCriterion extends AbstractAnalysisCriterion {
+/**
+ * Net loss criterion.
+ *
+ * The net loss (without commissions) of the provided {@link Trade trade(s)}
+ * over the provided {@link BarSeries series}.
+ */
+public class NetLossCriterion extends AbstractAnalysisCriterion {
 
+	/**
+	 * Calculates the net loss (without commissions) of all trades
+	 *
+	 * @param series        the BarSeries
+	 * @param tradingRecord the TradingRecord
+	 * @return the total loss of the trades
+	 */
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         return tradingRecord.getTrades().stream().filter(Trade::isClosed).map(trade -> calculate(series, trade))
@@ -37,11 +50,11 @@ public class TotalLossCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * Calculates the gross loss of the given trade
+     * Calculates the net loss (without commissions) of the given trade
      *
      * @param series a bar series
      * @param trade  a trade
-     * @return the loss of the trade
+     * @return the total loss of the trade
      */
     @Override
     public Num calculate(BarSeries series, Trade trade) {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NetProfitCriterion.java
@@ -29,26 +29,33 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross profit criterion.
+ * Net profit criterion.
  *
- * The gross profit of the provided {@link Trade trade(s)} over the provided
+ * The net profit of the provided {@link Trade trade(s)} over the provided
  * {@link BarSeries series}.
  */
-public class TotalProfit2Criterion extends AbstractAnalysisCriterion {
+public class NetProfitCriterion extends AbstractAnalysisCriterion {
 
+	/**
+	 * Calculates the net profit (without commissions) of all trades
+	 *
+	 * @param series the BarSeries
+	 * @param trade  the TradingRecord
+	 * @return the gross profit
+	 */
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         return tradingRecord.getTrades().stream().filter(Trade::isClosed).map(trade -> calculate(series, trade))
                 .reduce(series.numOf(0), Num::plus);
     }
 
-    /**
-     * Calculates the gross profit value of given trade
-     *
-     * @param series a bar series
-     * @param trade  a trade to calculate profit
-     * @return the total profit
-     */
+	/**
+	 * Calculates the net profit (without commissions) of the given trade
+	 *
+	 * @param series the BarSeries
+	 * @param trade  the Trade
+	 * @return the total profit
+	 */
     @Override
     public Num calculate(BarSeries series, Trade trade) {
         if (trade.isClosed()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
@@ -31,12 +31,12 @@ import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
- * Reward risk ratio criterion, defined as the {@link GrossProfitCriterion total
+ * Reward risk ratio criterion, defined as the {@link GrossReturnCriterion total
  * profit} over the {@link MaximumDrawdownCriterion maximum drawdown}.
  */
 public class RewardRiskRatioCriterion extends AbstractAnalysisCriterion {
 
-    private final AnalysisCriterion totalProfitCriterion = new GrossProfitCriterion();
+    private final AnalysisCriterion totalProfitCriterion = new GrossReturnCriterion();
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/RewardRiskRatioCriterion.java
@@ -31,12 +31,12 @@ import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
- * Reward risk ratio criterion, defined as the {@link TotalProfitCriterion total
+ * Reward risk ratio criterion, defined as the {@link GrossProfitCriterion total
  * profit} over the {@link MaximumDrawdownCriterion maximum drawdown}.
  */
 public class RewardRiskRatioCriterion extends AbstractAnalysisCriterion {
 
-    private final AnalysisCriterion totalProfitCriterion = new TotalProfitCriterion();
+    private final AnalysisCriterion totalProfitCriterion = new GrossProfitCriterion();
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/package-info.java
@@ -27,7 +27,7 @@
  * Analysis criteria can be used to compare two trading
  * {@link org.ta4j.core.Strategy strategy}.<br>
  * The most common criterion is the
- * {@link org.ta4j.core.analysis.criteria.TotalProfitCriterion total profit
+ * {@link org.ta4j.core.analysis.criteria.GrossProfitCriterion total profit
  * criterion}. It measures how much is profitable a strategy.
  */
 package org.ta4j.core.analysis.criteria;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/package-info.java
@@ -27,7 +27,7 @@
  * Analysis criteria can be used to compare two trading
  * {@link org.ta4j.core.Strategy strategy}.<br>
  * The most common criterion is the
- * {@link org.ta4j.core.analysis.criteria.GrossProfitCriterion total profit
+ * {@link org.ta4j.core.analysis.criteria.GrossReturnCriterion total profit
  * criterion}. It measures how much is profitable a strategy.
  */
 package org.ta4j.core.analysis.criteria;

--- a/ta4j-core/src/main/java/org/ta4j/core/tradereport/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/tradereport/PerformanceReportGenerator.java
@@ -28,8 +28,8 @@ import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.criteria.ProfitLossCriterion;
 import org.ta4j.core.analysis.criteria.ProfitLossPercentageCriterion;
-import org.ta4j.core.analysis.criteria.TotalLossCriterion;
-import org.ta4j.core.analysis.criteria.TotalProfit2Criterion;
+import org.ta4j.core.analysis.criteria.NetLossCriterion;
+import org.ta4j.core.analysis.criteria.NetProfitCriterion;
 import org.ta4j.core.num.Num;
 
 /**
@@ -44,8 +44,8 @@ public class PerformanceReportGenerator implements ReportGenerator<PerformanceRe
     public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
         final Num totalProfitLoss = new ProfitLossCriterion().calculate(series, tradingRecord);
         final Num totalProfitLossPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
-        final Num totalProfit = new TotalProfit2Criterion().calculate(series, tradingRecord);
-        final Num totalLoss = new TotalLossCriterion().calculate(series, tradingRecord);
+        final Num totalProfit = new NetProfitCriterion().calculate(series, tradingRecord);
+        final Num totalLoss = new NetLossCriterion().calculate(series, tradingRecord);
         return new PerformanceReport(totalProfitLoss, totalProfitLossPercentage, totalProfit, totalLoss);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
@@ -48,7 +48,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     private List<Strategy> strategies;
 
     public AbstractAnalysisCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new TotalProfitCriterion(), numFunction);
+        super((params) -> new GrossProfitCriterion(), numFunction);
     }
 
     @Before

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
@@ -48,7 +48,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     private List<Strategy> strategies;
 
     public AbstractAnalysisCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new GrossProfitCriterion(), numFunction);
+        super((params) -> new GrossReturnCriterion(), numFunction);
     }
 
     @Before

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossLossCriterionTest.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 public class GrossLossCriterionTest extends AbstractCriterionTest {
 
     public GrossLossCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new NetProfitCriterion(), numFunction);
+        super((params) -> new GrossLossCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossLossCriterionTest.java
@@ -1,0 +1,41 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.analysis.criteria;
+
+import org.junit.Test;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+public class GrossLossCriterionTest extends AbstractCriterionTest {
+
+    public GrossLossCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NetProfitCriterion(), numFunction);
+    }
+
+    @Test
+    public void testCalculateOneOpenTradeShouldReturnZero() {
+        openedTradeUtils.testCalculateOneOpenTradeShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossProfitCriterionTest.java
@@ -38,10 +38,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-public class TotalProfitCriterionTest extends AbstractCriterionTest {
+public class GrossProfitCriterionTest extends AbstractCriterionTest {
 
-    public TotalProfitCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new TotalProfitCriterion(), numFunction);
+    public GrossProfitCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new GrossProfitCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossProfitCriterionTest.java
@@ -1,0 +1,41 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2020 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.analysis.criteria;
+
+import org.junit.Test;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+public class GrossProfitCriterionTest extends AbstractCriterionTest {
+
+    public GrossProfitCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new GrossProfitCriterion(), numFunction);
+    }
+
+    @Test
+    public void testCalculateOneOpenTradeShouldReturnZero() {
+        openedTradeUtils.testCalculateOneOpenTradeShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/GrossReturnCriterionTest.java
@@ -38,10 +38,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-public class GrossProfitCriterionTest extends AbstractCriterionTest {
+public class GrossReturnCriterionTest extends AbstractCriterionTest {
 
-    public GrossProfitCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new GrossProfitCriterion(), numFunction);
+    public GrossReturnCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new GrossReturnCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NetLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NetLossCriterionTest.java
@@ -37,10 +37,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-public class TotalLossCriterionTest extends AbstractCriterionTest {
+public class NetLossCriterionTest extends AbstractCriterionTest {
 
-    public TotalLossCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new TotalLossCriterion(), numFunction);
+    public NetLossCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NetLossCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NetProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NetProfitCriterionTest.java
@@ -28,10 +28,10 @@ import org.ta4j.core.num.Num;
 
 import java.util.function.Function;
 
-public class TotalProfit2CriterionTest extends AbstractCriterionTest {
+public class NetProfitCriterionTest extends AbstractCriterionTest {
 
-    public TotalProfit2CriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new TotalProfit2Criterion(), numFunction);
+    public NetProfitCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NetProfitCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
@@ -46,7 +46,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
         assertNumEquals(1.10 * 1.05 / 1.05, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -56,7 +56,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
         assertNumEquals(0.95 * 0.7 / 0.7, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -65,7 +65,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
         assertNumEquals((100d / 70) / (100d / 95), buyAndHold.calculate(series, trade));
     }
 
@@ -73,7 +73,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
     public void calculateWithNoTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion buyAndHold = getCriterion(new TotalProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
         assertNumEquals(1 / 0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
 
@@ -102,7 +102,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new TotalProfitCriterion());
+        AnalysisCriterion criterion = getCriterion(new GrossProfitCriterion());
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterionTest.java
@@ -46,7 +46,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(2, series),
                 Order.buyAt(3, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossReturnCriterion());
         assertNumEquals(1.10 * 1.05 / 1.05, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -56,7 +56,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Order.buyAt(0, series), Order.sellAt(1, series),
                 Order.buyAt(2, series), Order.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossReturnCriterion());
         assertNumEquals(0.95 * 0.7 / 0.7, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -65,7 +65,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         Trade trade = new Trade(Order.buyAt(0, series), Order.sellAt(1, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossReturnCriterion());
         assertNumEquals((100d / 70) / (100d / 95), buyAndHold.calculate(series, trade));
     }
 
@@ -73,7 +73,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
     public void calculateWithNoTrades() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion buyAndHold = getCriterion(new GrossProfitCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new GrossReturnCriterion());
         assertNumEquals(1 / 0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
 
@@ -102,7 +102,7 @@ public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new GrossProfitCriterion());
+        AnalysisCriterion criterion = getCriterion(new GrossReturnCriterion());
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -27,7 +27,7 @@ import org.ta4j.core.*;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.analysis.criteria.AverageProfitableTradesCriterion;
 import org.ta4j.core.analysis.criteria.RewardRiskRatioCriterion;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.analysis.criteria.VersusBuyAndHoldCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -100,7 +100,7 @@ public class Quickstart {
 
         // Total profit of our strategy
         // vs total profit of a buy-and-hold strategy
-        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new TotalProfitCriterion());
+        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new GrossProfitCriterion());
         System.out.println("Our profit vs buy-and-hold profit: " + vsBuyAndHold.calculate(series, tradingRecord));
 
         // Your turn!

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -27,7 +27,7 @@ import org.ta4j.core.*;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.analysis.criteria.AverageProfitableTradesCriterion;
 import org.ta4j.core.analysis.criteria.RewardRiskRatioCriterion;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.analysis.criteria.VersusBuyAndHoldCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -100,7 +100,7 @@ public class Quickstart {
 
         // Total profit of our strategy
         // vs total profit of a buy-and-hold strategy
-        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new GrossProfitCriterion());
+        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new GrossReturnCriterion());
         System.out.println("Our profit vs buy-and-hold profit: " + vsBuyAndHold.calculate(series, tradingRecord));
 
         // Your turn!

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -52,7 +52,7 @@ public class StrategyAnalysis {
          */
 
         // Gross profit
-        GrossProfitCriterion totalProfit = new GrossProfitCriterion();
+        GrossReturnCriterion totalProfit = new GrossReturnCriterion();
         System.out.println("Gross profit: " + totalProfit.calculate(series, tradingRecord));
         // Number of bars
         System.out.println("Number of bars: " + new NumberOfBarsCriterion().calculate(series, tradingRecord));

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -51,9 +51,9 @@ public class StrategyAnalysis {
          * Analysis criteria
          */
 
-        // Total profit
-        TotalProfitCriterion totalProfit = new TotalProfitCriterion();
-        System.out.println("Total profit: " + totalProfit.calculate(series, tradingRecord));
+        // Gross profit
+        GrossProfitCriterion totalProfit = new GrossProfitCriterion();
+        System.out.println("Gross profit: " + totalProfit.calculate(series, tradingRecord));
         // Number of bars
         System.out.println("Number of bars: " + new NumberOfBarsCriterion().calculate(series, tradingRecord));
         // Average profit (per bar)

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -25,7 +25,7 @@ package ta4jexamples.backtesting;
 
 import org.ta4j.core.*;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
@@ -54,7 +54,7 @@ public class SimpleMovingAverageBacktest {
                 DecimalNum.valueOf(50));
         System.out.println(tradingRecord2DaySma);
 
-        AnalysisCriterion criterion = new GrossProfitCriterion();
+        AnalysisCriterion criterion = new GrossReturnCriterion();
         Num calculate3DaySma = criterion.calculate(series, tradingRecord3DaySma);
         Num calculate2DaySma = criterion.calculate(series, tradingRecord2DaySma);
 

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -25,7 +25,7 @@ package ta4jexamples.backtesting;
 
 import org.ta4j.core.*;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
@@ -54,7 +54,7 @@ public class SimpleMovingAverageBacktest {
                 DecimalNum.valueOf(50));
         System.out.println(tradingRecord2DaySma);
 
-        AnalysisCriterion criterion = new TotalProfitCriterion();
+        AnalysisCriterion criterion = new GrossProfitCriterion();
         Num calculate3DaySma = criterion.calculate(series, tradingRecord3DaySma);
         Num calculate2DaySma = criterion.calculate(series, tradingRecord2DaySma);
 

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -24,7 +24,7 @@
 package ta4jexamples.num;
 
 import org.ta4j.core.*;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.RSIIndicator;
@@ -85,7 +85,7 @@ public class CompareNumTypes {
         long start = System.currentTimeMillis();
         BarSeriesManager manager = new BarSeriesManager(series);
         TradingRecord record1 = manager.run(strategy1);
-        GrossProfitCriterion profit1 = new GrossProfitCriterion();
+        GrossReturnCriterion profit1 = new GrossReturnCriterion();
         Num profitResult1 = profit1.calculate(series, record1);
         long end = System.currentTimeMillis();
 

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -24,7 +24,7 @@
 package ta4jexamples.num;
 
 import org.ta4j.core.*;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.RSIIndicator;
@@ -85,7 +85,7 @@ public class CompareNumTypes {
         long start = System.currentTimeMillis();
         BarSeriesManager manager = new BarSeriesManager(series);
         TradingRecord record1 = manager.run(strategy1);
-        TotalProfitCriterion profit1 = new TotalProfitCriterion();
+        GrossProfitCriterion profit1 = new GrossProfitCriterion();
         Num profitResult1 = profit1.calculate(series, record1);
         long end = System.currentTimeMillis();
 

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.adx.ADXIndicator;
 import org.ta4j.core.indicators.adx.MinusDIIndicator;
@@ -95,6 +95,6 @@ public class ADXStrategy {
 
         // Analysis
         System.out.println(
-                "Total profit for the strategy: " + new TotalProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.adx.ADXIndicator;
 import org.ta4j.core.indicators.adx.MinusDIIndicator;
@@ -95,6 +95,6 @@ public class ADXStrategy {
 
         // Analysis
         System.out.println(
-                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.CCIIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.trading.rules.OverIndicatorRule;
@@ -85,6 +85,6 @@ public class CCICorrectionStrategy {
 
         // Analysis
         System.out.println(
-                "Total profit for the strategy: " + new TotalProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.CCIIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.trading.rules.OverIndicatorRule;
@@ -85,6 +85,6 @@ public class CCICorrectionStrategy {
 
         // Analysis
         System.out.println(
-                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.indicators.helpers.HighestValueIndicator;
@@ -93,6 +93,6 @@ public class GlobalExtremaStrategy {
 
         // Analysis
         System.out.println(
-                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.indicators.helpers.HighestValueIndicator;
@@ -93,6 +93,6 @@ public class GlobalExtremaStrategy {
 
         // Analysis
         System.out.println(
-                "Total profit for the strategy: " + new TotalProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.StochasticOscillatorKIndicator;
@@ -100,6 +100,6 @@ public class MovingMomentumStrategy {
 
         // Analysis
         System.out.println(
-                "Total profit for the strategy: " + new TotalProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.StochasticOscillatorKIndicator;
@@ -100,6 +100,6 @@ public class MovingMomentumStrategy {
 
         // Analysis
         System.out.println(
-                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.indicators.RSIIndicator;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -97,7 +97,7 @@ public class RSI2Strategy {
 
         // Analysis
         System.out.println(
-                "Total profit for the strategy: " + new TotalProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
     }
 
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.indicators.RSIIndicator;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -97,7 +97,7 @@ public class RSI2Strategy {
 
         // Analysis
         System.out.println(
-                "Gross profit for the strategy: " + new GrossProfitCriterion().calculate(series, tradingRecord));
+                "Gross profit for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
     }
 
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -28,7 +28,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossReturnCriterion;
 import org.ta4j.core.num.Num;
 import ta4jexamples.loaders.CsvTradesLoader;
 import ta4jexamples.strategies.CCICorrectionStrategy;
@@ -175,7 +175,7 @@ public class WalkForward {
         Map<Strategy, String> strategies = buildStrategiesMap(series);
 
         // The analysis criterion
-        AnalysisCriterion profitCriterion = new GrossProfitCriterion();
+        AnalysisCriterion profitCriterion = new GrossReturnCriterion();
 
         for (BarSeries slice : subseries) {
             // For each sub-series...

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -28,7 +28,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.analysis.criteria.GrossProfitCriterion;
 import org.ta4j.core.num.Num;
 import ta4jexamples.loaders.CsvTradesLoader;
 import ta4jexamples.strategies.CCICorrectionStrategy;
@@ -175,7 +175,7 @@ public class WalkForward {
         Map<Strategy, String> strategies = buildStrategiesMap(series);
 
         // The analysis criterion
-        AnalysisCriterion profitCriterion = new TotalProfitCriterion();
+        AnalysisCriterion profitCriterion = new GrossProfitCriterion();
 
         for (BarSeries slice : subseries) {
             // For each sub-series...


### PR DESCRIPTION
Changes proposed in this pull request:
- Rename TotalLossCriterion to `NetLossCriterion` 
- Rename TotalProfit2Criterion to `NetProfitCriterion` 
- Rename TotalProfitCriterion to `GrossReturnCriterion` 
- Add `GrossLossCriterion` 
- Add `GrossProfitCriterion` 

- [] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
