### PR TITLE
Do not annotate BarSeriesBuilder as Serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 - **Fixed `Trade`**: problem with profit calculations on short trades.
 - **Fixed `TotalLossCriterion`**: problem with profit calculations on short trades.
+- **Fixed `BarSeriesBuilder`**: removed the Serializable interface
 
 ### Changed
 - **Trade**: Changed the way Nums are created.
@@ -23,7 +24,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **NumberOfBreakEvenTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **NumberOfLosingTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **NumberOfWinningTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
-- **ProfitLossPercentageCriterion**: Changed to calculate trade profits using Trade's entry and exit prices.
+- **ProfitLossPercentageCriterion**: ChangBed to calculate trade profits using Trade's entry and exit prices.
 - **TotalLossCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **TotalReturnCriterion** (previously TotalProfitCriterion): Changed to calculate trade profits using Trade's getProfit().
 - **WMAIndicator**: reduced complexity of WMAIndicator implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **NumberOfBreakEvenTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **NumberOfLosingTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **NumberOfWinningTradesCriterion**: Changed to calculate trade profits using Trade's getProfit().
-- **ProfitLossPercentageCriterion**: ChangBed to calculate trade profits using Trade's entry and exit prices.
+- **ProfitLossPercentageCriterion**: Changed to calculate trade profits using Trade's entry and exit prices.
 - **TotalLossCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **TotalReturnCriterion** (previously TotalProfitCriterion): Changed to calculate trade profits using Trade's getProfit().
 - **WMAIndicator**: reduced complexity of WMAIndicator implementation

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
@@ -23,12 +23,10 @@
  */
 package org.ta4j.core;
 
-import java.io.Serializable;
-
 /**
  * Interface to build a bar series
  */
-public interface BarSeriesBuilder extends Serializable {
+public interface BarSeriesBuilder {
     /**
      * Builds the bar series with corresponding parameters
      *

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -33,7 +33,6 @@ import java.util.function.Function;
 
 public class BaseBarSeriesBuilder implements BarSeriesBuilder {
 
-    private static final long serialVersionUID = 111164611841087550L;
     /**
      * Default Num type function
      **/


### PR DESCRIPTION
Fixes #564 .

Changes proposed in this pull request:
- Removed the Serializable interface from `BarSeriesBuilder` because it is not meant to be serialized

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
