### PR TITLE
Add provided scope for slf4j dependency.

### DIFF
--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -17,6 +17,7 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.7.25</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
It avoid mismatch of multiple versions of slf4j in a OSGi container.


Fixes #627.

Changes proposed in this pull request:
- Change scope of slf4j-api dependency from compile to provided

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
