### PR TITLE
Rename DecimalTransformIndicator to TransformIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Breaking
 - **Breaking:** **PrecisionNum** renamed to **DecimalNum**
+- **Breaking:** **DecimalTransformIndicator** renamed to **TransformIndicator**
 - **Breaking:** **AverageProfitableTradesCriterion** renamed to **WinningTradesRatioCriterion**
 - **Breaking:** **AverageProfitCriterion** renamed to **AverageReturnPerBarCriterion**
 - **Breaking:** **BuyAndHoldCriterion** renamed to **BuyAndHoldReturnCriterion**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -28,9 +28,9 @@ import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.num.Num;
 
 /**
- * Simple transform indicator for Num.
+ * Transform indicator for Num.
  *
- * <p>Transforms any indicator by using common math operations.
+ * <p>Transforms the Num of any indicator by using common math operations.
  *
  * @apiNote Minimal deviations in last decimal places possible. During the
  *          calculations this indicator converts {@link Num DecimalNum} to

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -28,21 +28,22 @@ import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.num.Num;
 
 /**
- * Simple decimal transform indicator.
+ * Simple transform indicator for Num.
+ *
+ * <p>Transforms any indicator by using common math operations.
  *
  * @apiNote Minimal deviations in last decimal places possible. During the
- *          calculations this indicator converts {@link Num PrecisionNum} to to
- *          {@link Double double} Transforms any indicator by using common math
- *          operations.
+ *          calculations this indicator converts {@link Num DecimalNum} to
+ *          {@link Double double}
  */
-public class DecimalTransformIndicator extends CachedIndicator<Num> {
+public class TransformIndicator extends CachedIndicator<Num> {
 
     private static final long serialVersionUID = -8017034587193428498L;
 
     /**
      * Select the type for transformation.
      */
-    public enum DecimalTransformType {
+    public enum TransformType {
 
         /**
          * Transforms the input indicator by indicator.plus(coefficient).
@@ -110,7 +111,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
     /**
      * Select the type for transformation.
      */
-    public enum DecimalTransformSimpleType {
+    public enum TransformSimpleType {
         /**
          * Transforms the input indicator by indicator.abs().
          */
@@ -146,8 +147,8 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
 
     private Indicator<Num> indicator;
     private Num coefficient;
-    private DecimalTransformType type;
-    private DecimalTransformSimpleType simpleType;
+    private TransformType type;
+    private TransformSimpleType simpleType;
 
     /**
      * Constructor.
@@ -156,7 +157,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
      * @param coefficient the value for transformation
      * @param type        the type of the transformation
      */
-    public DecimalTransformIndicator(Indicator<Num> indicator, Number coefficient, DecimalTransformType type) {
+    public TransformIndicator(Indicator<Num> indicator, Number coefficient, TransformType type) {
         super(indicator);
         this.indicator = indicator;
         this.coefficient = numOf(coefficient);
@@ -169,7 +170,7 @@ public class DecimalTransformIndicator extends CachedIndicator<Num> {
      * @param indicator the indicator
      * @param type      the type of the transformation
      */
-    public DecimalTransformIndicator(Indicator<Num> indicator, DecimalTransformSimpleType type) {
+    public TransformIndicator(Indicator<Num> indicator, TransformSimpleType type) {
         super(indicator);
         this.indicator = indicator;
         this.simpleType = type;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
@@ -29,28 +29,28 @@ import org.ta4j.core.BaseBarSeriesBuilder;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.indicators.helpers.DecimalTransformIndicator.DecimalTransformSimpleType;
-import org.ta4j.core.indicators.helpers.DecimalTransformIndicator.DecimalTransformType;
+import org.ta4j.core.indicators.helpers.TransformIndicator.TransformSimpleType;
+import org.ta4j.core.indicators.helpers.TransformIndicator.TransformType;
 import org.ta4j.core.num.Num;
 
 import java.util.function.Function;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-public class DecimalTransformIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+public class TransformIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
-    private DecimalTransformIndicator transPlus;
-    private DecimalTransformIndicator transMinus;
-    private DecimalTransformIndicator transMultiply;
-    private DecimalTransformIndicator transDivide;
-    private DecimalTransformIndicator transMax;
-    private DecimalTransformIndicator transMin;
+    private TransformIndicator transPlus;
+    private TransformIndicator transMinus;
+    private TransformIndicator transMultiply;
+    private TransformIndicator transDivide;
+    private TransformIndicator transMax;
+    private TransformIndicator transMin;
 
-    private DecimalTransformIndicator transAbs;
-    private DecimalTransformIndicator transSqrt;
-    private DecimalTransformIndicator transLog;
+    private TransformIndicator transAbs;
+    private TransformIndicator transSqrt;
+    private TransformIndicator transLog;
 
-    public DecimalTransformIndicatorTest(Function<Number, Num> numFunction) {
+    public TransformIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
     }
 
@@ -59,17 +59,17 @@ public class DecimalTransformIndicatorTest extends AbstractIndicatorTest<Indicat
         BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
         ConstantIndicator<Num> constantIndicator = new ConstantIndicator<>(series, numOf(4));
 
-        transPlus = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.plus);
-        transMinus = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.minus);
-        transMultiply = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.multiply);
-        transDivide = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.divide);
-        transMax = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.max);
-        transMin = new DecimalTransformIndicator(constantIndicator, 10, DecimalTransformType.min);
+        transPlus = new TransformIndicator(constantIndicator, 10, TransformType.plus);
+        transMinus = new TransformIndicator(constantIndicator, 10, TransformType.minus);
+        transMultiply = new TransformIndicator(constantIndicator, 10, TransformType.multiply);
+        transDivide = new TransformIndicator(constantIndicator, 10, TransformType.divide);
+        transMax = new TransformIndicator(constantIndicator, 10, TransformType.max);
+        transMin = new TransformIndicator(constantIndicator, 10, TransformType.min);
 
-        transAbs = new DecimalTransformIndicator(new ConstantIndicator<Num>(series, numOf(-4)),
-                DecimalTransformSimpleType.abs);
-        transSqrt = new DecimalTransformIndicator(constantIndicator, DecimalTransformSimpleType.sqrt);
-        transLog = new DecimalTransformIndicator(constantIndicator, DecimalTransformSimpleType.log);
+        transAbs = new TransformIndicator(new ConstantIndicator<Num>(series, numOf(-4)),
+                TransformSimpleType.abs);
+        transSqrt = new TransformIndicator(constantIndicator, TransformSimpleType.sqrt);
+        transLog = new TransformIndicator(constantIndicator, TransformSimpleType.log);
     }
 
     @Test


### PR DESCRIPTION
DecimalTransformIndicator is not the correct name, because it transforms Num (hence NumTransformIndicator). To keep it simple: I renamed it to TransformIndicator.

Changes proposed in this pull request:
- Rename DecimalTransformIndicator to TransformIndicator

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
