### PR TITLE
Upgraded travis config to the newest supported ubuntu dist on travis:…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 
 language: java
 


### PR DESCRIPTION
Upgraded travis config to the newest supported ubuntu dist on travis: bionic

https://docs.travis-ci.com/user/reference/overview/

Ubuntu Xenial support end on April 2021 (https://wiki.ubuntu.com/Releases), so it is time to upgrade dist used by travis.


Fixes #.

Changes proposed in this pull request:
- Upgraded travis config to the newest supported ubuntu dist on travis: bionic
- 
- 

Not needed, confing change only for CI
- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
