### PR TITLE
Feature/recursive sma indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Added
 - :tada: **Enhancement** Loggers in `BaseBarSeries` and `BarSeriesManager` made static for better performance.
+- :tada: **RecursiveSMAIndicator**: New indicator for faster SMA calculation
 
 ### Removed/Deprecated
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Order.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Order.java
@@ -132,10 +132,10 @@ public class Order implements Serializable {
     /**
      * Constructor.
      * 
-     * @param index  the index the order is executed
-     * @param series the bar series
-     * @param type   the type of the order
-     * @param amount the amount to be (or that was) ordered
+     * @param index                the index the order is executed
+     * @param series               the bar series
+     * @param type                 the type of the order
+     * @param amount               the amount to be (or that was) ordered
      * @param transactionCostModel the cost model for order execution cost
      */
     protected Order(int index, BarSeries series, OrderType type, Num amount, CostModel transactionCostModel) {
@@ -275,15 +275,15 @@ public class Order implements Serializable {
     }
 
     @Override
-	  public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null || getClass() != obj.getClass()) return false;
-		final Order other = (Order) obj;
-		return Objects.equals(type, other.type) 
-			&& Objects.equals(index, other.index)
-			&& Objects.equals(pricePerAsset, other.pricePerAsset) 
-			&& Objects.equals(amount, other.amount);
-	  }
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        final Order other = (Order) obj;
+        return Objects.equals(type, other.type) && Objects.equals(index, other.index)
+                && Objects.equals(pricePerAsset, other.pricePerAsset) && Objects.equals(amount, other.amount);
+    }
 
     @Override
     public String toString() {
@@ -300,9 +300,9 @@ public class Order implements Serializable {
     }
 
     /**
-     * @param index  the index the order is executed
-     * @param price  the price for the order
-     * @param amount the amount to be (or that was) bought
+     * @param index                the index the order is executed
+     * @param price                the price for the order
+     * @param amount               the amount to be (or that was) bought
      * @param transactionCostModel the cost model for order execution
      * @return a BUY order
      */
@@ -331,9 +331,9 @@ public class Order implements Serializable {
     }
 
     /**
-     * @param index  the index the order is executed
-     * @param series the bar series
-     * @param amount the amount to be (or that was) bought
+     * @param index                the index the order is executed
+     * @param series               the bar series
+     * @param amount               the amount to be (or that was) bought
      * @param transactionCostModel the cost model for order execution
      * @return a BUY order
      */
@@ -361,9 +361,9 @@ public class Order implements Serializable {
     }
 
     /**
-     * @param index  the index the order is executed
-     * @param price  the price for the order
-     * @param amount the amount to be (or that was) sold
+     * @param index                the index the order is executed
+     * @param price                the price for the order
+     * @param amount               the amount to be (or that was) sold
      * @param transactionCostModel the cost model for order execution
      * @return a SELL order
      */
@@ -382,9 +382,9 @@ public class Order implements Serializable {
     }
 
     /**
-     * @param index  the index the order is executed
-     * @param series the bar series
-     * @param amount the amount to be (or that was) bought
+     * @param index                the index the order is executed
+     * @param series               the bar series
+     * @param amount               the amount to be (or that was) bought
      * @param transactionCostModel the cost model for order execution
      * @return a SELL order
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveSMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveSMAIndicator.java
@@ -27,12 +27,13 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.num.Num;
 
 /**
- * Faster implementation of the simple moving average (SMA) indicator. It recursively calculates
- * the current value using only the previous value. The decreased complexity allows for broad
- * applications, even for very long timeframes.
+ * Faster implementation of the simple moving average (SMA) indicator. It
+ * recursively calculates the current value using only the previous value. The
+ * decreased complexity allows for broad applications, even for very long
+ * timeframes.
  *
  * @see <a href=
- * "https://de.wikipedia.org/wiki/Gleitender_Mittelwert#Online-Berechnung">https://de.wikipedia.org/wiki/Gleitender_Mittelwert#Online-Berechnung</a>
+ *      "https://de.wikipedia.org/wiki/Gleitender_Mittelwert#Online-Berechnung">https://de.wikipedia.org/wiki/Gleitender_Mittelwert#Online-Berechnung</a>
  * @see SMAIndicator
  */
 public class RecursiveSMAIndicator extends CachedIndicator<Num> {
@@ -46,8 +47,9 @@ public class RecursiveSMAIndicator extends CachedIndicator<Num> {
     /**
      * @param indicator          the indicator
      * @param barCount           the timeframe
-     * @param fullRecalcBarCount number of bars in the time series after which a full recalculation
-     *                           using the standard SMA algorithm should be performed in order to to account for
+     * @param fullRecalcBarCount number of bars in the time series after which a
+     *                           full recalculation using the standard SMA algorithm
+     *                           should be performed in order to to account for
      *                           prevent accumulated rounding errors.
      */
     public RecursiveSMAIndicator(Indicator<Num> indicator, int barCount, int fullRecalcBarCount) {
@@ -62,15 +64,14 @@ public class RecursiveSMAIndicator extends CachedIndicator<Num> {
         if (barCount > index || index % fullRecalcBarCount == 0) {
             return calculateFull(index);
         } else {
-            return getValue(index - 1)
-                    .plus(indicator.getValue(index).dividedBy(numOf(barCount)))
+            return getValue(index - 1).plus(indicator.getValue(index).dividedBy(numOf(barCount)))
                     .minus(indicator.getValue(index - barCount).dividedBy(numOf(barCount)));
         }
     }
 
     /**
-     * This method encapsulates the standard SMA implementation.
-     * Performs a full recalculation using all bars of the time frame.
+     * This method encapsulates the standard SMA implementation. Performs a full
+     * recalculation using all bars of the time frame.
      *
      * @see SMAIndicator#calculate(int)
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveSMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveSMAIndicator.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- * <p>
+ *
  * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
  * authors (see AUTHORS)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -51,6 +51,7 @@ public class CloseLocationValueIndicator extends CachedIndicator<Num> {
 
         final Num diffHighLow = high.minus(low);
 
-        return (diffHighLow.isNaN() || diffHighLow.isZero()) ? zero : ((close.minus(low)).minus(high.minus(close))).dividedBy(diffHighLow);
+        return (diffHighLow.isNaN() || diffHighLow.isZero()) ? zero
+                : ((close.minus(low)).minus(high.minus(close))).dividedBy(diffHighLow);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -79,7 +79,7 @@ public class DoubleNum implements Num {
 
     @Override
     public String getName() {
-    	return this.getClass().getSimpleName();
+        return this.getClass().getSimpleName();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/PrecisionNum.java
@@ -551,7 +551,7 @@ public final class PrecisionNum implements Num {
      */
     @Override
     public boolean isPositiveOrZero() {
-    	return delegate.signum() >= 0;
+        return delegate.signum() >= 0;
     }
 
     /**
@@ -561,7 +561,7 @@ public final class PrecisionNum implements Num {
      */
     @Override
     public boolean isNegative() {
-    	return delegate.signum() < 0;
+        return delegate.signum() < 0;
     }
 
     /**
@@ -571,7 +571,7 @@ public final class PrecisionNum implements Num {
      */
     @Override
     public boolean isNegativeOrZero() {
-    	return delegate.signum() <= 0;
+        return delegate.signum() <= 0;
     }
 
     /**

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -47,7 +47,7 @@ public class TestUtils {
     /**
      * Verifies that the actual {@code Num} value is not equal to {@link NaN}.
      *
-     * @param actual   the actual {@code Num} value
+     * @param actual the actual {@code Num} value
      * @throws AssertionError if the actual value is equal to {@link NaN}
      */
     public static void assertNotNaN(Num actual) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecursiveSMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecursiveSMAIndicatorTest.java
@@ -38,7 +38,6 @@ import java.util.function.Function;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-
 public class RecursiveSMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
     private BarSeries data;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecursiveSMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecursiveSMAIndicatorTest.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- * <p>
+ *
  * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
  * authors (see AUTHORS)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
@@ -34,10 +34,10 @@ public class DoubleNumTest {
     public void testEqualsDoubleNumWithPrecisionNum() {
         final PrecisionNum precisionNum = PrecisionNum.valueOf(3.0);
         final DoubleNum doubleNum = DoubleNum.valueOf(3.0);
-        
+
         assertFalse(doubleNum.equals(precisionNum));
     }
-    
+
     @Test
     public void testZeroEquals() {
         final Num num1 = DoubleNum.valueOf(-0.0);


### PR DESCRIPTION
Changes proposed in this pull request:
- **RecursiveSMAIndicator**: New indicator for faster SMA calculation
The current SMA implementation is very slow when calculated for large timeframes (>10,000 bars). This change introduces a new, recursive implementation for the SMA using this algorithm:
![image](https://user-images.githubusercontent.com/6397462/107441777-22222080-6b36-11eb-9c11-1aa502de3cde.png)
Source: https://de.wikipedia.org/wiki/Gleitender_Mittelwert#Online-Berechnung (only available in the german wikipedia)
Tests for proving equality to the SMAIndicator and comparing performance are provided.

- [X] added an entry to the unreleased section of `CHANGELOG.md` 
