### PR TITLE
Added Num#between() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **ProfitLossPercentageCriterion**: Changed to calculate trade profits using Trade's entry and exit prices.
 - **TotalLossCriterion**: Changed to calculate trade profits using Trade's getProfit().
 - **TotalReturnCriterion** (previously TotalProfitCriterion): Changed to calculate trade profits using Trade's getProfit().
-- **WMAIndicator**: reduced complexity of WMAIndicator implementation
+- **InPipeRule**: reduced complexity by using Num.isBetween()
+- **InSlopeRule**: reduced complexity by using Num.isBetween()
 
 ### Removed/Deprecated
 - **MultiplierIndicator**: replaced by TransformIndicator.
@@ -63,6 +64,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added convertBarSeries(BarSeries, conversionFunction) to BarSeriesUtils.
 - :tada: **Enhancement** added UnstableIndicator.
 - :tada: **Enhancement** added Chainrule.
+- :tada: **Enhancement** added Num#isBetween() to test the Num if it is between a range.
 
 
 ## 0.13 (released November 5, 2019)

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -231,6 +231,36 @@ public interface Num extends Comparable<Num>, Serializable {
     boolean isLessThanOrEqual(Num other);
 
     /**
+     * Checks if this value is between <code>start</code> (inclusive) and
+     * <code>end</code> (inclusive).
+     * 
+     * @param start the start value, not null
+     * @param end   the end value, not null
+     * @return true if this value is between start and end.
+     */
+    default boolean isBetween(Num start, Num end) {
+        return isBetween(start, end, true, true);
+    }
+
+    /**
+     * Checks if this value is between <code>start</code> and <code>end</code>.
+     * 
+     * @param start          the start value, not null
+     * @param end            the end value, not null
+     * @param startInclusive if this value should include start
+     * @param endInclusive   if this value should include end
+     * @return true if number is between start and end
+     */
+    default boolean isBetween(Num start, Num end, boolean startInclusive, boolean endInclusive) {
+        if (start == null || end == null || start.isNaN() || end.isNaN()) {
+            return false;
+        }
+        boolean starts = startInclusive ? isGreaterThanOrEqual(start) : isGreaterThan(start);
+        boolean ends = endInclusive ? isLessThanOrEqual(end) : isLessThan(end);
+        return starts && ends;
+    }
+
+    /**
      * Returns the minimum of this {@code num} and {@code other}.
      * 
      * @param other value with which the minimum is to be computed

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/InPipeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/InPipeRule.java
@@ -81,8 +81,7 @@ public class InPipeRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = ref.getValue(index).isLessThanOrEqual(upper.getValue(index))
-                && ref.getValue(index).isGreaterThanOrEqual(lower.getValue(index));
+        final boolean satisfied = ref.getValue(index).isBetween(lower.getValue(index), upper.getValue(index));
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/trading/rules/InSlopeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/trading/rules/InSlopeRule.java
@@ -106,11 +106,8 @@ public class InSlopeRule extends AbstractRule {
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         DifferenceIndicator diff = new DifferenceIndicator(ref, prev);
         Num val = diff.getValue(index);
-        boolean minSlopeSatisfied = minSlope.isNaN() || val.isGreaterThanOrEqual(minSlope);
-        boolean maxSlopeSatisfied = maxSlope.isNaN() || val.isLessThanOrEqual(maxSlope);
         boolean isNaN = minSlope.isNaN() && maxSlope.isNaN();
-
-        final boolean satisfied = minSlopeSatisfied && maxSlopeSatisfied && !isNaN;
+        final boolean satisfied = !isNaN && (minSlope.isNaN() || maxSlope.isNaN() || val.isBetween(minSlope, maxSlope));
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -331,6 +331,7 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         assertFalse(val.isBetween(NaN, NaN));
         assertFalse(val.isBetween(null, NaN));
         assertFalse(val.isBetween(NaN, null));
+        assertFalse(val.isBetween(null, null));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -312,5 +312,23 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         Num sqrt = numOf(numBD).sqrt();
         assertNumEquals("547722.55750516611345696978280080", sqrt);
     }
+    
+    @Test
+    public void isBetween() {
+        Num val = numOf(BigDecimal.valueOf(1.33));
+        Num start1 = numOf(BigDecimal.valueOf(1.32));
+        Num start2 = numOf(BigDecimal.valueOf(1.33));
+        Num end1 = numOf(BigDecimal.valueOf(1.33));
+        Num end2 = numOf(BigDecimal.valueOf(1.34));
+        assertTrue(val.isBetween(start1, end1));
+        assertTrue(val.isBetween(start2, end1));
+        assertTrue(val.isBetween(start2, end2));
+        assertFalse(val.isBetween(start2, end2, false, true));
+        assertTrue(val.isBetween(start2, end2, true, false));
+        assertFalse(val.isBetween(NaN, end2, false, false));
+        assertFalse(val.isBetween(start1, NaN, false, false));
+        assertFalse(val.isBetween(NaN, NaN, false, false));
+        assertFalse(val.isBetween(NaN, NaN));
+    }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -329,6 +329,8 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         assertFalse(val.isBetween(start1, NaN, false, false));
         assertFalse(val.isBetween(NaN, NaN, false, false));
         assertFalse(val.isBetween(NaN, NaN));
+        assertFalse(val.isBetween(null, NaN));
+        assertFalse(val.isBetween(NaN, null));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -312,7 +312,7 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         Num sqrt = numOf(numBD).sqrt();
         assertNumEquals("547722.55750516611345696978280080", sqrt);
     }
-    
+
     @Test
     public void isBetween() {
         Num val = numOf(BigDecimal.valueOf(1.33));

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/InSlopeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/InSlopeRuleTest.java
@@ -49,7 +49,7 @@ public class InSlopeRuleTest {
         Indicator<Num> indicator = new FixedDecimalIndicator(series, 50, 70, 80, 90, 99, 60, 30, 20, 10, 0);
         rulePositiveSlope = new InSlopeRule(indicator, series.numOf(20), series.numOf(30));
         ruleNegativeSlope = new InSlopeRule(indicator, series.numOf(-40), series.numOf(-20));
-        
+
         ruleSlopeNaN = new InSlopeRule(indicator, NaN.NaN, NaN.NaN);
         rulePositiveSlopeNaN = new InSlopeRule(indicator, NaN.NaN, series.numOf(30));
         ruleNegativeSlopeNaN = new InSlopeRule(indicator, series.numOf(-40), NaN.NaN);
@@ -66,17 +66,17 @@ public class InSlopeRuleTest {
         assertFalse(ruleNegativeSlope.isSatisfied(1));
         assertTrue(ruleNegativeSlope.isSatisfied(5));
         assertFalse(ruleNegativeSlope.isSatisfied(9));
-        
+
         assertFalse(ruleSlopeNaN.isSatisfied(0));
         assertFalse(ruleSlopeNaN.isSatisfied(1));
         assertFalse(ruleSlopeNaN.isSatisfied(5));
         assertFalse(ruleSlopeNaN.isSatisfied(9));
-        
+
         assertTrue(rulePositiveSlopeNaN.isSatisfied(0));
         assertTrue(rulePositiveSlopeNaN.isSatisfied(1));
         assertTrue(rulePositiveSlopeNaN.isSatisfied(2));
         assertTrue(rulePositiveSlopeNaN.isSatisfied(9));
-        
+
         assertTrue(ruleNegativeSlopeNaN.isSatisfied(0));
         assertTrue(ruleNegativeSlopeNaN.isSatisfied(1));
         assertTrue(ruleNegativeSlopeNaN.isSatisfied(5));

--- a/ta4j-core/src/test/java/org/ta4j/core/trading/rules/InSlopeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/trading/rules/InSlopeRuleTest.java
@@ -32,12 +32,16 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 public class InSlopeRuleTest {
 
     private InSlopeRule rulePositiveSlope;
     private InSlopeRule ruleNegativeSlope;
+    private InSlopeRule ruleSlopeNaN;
+    private InSlopeRule rulePositiveSlopeNaN;
+    private InSlopeRule ruleNegativeSlopeNaN;
 
     @Before
     public void setUp() {
@@ -45,6 +49,10 @@ public class InSlopeRuleTest {
         Indicator<Num> indicator = new FixedDecimalIndicator(series, 50, 70, 80, 90, 99, 60, 30, 20, 10, 0);
         rulePositiveSlope = new InSlopeRule(indicator, series.numOf(20), series.numOf(30));
         ruleNegativeSlope = new InSlopeRule(indicator, series.numOf(-40), series.numOf(-20));
+        
+        ruleSlopeNaN = new InSlopeRule(indicator, NaN.NaN, NaN.NaN);
+        rulePositiveSlopeNaN = new InSlopeRule(indicator, NaN.NaN, series.numOf(30));
+        ruleNegativeSlopeNaN = new InSlopeRule(indicator, series.numOf(-40), NaN.NaN);
     }
 
     @Test
@@ -58,5 +66,20 @@ public class InSlopeRuleTest {
         assertFalse(ruleNegativeSlope.isSatisfied(1));
         assertTrue(ruleNegativeSlope.isSatisfied(5));
         assertFalse(ruleNegativeSlope.isSatisfied(9));
+        
+        assertFalse(ruleSlopeNaN.isSatisfied(0));
+        assertFalse(ruleSlopeNaN.isSatisfied(1));
+        assertFalse(ruleSlopeNaN.isSatisfied(5));
+        assertFalse(ruleSlopeNaN.isSatisfied(9));
+        
+        assertTrue(rulePositiveSlopeNaN.isSatisfied(0));
+        assertTrue(rulePositiveSlopeNaN.isSatisfied(1));
+        assertTrue(rulePositiveSlopeNaN.isSatisfied(2));
+        assertTrue(rulePositiveSlopeNaN.isSatisfied(9));
+        
+        assertTrue(ruleNegativeSlopeNaN.isSatisfied(0));
+        assertTrue(ruleNegativeSlopeNaN.isSatisfied(1));
+        assertTrue(ruleNegativeSlopeNaN.isSatisfied(5));
+        assertTrue(ruleNegativeSlopeNaN.isSatisfied(9));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- :tada: **Enhancement** added Num#isBetween() to test the Num if it is between a range
- **InPipeRule**: reduced complexity by using Num.isBetween()
- **InSlopeRule**: reduced complexity by using Num.isBetween()
- **InSlopeRule**: more unit tests to test against NaN

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

Would be nice to add `Num#isBetween()`. Other (future) indicators or (future) rules can use this common method instead of duplication code and tests. The `isBetween()`-method is bullet proof and checks agains all kinds of `Null` or `NaN` (which is currently not the case within the above rules, I have thus added more unit tests for that). 

I will **not** add any other methods within Num in future, as we really should keep it sleek. However, `isBetween()` is the missing link between isGt and isLt. Other indicators and rules can make use of it, if they need such a check. We could also look for current indicators or rules which has such a check and replace the code by using `isBetween()`.
