### PR TITLE
Fixed formatting for failing travis build

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -111,8 +111,8 @@ public class BaseTradingRecord implements TradingRecord {
      * Constructor.
      *
      * @param name           the name of the trading record
-     * @param entryOrderType the {@link OrderType order type} of entries in
-     *                       the trading session
+     * @param entryOrderType the {@link OrderType order type} of entries in the
+     *                       trading session
      */
     public BaseTradingRecord(String name, OrderType orderType) {
         this(orderType, new ZeroCostModel(), new ZeroCostModel());
@@ -122,10 +122,10 @@ public class BaseTradingRecord implements TradingRecord {
     /**
      * Constructor.
      *
-     * @param entryOrderType       the {@link OrderType order type} of entries
-     *                             in the trading session
-     * @param entryOrderType the {@link OrderType order type} of entries in
-     *                       the trading session
+     * @param entryOrderType the {@link OrderType order type} of entries in the
+     *                       trading session
+     * @param entryOrderType the {@link OrderType order type} of entries in the
+     *                       trading session
      */
     public BaseTradingRecord(OrderType orderType) {
         this(orderType, new ZeroCostModel(), new ZeroCostModel());
@@ -134,13 +134,12 @@ public class BaseTradingRecord implements TradingRecord {
     /**
      * Constructor.
      *
-     * @param entryOrderType       the {@link OrderType order type} of entries
-     *                             in the trading session
+     * @param entryOrderType       the {@link OrderType order type} of entries in
+     *                             the trading session
      * @param transactionCostModel the cost model for transactions of the asset
      * @param holdingCostModel     the cost model for holding asset (e.g. borrowing)
      */
-    public BaseTradingRecord(OrderType entryOrderType, CostModel transactionCostModel,
-            CostModel holdingCostModel) {
+    public BaseTradingRecord(OrderType entryOrderType, CostModel transactionCostModel, CostModel holdingCostModel) {
         if (entryOrderType == null) {
             throw new IllegalArgumentException("Starting type must not be null");
         }
@@ -182,11 +181,11 @@ public class BaseTradingRecord implements TradingRecord {
             recordOrder(newOrder, newOrderWillBeAnEntry);
         }
     }
-    
+
     @Override
     public OrderType getStartingType() {
-		return startingType;
-	}
+        return startingType;
+    }
 
     @Override
     public String getName() {

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -42,12 +42,12 @@ import static org.ta4j.core.num.NaN.NaN;
  * </ul>
  */
 public interface TradingRecord extends Serializable {
-    
+
     /**
-	 * @return the entry type (BUY or SELL) of the first trade in the trading
-	 *         session
-	 */
-	OrderType getStartingType();
+     * @return the entry type (BUY or SELL) of the first trade in the trading
+     *         session
+     */
+    OrderType getStartingType();
 
     /**
      * @return the name of the TradingRecord

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java
@@ -37,165 +37,165 @@ import org.ta4j.core.num.Num;
  */
 public class DecimalTransformIndicator extends CachedIndicator<Num> {
 
-	private static final long serialVersionUID = -8017034587193428498L;
+    private static final long serialVersionUID = -8017034587193428498L;
 
-	/**
-	 * Select the type for transformation.
-	 */
-	public enum DecimalTransformType {
+    /**
+     * Select the type for transformation.
+     */
+    public enum DecimalTransformType {
 
-		/**
-		 * Transforms the input indicator by indicator.plus(coefficient).
-		 */
-		plus {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.plus(coefficient);
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.plus(coefficient).
+         */
+        plus {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.plus(coefficient);
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.minus(coefficient).
-		 */
-		minus {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.minus(coefficient);
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.minus(coefficient).
+         */
+        minus {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.minus(coefficient);
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.multipliedBy(coefficient).
-		 */
-		multiply {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.multipliedBy(coefficient);
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.multipliedBy(coefficient).
+         */
+        multiply {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.multipliedBy(coefficient);
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.dividedBy(coefficient).
-		 */
-		divide {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.dividedBy(coefficient);
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.dividedBy(coefficient).
+         */
+        divide {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.dividedBy(coefficient);
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.max(coefficient).
-		 */
-		max {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.max(coefficient);
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.max(coefficient).
+         */
+        max {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.max(coefficient);
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.min(coefficient).
-		 */
-		min {
-			@Override
-			Num calculate(Num val, Num coefficient) {
-				return val.min(coefficient);
-			}
-		};
+        /**
+         * Transforms the input indicator by indicator.min(coefficient).
+         */
+        min {
+            @Override
+            Num calculate(Num val, Num coefficient) {
+                return val.min(coefficient);
+            }
+        };
 
-		abstract Num calculate(Num val, Num coefficient);
-	}
+        abstract Num calculate(Num val, Num coefficient);
+    }
 
-	/**
-	 * Select the type for transformation.
-	 */
-	public enum DecimalTransformSimpleType {
-		/**
-		 * Transforms the input indicator by indicator.abs().
-		 */
-		abs {
-			@Override
-			Num calculate(Num val) {
-				return val.abs();
-			}
-		},
+    /**
+     * Select the type for transformation.
+     */
+    public enum DecimalTransformSimpleType {
+        /**
+         * Transforms the input indicator by indicator.abs().
+         */
+        abs {
+            @Override
+            Num calculate(Num val) {
+                return val.abs();
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.sqrt().
-		 */
-		sqrt {
-			@Override
-			Num calculate(Num val) {
-				return val.sqrt();
-			}
-		},
+        /**
+         * Transforms the input indicator by indicator.sqrt().
+         */
+        sqrt {
+            @Override
+            Num calculate(Num val) {
+                return val.sqrt();
+            }
+        },
 
-		/**
-		 * Transforms the input indicator by indicator.log().
-		 */
-		log {
-			@Override
-			Num calculate(Num val) {
-				return val.numOf(Math.log(val.doubleValue()));
-			}
-		};
+        /**
+         * Transforms the input indicator by indicator.log().
+         */
+        log {
+            @Override
+            Num calculate(Num val) {
+                return val.numOf(Math.log(val.doubleValue()));
+            }
+        };
 
-		abstract Num calculate(Num val);
-	}
+        abstract Num calculate(Num val);
+    }
 
-	private Indicator<Num> indicator;
-	private Num coefficient;
-	private DecimalTransformType type;
-	private DecimalTransformSimpleType simpleType;
+    private Indicator<Num> indicator;
+    private Num coefficient;
+    private DecimalTransformType type;
+    private DecimalTransformSimpleType simpleType;
 
-	/**
-	 * Constructor.
-	 * 
-	 * @param indicator   the indicator
-	 * @param coefficient the value for transformation
-	 * @param type        the type of the transformation
-	 */
-	public DecimalTransformIndicator(Indicator<Num> indicator, Number coefficient, DecimalTransformType type) {
-		super(indicator);
-		this.indicator = indicator;
-		this.coefficient = numOf(coefficient);
-		this.type = type;
-	}
+    /**
+     * Constructor.
+     * 
+     * @param indicator   the indicator
+     * @param coefficient the value for transformation
+     * @param type        the type of the transformation
+     */
+    public DecimalTransformIndicator(Indicator<Num> indicator, Number coefficient, DecimalTransformType type) {
+        super(indicator);
+        this.indicator = indicator;
+        this.coefficient = numOf(coefficient);
+        this.type = type;
+    }
 
-	/**
-	 * Constructor.
-	 * 
-	 * @param indicator the indicator
-	 * @param type      the type of the transformation
-	 */
-	public DecimalTransformIndicator(Indicator<Num> indicator, DecimalTransformSimpleType type) {
-		super(indicator);
-		this.indicator = indicator;
-		this.simpleType = type;
-	}
+    /**
+     * Constructor.
+     * 
+     * @param indicator the indicator
+     * @param type      the type of the transformation
+     */
+    public DecimalTransformIndicator(Indicator<Num> indicator, DecimalTransformSimpleType type) {
+        super(indicator);
+        this.indicator = indicator;
+        this.simpleType = type;
+    }
 
-	@Override
-	protected Num calculate(int index) {
+    @Override
+    protected Num calculate(int index) {
 
-		Num val = indicator.getValue(index);
+        Num val = indicator.getValue(index);
 
-		if (type != null) {
-			return type.calculate(val, coefficient);
-		}
+        if (type != null) {
+            return type.calculate(val, coefficient);
+        }
 
-		else if (simpleType != null) {
-			return simpleType.calculate(val);
-		}
+        else if (simpleType != null) {
+            return simpleType.calculate(val);
+        }
 
-		return val;
-	}
+        return val;
+    }
 
-	@Override
-	public String toString() {
-		if (type != null) {
-			return getClass().getSimpleName() + " Coefficient: " + coefficient + " Transform(" + type.name() + ")";
-		}
-		return getClass().getSimpleName() + "Transform(" + simpleType.name() + ")";
-	}
+    @Override
+    public String toString() {
+        if (type != null) {
+            return getClass().getSimpleName() + " Coefficient: " + coefficient + " Transform(" + type.name() + ")";
+        }
+        return getClass().getSimpleName() + "Transform(" + simpleType.name() + ")";
+    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -50,7 +50,7 @@ public class NaN implements Num {
 
     private NaN() {
     }
-    
+
     /**
      * Returns a {@code Num} version of the given {@code Num}.
      *


### PR DESCRIPTION
Fixes #.
Travis build on develop branch is failing due to:
```[ERROR] Failed to execute goal net.revelc.code.formatter:formatter-maven-plugin:2.10.0:validate (default-cli) on project ta4j-core: File '/home/travis/build/ta4j/ta4j/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DecimalTransformIndicator.java' has not been previously formatted.  Please format file and commit before running validation! -> [Help 1]```

https://cdn.travis-ci.org/github/ta4j/ta4j/builds/712251184

This PR is fixing it.


Changes proposed in this pull request:
- Fixed formatting for failing Travis build

Not needed
- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
