### PR TITLE
Rename package "tradereports" to "reports"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Breaking:** **RewardRiskRatioCriterion** renamed to **ReturnOverMaxDrawdownCriterion**
 - **Breaking:** **TotalProfitCriterion** renamed to **TotalReturnCriterion**
 - **Breaking:** **TotalProfit2Criterion** renamed to **TotalProfitCriterion**
+- **Breaking:** package "tradereports" renamed to "reports"
 
 ### Fixed
 - **Fixed `Trade`**: problem with profit calculations on short trades.

--- a/ta4j-core/src/main/java/org/ta4j/core/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BacktestExecutor.java
@@ -24,8 +24,8 @@
 package org.ta4j.core;
 
 import org.ta4j.core.num.Num;
-import org.ta4j.core.tradereport.TradingStatement;
-import org.ta4j.core.tradereport.TradingStatementGenerator;
+import org.ta4j.core.reports.TradingStatement;
+import org.ta4j.core.reports.TradingStatementGenerator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
@@ -21,35 +21,41 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
 import org.ta4j.core.num.Num;
 
 /**
- * This class represents report with statistics for executed trades
+ * This class represents report which contains performance statistics
  */
-public class TradeStatsReport {
+public class PerformanceReport {
 
-    private final Num profitTradeCount;
-    private final Num lossTradeCount;
-    private final Num breakEvenTradeCount;
+    private final Num totalProfitLoss;
+    private final Num totalProfitLossPercentage;
+    private final Num totalProfit;
+    private final Num totalLoss;
 
-    public TradeStatsReport(Num profitTradeCount, Num lossTradeCount, Num breakEvenTradeCount) {
-        this.profitTradeCount = profitTradeCount;
-        this.lossTradeCount = lossTradeCount;
-        this.breakEvenTradeCount = breakEvenTradeCount;
+    public PerformanceReport(Num totalProfitLoss, Num totalProfitLossPercentage, Num totalProfit, Num totalLoss) {
+        this.totalProfitLoss = totalProfitLoss;
+        this.totalProfitLossPercentage = totalProfitLossPercentage;
+        this.totalProfit = totalProfit;
+        this.totalLoss = totalLoss;
     }
 
-    public Num getProfitTradeCount() {
-        return profitTradeCount;
+    public Num getTotalProfitLoss() {
+        return totalProfitLoss;
     }
 
-    public Num getLossTradeCount() {
-        return lossTradeCount;
+    public Num getTotalProfitLossPercentage() {
+        return totalProfitLossPercentage;
     }
 
-    public Num getBreakEvenTradeCount() {
-        return breakEvenTradeCount;
+    public Num getTotalProfit() {
+        return totalProfit;
+    }
+
+    public Num getTotalLoss() {
+        return totalLoss;
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
@@ -21,39 +21,31 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.ProfitLossCriterion;
+import org.ta4j.core.analysis.criteria.ProfitLossPercentageCriterion;
+import org.ta4j.core.analysis.criteria.TotalLossCriterion;
+import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
+import org.ta4j.core.num.Num;
 
 /**
- * This class generates TradingStatement basis on provided trading report and
+ * This class generates PerformanceReport basis on provided trading report and
  * bar series
  *
- * @see TradingStatement
+ * @see PerformanceReport
  */
-public class TradingStatementGenerator implements ReportGenerator<TradingStatement> {
-
-    private final PerformanceReportGenerator performanceReportGenerator;
-    private final TradeStatsReportGenerator tradeStatsReportGenerator;
-
-    public TradingStatementGenerator() {
-        this(new PerformanceReportGenerator(), new TradeStatsReportGenerator());
-    }
-
-    public TradingStatementGenerator(PerformanceReportGenerator performanceReportGenerator,
-            TradeStatsReportGenerator tradeStatsReportGenerator) {
-        super();
-        this.performanceReportGenerator = performanceReportGenerator;
-        this.tradeStatsReportGenerator = tradeStatsReportGenerator;
-    }
+public class PerformanceReportGenerator implements ReportGenerator<PerformanceReport> {
 
     @Override
-    public TradingStatement generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
-        final PerformanceReport performanceReport = performanceReportGenerator.generate(strategy, tradingRecord,
-                series);
-        final TradeStatsReport tradeStatsReport = tradeStatsReportGenerator.generate(strategy, tradingRecord, series);
-        return new TradingStatement(strategy, tradeStatsReport, performanceReport);
+    public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
+        final Num totalProfitLoss = new ProfitLossCriterion().calculate(series, tradingRecord);
+        final Num totalProfitLossPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
+        final Num totalProfit = new TotalProfitCriterion().calculate(series, tradingRecord);
+        final Num totalLoss = new TotalLossCriterion().calculate(series, tradingRecord);
+        return new PerformanceReport(totalProfitLoss, totalProfitLossPercentage, totalProfit, totalLoss);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
@@ -21,8 +21,26 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+package org.ta4j.core.reports;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.TradingRecord;
+
 /**
- * The main module for trade reports
+ * Generic interface for generating trade reports
  *
+ * @param <T> type of report to be generated
  */
-package org.ta4j.core.tradereport;
+public interface ReportGenerator<T> {
+
+    /**
+     * Generate report
+     *
+     * @param tradingRecord the trading record which is a source to generate report,
+     *                      not null
+     * @param series        the bar series, not null
+     * @return generated report
+     */
+    T generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series);
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradeStatsReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradeStatsReport.java
@@ -21,26 +21,35 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.Strategy;
-import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
 
 /**
- * Generic interface for generating trade reports
- *
- * @param <T> type of report to be generated
+ * This class represents report with statistics for executed trades
  */
-public interface ReportGenerator<T> {
+public class TradeStatsReport {
 
-    /**
-     * Generate report
-     *
-     * @param tradingRecord the trading record which is a source to generate report,
-     *                      not null
-     * @param series        the bar series, not null
-     * @return generated report
-     */
-    T generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series);
+    private final Num profitTradeCount;
+    private final Num lossTradeCount;
+    private final Num breakEvenTradeCount;
+
+    public TradeStatsReport(Num profitTradeCount, Num lossTradeCount, Num breakEvenTradeCount) {
+        this.profitTradeCount = profitTradeCount;
+        this.lossTradeCount = lossTradeCount;
+        this.breakEvenTradeCount = breakEvenTradeCount;
+    }
+
+    public Num getProfitTradeCount() {
+        return profitTradeCount;
+    }
+
+    public Num getLossTradeCount() {
+        return lossTradeCount;
+    }
+
+    public Num getBreakEvenTradeCount() {
+        return breakEvenTradeCount;
+    }
+
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradeStatsReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradeStatsReportGenerator.java
@@ -21,35 +21,29 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.NumberOfBreakEvenTradesCriterion;
+import org.ta4j.core.analysis.criteria.NumberOfLosingTradesCriterion;
+import org.ta4j.core.analysis.criteria.NumberOfWinningTradesCriterion;
+import org.ta4j.core.num.Num;
 
 /**
- * This class represents trading statement report which contains trade and
- * performance statistics
+ * This class generates TradeStatsReport basis on provided trading report and
+ * bar series.
+ *
+ * @see TradeStatsReport
  */
-public class TradingStatement {
+public class TradeStatsReportGenerator implements ReportGenerator<TradeStatsReport> {
 
-    private final Strategy strategy;
-    private final TradeStatsReport tradeStatsReport;
-    private final PerformanceReport performanceReport;
-
-    public TradingStatement(Strategy strategy, TradeStatsReport tradeStatsReport, PerformanceReport performanceReport) {
-        this.strategy = strategy;
-        this.tradeStatsReport = tradeStatsReport;
-        this.performanceReport = performanceReport;
-    }
-
-    public Strategy getStrategy() {
-        return strategy;
-    }
-
-    public TradeStatsReport getTradeStatsReport() {
-        return tradeStatsReport;
-    }
-
-    public PerformanceReport getPerformanceReport() {
-        return performanceReport;
+    @Override
+    public TradeStatsReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
+        final Num profitTradeCount = new NumberOfWinningTradesCriterion().calculate(series, tradingRecord);
+        final Num lossTradeCount = new NumberOfLosingTradesCriterion().calculate(series, tradingRecord);
+        final Num breakEvenTradeCount = new NumberOfBreakEvenTradesCriterion().calculate(series, tradingRecord);
+        return new TradeStatsReport(profitTradeCount, lossTradeCount, breakEvenTradeCount);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
@@ -21,31 +21,35 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
-import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
-import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.ProfitLossCriterion;
-import org.ta4j.core.analysis.criteria.ProfitLossPercentageCriterion;
-import org.ta4j.core.analysis.criteria.TotalLossCriterion;
-import org.ta4j.core.analysis.criteria.TotalProfitCriterion;
-import org.ta4j.core.num.Num;
 
 /**
- * This class generates PerformanceReport basis on provided trading report and
- * bar series
- *
- * @see PerformanceReport
+ * This class represents trading statement report which contains trade and
+ * performance statistics
  */
-public class PerformanceReportGenerator implements ReportGenerator<PerformanceReport> {
+public class TradingStatement {
 
-    @Override
-    public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
-        final Num totalProfitLoss = new ProfitLossCriterion().calculate(series, tradingRecord);
-        final Num totalProfitLossPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
-        final Num totalProfit = new TotalProfitCriterion().calculate(series, tradingRecord);
-        final Num totalLoss = new TotalLossCriterion().calculate(series, tradingRecord);
-        return new PerformanceReport(totalProfitLoss, totalProfitLossPercentage, totalProfit, totalLoss);
+    private final Strategy strategy;
+    private final TradeStatsReport tradeStatsReport;
+    private final PerformanceReport performanceReport;
+
+    public TradingStatement(Strategy strategy, TradeStatsReport tradeStatsReport, PerformanceReport performanceReport) {
+        this.strategy = strategy;
+        this.tradeStatsReport = tradeStatsReport;
+        this.performanceReport = performanceReport;
+    }
+
+    public Strategy getStrategy() {
+        return strategy;
+    }
+
+    public TradeStatsReport getTradeStatsReport() {
+        return tradeStatsReport;
+    }
+
+    public PerformanceReport getPerformanceReport() {
+        return performanceReport;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
@@ -21,29 +21,39 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
+package org.ta4j.core.reports;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.criteria.NumberOfBreakEvenTradesCriterion;
-import org.ta4j.core.analysis.criteria.NumberOfLosingTradesCriterion;
-import org.ta4j.core.analysis.criteria.NumberOfWinningTradesCriterion;
-import org.ta4j.core.num.Num;
 
 /**
- * This class generates TradeStatsReport basis on provided trading report and
- * bar series.
+ * This class generates TradingStatement basis on provided trading report and
+ * bar series
  *
- * @see TradeStatsReport
+ * @see TradingStatement
  */
-public class TradeStatsReportGenerator implements ReportGenerator<TradeStatsReport> {
+public class TradingStatementGenerator implements ReportGenerator<TradingStatement> {
+
+    private final PerformanceReportGenerator performanceReportGenerator;
+    private final TradeStatsReportGenerator tradeStatsReportGenerator;
+
+    public TradingStatementGenerator() {
+        this(new PerformanceReportGenerator(), new TradeStatsReportGenerator());
+    }
+
+    public TradingStatementGenerator(PerformanceReportGenerator performanceReportGenerator,
+            TradeStatsReportGenerator tradeStatsReportGenerator) {
+        super();
+        this.performanceReportGenerator = performanceReportGenerator;
+        this.tradeStatsReportGenerator = tradeStatsReportGenerator;
+    }
 
     @Override
-    public TradeStatsReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
-        final Num profitTradeCount = new NumberOfWinningTradesCriterion().calculate(series, tradingRecord);
-        final Num lossTradeCount = new NumberOfLosingTradesCriterion().calculate(series, tradingRecord);
-        final Num breakEvenTradeCount = new NumberOfBreakEvenTradesCriterion().calculate(series, tradingRecord);
-        return new TradeStatsReport(profitTradeCount, lossTradeCount, breakEvenTradeCount);
+    public TradingStatement generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
+        final PerformanceReport performanceReport = performanceReportGenerator.generate(strategy, tradingRecord,
+                series);
+        final TradeStatsReport tradeStatsReport = tradeStatsReportGenerator.generate(strategy, tradingRecord, series);
+        return new TradingStatement(strategy, tradeStatsReport, performanceReport);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
@@ -21,41 +21,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.tradereport;
-
-import org.ta4j.core.num.Num;
-
 /**
- * This class represents report which contains performance statistics
+ * The main module for trade reports
+ *
  */
-public class PerformanceReport {
-
-    private final Num totalProfitLoss;
-    private final Num totalProfitLossPercentage;
-    private final Num totalProfit;
-    private final Num totalLoss;
-
-    public PerformanceReport(Num totalProfitLoss, Num totalProfitLossPercentage, Num totalProfit, Num totalLoss) {
-        this.totalProfitLoss = totalProfitLoss;
-        this.totalProfitLossPercentage = totalProfitLossPercentage;
-        this.totalProfit = totalProfit;
-        this.totalLoss = totalLoss;
-    }
-
-    public Num getTotalProfitLoss() {
-        return totalProfitLoss;
-    }
-
-    public Num getTotalProfitLossPercentage() {
-        return totalProfitLossPercentage;
-    }
-
-    public Num getTotalProfit() {
-        return totalProfit;
-    }
-
-    public Num getTotalLoss() {
-        return totalLoss;
-    }
-
-}
+package org.ta4j.core.reports;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- **Breaking:** package "tradereports" renamed to "reports" (no need for redundant word _trade_, ta4j is all about trading and it fits to the actual naming schema (we also don't say trade**analysis** or trading**indicators**,trading**costs**,..)


- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
