### PR TITLE
Added criterions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`GrossLossCriterion.class`**.
 - :tada: **Enhancement** added **`NetProfitCriterion.class`**.
 - :tada: **Enhancement** added chooseBest() method with parameter tradeType in AnalysisCriterion.
+- :tada: **Enhancement** added **`AverageLossCriterion.class`**.
+- :tada: **Enhancement** added **`AverageProfitCriterion.class`**.
+- :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
+- :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
+- :tada: **Enhancement** added **`NumberOfConsecutiveWinningPositionsCriterion.class`**.
 
 
 ## 0.13 (released November 5, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`AverageProfitCriterion.class`**.
 - :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
 - :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
-- :tada: **Enhancement** added **`NumberOfConsecutiveWinningPositionsCriterion.class`**.
+- :tada: **Enhancement** added **`ConsecutiveWinningPositionsCriterion.class`**.
 
 
 ## 0.13 (released November 5, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
 - :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
 - :tada: **Enhancement** added **`ConsecutiveWinningPositionsCriterion.class`**.
-- :tada: **Enhancement** added Position#isWinning.
-- :tada: **Enhancement** added Position#isLosing.
+- :tada: **Enhancement** added Position#hasProfit.
+- :tada: **Enhancement** added Position#hasLoss.
 
 
 ## 0.13 (released November 5, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
 - :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
 - :tada: **Enhancement** added **`ConsecutiveWinningPositionsCriterion.class`**.
+- :tada: **Enhancement** added Position#isWinning.
+- :tada: **Enhancement** added Position#isLosing.
 
 
 ## 0.13 (released November 5, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
 - :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
 - :tada: **Enhancement** added **`ConsecutiveWinningPositionsCriterion.class`**.
+- :tada: **Enhancement** added **`LosingPositionsRatioCriterion.class`**
 - :tada: **Enhancement** added Position#hasProfit.
 - :tada: **Enhancement** added Position#hasLoss.
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -220,14 +220,14 @@ public class Position implements Serializable {
      * @return true if position is closed and {@link #getProfit()} > 0
      */
     public boolean hasProfit() {
-        return isClosed() ? getProfit().isPositive() : false;
+        return getProfit().isPositive();
     }
 
     /**
      * @return true if position is closed and {@link #getProfit()} < 0
      */
     public boolean hasLoss() {
-        return isClosed() ? getProfit().isNegative() : false;
+        return getProfit().isNegative();
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -219,7 +219,7 @@ public class Position implements Serializable {
     /**
      * @return true if position is closed and {@link #getProfit()} > 0
      */
-    public boolean isWinning() {
+    public boolean hasProfit() {
         if (isClosed()) {
             return getProfit().isPositive();
         }
@@ -229,7 +229,7 @@ public class Position implements Serializable {
     /**
      * @return true if position is closed and {@link #getProfit()} < 0
      */
-    public boolean isLosing() {
+    public boolean hasLoss() {
         if (isClosed()) {
             return getProfit().isNegative();
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -215,7 +215,7 @@ public class Position implements Serializable {
     public String toString() {
         return "Entry: " + entry + " exit: " + exit;
     }
-    
+
     /**
      * @return true if position is closed and {@link #getProfit()} > 0
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -220,20 +220,14 @@ public class Position implements Serializable {
      * @return true if position is closed and {@link #getProfit()} > 0
      */
     public boolean hasProfit() {
-        if (isClosed()) {
-            return getProfit().isPositive();
-        }
-        return false;
+        return isClosed() ? getProfit().isPositive() : false;
     }
 
     /**
      * @return true if position is closed and {@link #getProfit()} < 0
      */
     public boolean hasLoss() {
-        if (isClosed()) {
-            return getProfit().isNegative();
-        }
-        return false;
+        return isClosed() ? getProfit().isNegative() : false;
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -215,6 +215,26 @@ public class Position implements Serializable {
     public String toString() {
         return "Entry: " + entry + " exit: " + exit;
     }
+    
+    /**
+     * @return true if position is closed and {@link #getProfit()} > 0
+     */
+    public boolean isWinning() {
+        if (isClosed()) {
+            return getProfit().isPositive();
+        }
+        return false;
+    }
+
+    /**
+     * @return true if position is closed and {@link #getProfit()} < 0
+     */
+    public boolean isLosing() {
+        if (isClosed()) {
+            return getProfit().isNegative();
+        }
+        return false;
+    }
 
     /**
      * Calculate the profit of the position if it is closed

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/AverageReturnPerBarCriterion.java
@@ -43,16 +43,6 @@ public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
     private AnalysisCriterion numberOfBars = new NumberOfBarsCriterion();
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Num bars = numberOfBars.calculate(series, tradingRecord);
-        if (bars.isEqual(series.numOf(0))) {
-            return series.numOf(1);
-        }
-
-        return grossReturn.calculate(series, tradingRecord).pow(series.numOf(1).dividedBy(bars));
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         Num bars = numberOfBars.calculate(series, position);
         if (bars.isEqual(series.numOf(0))) {
@@ -60,6 +50,16 @@ public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
         }
 
         return grossReturn.calculate(series, position).pow(series.numOf(1).dividedBy(bars));
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num bars = numberOfBars.calculate(series, tradingRecord);
+        if (bars.isEqual(series.numOf(0))) {
+            return series.numOf(1);
+        }
+
+        return grossReturn.calculate(series, tradingRecord).pow(series.numOf(1).dividedBy(bars));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/BuyAndHoldReturnCriterion.java
@@ -41,14 +41,14 @@ import org.ta4j.core.num.Num;
 public class BuyAndHoldReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return createBuyAndHoldTrade(series).getGrossReturn(series);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         return createBuyAndHoldTrade(series, position.getEntry().getIndex(), position.getExit().getIndex())
                 .getGrossReturn(series);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return createBuyAndHoldTrade(series).getGrossReturn(series);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
@@ -1,0 +1,58 @@
+package org.ta4j.core.analysis.criteria;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.pnl.ProfitLossRatioCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Expectancy criterion (Kelly Criterion).
+ *
+ * Measures the positive or negative expectancy. The higher the positive number,
+ * the better a winning expectation. A negative number means there is only
+ * losing expectations.
+ *
+ * @see <a href=
+ *      "https://www.straightforex.com/advanced-forex-course/money-management/two-important-things-to-be-considered/</a>
+ *
+ */
+public class ExpectancyCriterion extends AbstractAnalysisCriterion {
+
+    private ProfitLossRatioCriterion profitLossRatioCriterion = new ProfitLossRatioCriterion();
+    private NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
+    private NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num profitLossRatio = profitLossRatioCriterion.calculate(series, tradingRecord);
+        Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
+        return calculate(series, profitLossRatio, numberOfWinningPositions, numberOfPositions);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        Num profitLossRatio = profitLossRatioCriterion.calculate(series, position);
+        Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, position);
+        return calculate(series, profitLossRatio, numberOfWinningPositions, numberOfPositions);
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    private Num calculate(BarSeries series, Num profitLossRatio, Num numberOfWinningPositions,
+            Num numberOfAllPositions) {
+        Num one = series.numOf(1);
+        if (numberOfAllPositions.isZero() || profitLossRatio.isZero()) {
+            return series.numOf(0);
+        }
+        // Expectancy = (1 + AW/AL) * (ProbabilityToWinOnePosition - 1)
+        Num probabiltyToWinOnePosition = numberOfWinningPositions.dividedBy(numberOfAllPositions);
+        return (one.plus(profitLossRatio)).multipliedBy((probabiltyToWinOnePosition).minus(one));
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria;
 
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectancyCriterion.java
@@ -47,18 +47,18 @@ public class ExpectancyCriterion extends AbstractAnalysisCriterion {
     private NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Num profitLossRatio = profitLossRatioCriterion.calculate(series, tradingRecord);
-        Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
-        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
-        return calculate(series, profitLossRatio, numberOfWinningPositions, numberOfPositions);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         Num profitLossRatio = profitLossRatioCriterion.calculate(series, position);
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
         Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, position);
+        return calculate(series, profitLossRatio, numberOfWinningPositions, numberOfPositions);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num profitLossRatio = profitLossRatioCriterion.calculate(series, tradingRecord);
+        Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
         return calculate(series, profitLossRatio, numberOfWinningPositions, numberOfPositions);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterion.java
@@ -57,18 +57,18 @@ public class ExpectedShortfallCriterion extends AbstractAnalysisCriterion {
     }
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Returns returns = new Returns(series, tradingRecord, Returns.ReturnType.LOG);
-        return calculateES(returns, confidence);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position != null && position.getEntry() != null && position.getExit() != null) {
             Returns returns = new Returns(series, position, Returns.ReturnType.LOG);
             return calculateES(returns, confidence);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Returns returns = new Returns(series, tradingRecord, Returns.ReturnType.LOG);
+        return calculateES(returns, confidence);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LosingPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/LosingPositionsRatioCriterion.java
@@ -35,15 +35,18 @@ import org.ta4j.core.num.Num;
  */
 public class LosingPositionsRatioCriterion extends AbstractAnalysisCriterion {
 
+    private NumberOfLosingPositionsCriterion numberOfLosingPositionsCriterion = new NumberOfLosingPositionsCriterion();
+
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return position.hasLoss() ? series.numOf(1) : series.numOf(0);
+        return numberOfLosingPositionsCriterion.calculate(series, position);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfLossPositions = tradingRecord.getPositions().stream().filter(Position::hasLoss).count();
-        return series.numOf(numberOfLossPositions).dividedBy(series.numOf(tradingRecord.getPositionCount()));
+        Num numberOfLosingPositions = numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
+        numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
+        return numberOfLosingPositions.dividedBy(series.numOf(tradingRecord.getPositionCount()));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/MaximumDrawdownCriterion.java
@@ -38,18 +38,18 @@ import org.ta4j.core.num.Num;
 public class MaximumDrawdownCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        CashFlow cashFlow = new CashFlow(series, tradingRecord);
-        return calculateMaximumDrawdown(series, cashFlow);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position != null && position.getEntry() != null && position.getExit() != null) {
             CashFlow cashFlow = new CashFlow(series, position);
             return calculateMaximumDrawdown(series, cashFlow);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        CashFlow cashFlow = new CashFlow(series, tradingRecord);
+        return calculateMaximumDrawdown(series, cashFlow);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
@@ -36,12 +36,6 @@ import org.ta4j.core.num.Num;
 public class NumberOfBarsCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed).map(t -> calculate(series, t))
-                .reduce(series.numOf(0), Num::plus);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             final int exitIndex = position.getExit().getIndex();
@@ -49,6 +43,12 @@ public class NumberOfBarsCriterion extends AbstractAnalysisCriterion {
             return series.numOf(exitIndex - entryIndex + 1);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed).map(t -> calculate(series, t))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
@@ -34,6 +34,11 @@ import org.ta4j.core.num.Num;
 public class NumberOfBreakEvenPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
+    public Num calculate(BarSeries series, Position position) {
+        return isBreakEvenTrade(position) ? series.numOf(1) : series.numOf(0);
+    }
+
+    @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfBreakEvenTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
                 .filter(this::isBreakEvenTrade).count();
@@ -45,11 +50,6 @@ public class NumberOfBreakEvenPositionsCriterion extends AbstractAnalysisCriteri
             return position.getProfit().isZero();
         }
         return false;
-    }
-
-    @Override
-    public Num calculate(BarSeries series, Position position) {
-        return isBreakEvenTrade(position) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterion.java
@@ -34,6 +34,11 @@ import org.ta4j.core.num.Num;
 public class NumberOfConsecutiveWinningPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
+    public Num calculate(BarSeries series, Position position) {
+        return isWinningPosition(position) ? series.numOf(1) : series.numOf(0);
+    }
+
+    @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         int maxConsecutiveWins = 0;
         int consecutiveWins = 0;
@@ -54,11 +59,6 @@ public class NumberOfConsecutiveWinningPositionsCriterion extends AbstractAnalys
         }
 
         return series.numOf(maxConsecutiveWins);
-    }
-
-    @Override
-    public Num calculate(BarSeries series, Position position) {
-        return isWinningPosition(position) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterion.java
@@ -48,7 +48,7 @@ public class NumberOfConsecutiveWinningPositionsCriterion extends AbstractAnalys
             }
         }
 
-        // in case all positions are wining positions
+        // in case all positions are winning positions
         if (maxConsecutiveWins < consecutiveWins) {
             maxConsecutiveWins = consecutiveWins;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
@@ -36,13 +36,13 @@ public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(Position::isLosing).count();
+                .filter(Position::hasLoss).count();
         return series.numOf(numberOfLosingPositions);
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return position.isLosing() ? series.numOf(1) : series.numOf(0);
+        return position.hasLoss() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
@@ -29,20 +29,20 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Number of losing position criterion.
+ * Number of losing positions criterion.
  */
 public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isLosingPosition).count();
+                .filter(Position::isLosing).count();
         return series.numOf(numberOfLosingPositions);
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return isLosingPosition(position) ? series.numOf(1) : series.numOf(0);
+        return position.isLosing() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override
@@ -50,10 +50,4 @@ public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion 
         return criterionValue1.isLessThan(criterionValue2);
     }
 
-    private boolean isLosingPosition(Position position) {
-        if (position.isClosed()) {
-            return position.getProfit().isNegative();
-        }
-        return false;
-    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
@@ -34,14 +34,14 @@ import org.ta4j.core.num.Num;
 public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::hasLoss).count();
-        return series.numOf(numberOfLosingPositions);
+    public Num calculate(BarSeries series, Position position) {
+        return position.hasLoss() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override
-    public Num calculate(BarSeries series, Position position) {
-        return position.hasLoss() ? series.numOf(1) : series.numOf(0);
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::hasLoss).count();
+        return series.numOf(numberOfLosingPositions);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
@@ -29,14 +29,13 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Number of losing positions criterion.
+ * Number of closed losing positions criterion.
  */
 public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(Position::hasLoss).count();
+        long numberOfLosingPositions = tradingRecord.getPositions().stream().filter(Position::hasLoss).count();
         return series.numOf(numberOfLosingPositions);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfPositionsCriterion.java
@@ -34,13 +34,13 @@ import org.ta4j.core.num.Num;
 public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return series.numOf(tradingRecord.getPositionCount());
+    public Num calculate(BarSeries series, Position position) {
+        return series.numOf(1);
     }
 
     @Override
-    public Num calculate(BarSeries series, Position position) {
-        return series.numOf(1);
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return series.numOf(tradingRecord.getPositionCount());
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -36,14 +36,14 @@ public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(Position::isWinning).count();
+                .filter(Position::hasProfit).count();
         return series.numOf(numberOfWinningPositions);
     }
 
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return position.isWinning() ? series.numOf(1) : series.numOf(0);
+        return position.hasProfit() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -34,14 +34,14 @@ import org.ta4j.core.num.Num;
 public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::hasProfit).count();
-        return series.numOf(numberOfWinningPositions);
+    public Num calculate(BarSeries series, Position position) {
+        return position.hasProfit() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override
-    public Num calculate(BarSeries series, Position position) {
-        return position.hasProfit() ? series.numOf(1) : series.numOf(0);
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::hasProfit).count();
+        return series.numOf(numberOfWinningPositions);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -29,27 +29,21 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Number of winning position criterion.
+ * Number of winning positions criterion.
  */
 public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isWinningPositions).count();
+                .filter(Position::isWinning).count();
         return series.numOf(numberOfWinningPositions);
     }
 
-    private boolean isWinningPositions(Position position) {
-        if (position.isClosed()) {
-            return position.getProfit().isPositive();
-        }
-        return false;
-    }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return isWinningPositions(position) ? series.numOf(1) : series.numOf(0);
+        return position.isWinning() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -35,12 +35,12 @@ public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfWinningTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isWinningTrade).count();
-        return series.numOf(numberOfWinningTrades);
+        long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .filter(this::isWinningPositions).count();
+        return series.numOf(numberOfWinningPositions);
     }
 
-    private boolean isWinningTrade(Position position) {
+    private boolean isWinningPositions(Position position) {
         if (position.isClosed()) {
             return position.getProfit().isPositive();
         }
@@ -49,7 +49,7 @@ public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return isWinningTrade(position) ? series.numOf(1) : series.numOf(0);
+        return isWinningPositions(position) ? series.numOf(1) : series.numOf(0);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -40,7 +40,6 @@ public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion
         return series.numOf(numberOfWinningPositions);
     }
 
-
     @Override
     public Num calculate(BarSeries series, Position position) {
         return position.hasProfit() ? series.numOf(1) : series.numOf(0);

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -29,14 +29,13 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Number of winning positions criterion.
+ * Number of closed winning positions criterion.
  */
 public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(Position::hasProfit).count();
+        long numberOfWinningPositions = tradingRecord.getPositions().stream().filter(Position::hasProfit).count();
         return series.numOf(numberOfWinningPositions);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -41,6 +41,17 @@ public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
 
     @Override
+    public Num calculate(BarSeries series, Position position) {
+        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, position);
+        if (maxDrawdown.isZero()) {
+            return NaN.NaN;
+        } else {
+            final Num totalProfit = grossReturnCriterion.calculate(series, position);
+            return totalProfit.dividedBy(maxDrawdown);
+        }
+    }
+
+    @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         final Num maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
         if (maxDrawdown.isZero()) {
@@ -54,16 +65,5 @@ public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
-    }
-
-    @Override
-    public Num calculate(BarSeries series, Position position) {
-        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, position);
-        if (maxDrawdown.isZero()) {
-            return NaN.NaN;
-        } else {
-            final Num totalProfit = grossReturnCriterion.calculate(series, position);
-            return totalProfit.dividedBy(maxDrawdown);
-        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ValueAtRiskCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/ValueAtRiskCriterion.java
@@ -54,18 +54,18 @@ public class ValueAtRiskCriterion extends AbstractAnalysisCriterion {
     }
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Returns returns = new Returns(series, tradingRecord, Returns.ReturnType.LOG);
-        return calculateVaR(returns, confidence);
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position != null && position.isClosed()) {
             Returns returns = new Returns(series, position, Returns.ReturnType.LOG);
             return calculateVaR(returns, confidence);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Returns returns = new Returns(series, tradingRecord, Returns.ReturnType.LOG);
+        return calculateVaR(returns, confidence);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/VersusBuyAndHoldCriterion.java
@@ -50,21 +50,21 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
     }
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        TradingRecord fakeRecord = new BaseTradingRecord();
-        fakeRecord.enter(series.getBeginIndex());
-        fakeRecord.exit(series.getEndIndex());
-
-        return criterion.calculate(series, tradingRecord).dividedBy(criterion.calculate(series, fakeRecord));
-    }
-
-    @Override
     public Num calculate(BarSeries series, Position position) {
         TradingRecord fakeRecord = new BaseTradingRecord();
         fakeRecord.enter(series.getBeginIndex());
         fakeRecord.exit(series.getEndIndex());
 
         return criterion.calculate(series, position).dividedBy(criterion.calculate(series, fakeRecord));
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        TradingRecord fakeRecord = new BaseTradingRecord();
+        fakeRecord.enter(series.getBeginIndex());
+        fakeRecord.exit(series.getEndIndex());
+
+        return criterion.calculate(series, tradingRecord).dividedBy(criterion.calculate(series, fakeRecord));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
@@ -35,15 +35,17 @@ import org.ta4j.core.num.Num;
  */
 public class WinningPositionsRatioCriterion extends AbstractAnalysisCriterion {
 
+    private NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return position.hasProfit() ? series.numOf(1) : series.numOf(0);
+        return numberOfWinningPositionsCriterion.calculate(series, position);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfProfitPositions = tradingRecord.getPositions().stream().filter(Position::hasProfit).count();
-        return series.numOf(numberOfProfitPositions).dividedBy(series.numOf(tradingRecord.getPositionCount()));
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
+        return numberOfWinningPositions.dividedBy(series.numOf(tradingRecord.getPositionCount()));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
@@ -37,22 +37,13 @@ public class WinningPositionsRatioCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return isProfitablePosition(series, position) ? series.numOf(1) : series.numOf(0);
-    }
-
-    private boolean isProfitablePosition(BarSeries series, Position position) {
-        if (position.isClosed()) {
-            Num zero = series.numOf(0);
-            return position.getProfit().isGreaterThan(zero);
-        }
-        return false;
+        return position.hasProfit() ? series.numOf(1) : series.numOf(0);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfProfitable = tradingRecord.getPositions().stream().filter(t -> isProfitablePosition(series, t))
-                .count();
-        return series.numOf(numberOfProfitable).dividedBy(series.numOf(tradingRecord.getPositionCount()));
+        long numberOfProfitPositions = tradingRecord.getPositions().stream().filter(Position::hasProfit).count();
+        return series.numOf(numberOfProfitPositions).dividedBy(series.numOf(tradingRecord.getPositionCount()));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
@@ -1,0 +1,49 @@
+package org.ta4j.core.analysis.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.analysis.criteria.NumberOfLosingPositionsCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Average gross loss (with commissions).
+ */
+public class AverageLossCriterion extends AbstractAnalysisCriterion {
+
+    private NumberOfLosingPositionsCriterion numberOfLosingPositionsCriterion = new NumberOfLosingPositionsCriterion();
+    private GrossLossCriterion grossLossCriterion = new GrossLossCriterion();
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        Num numberOfLosingTrades = numberOfLosingPositionsCriterion.calculate(series, position);
+        if (numberOfLosingTrades.isZero()) {
+            return series.numOf(0);
+        }
+        Num grossLoss = grossLossCriterion.calculate(series, position);
+        if (grossLoss.isZero()) {
+            return series.numOf(0);
+        }
+        return grossLoss.dividedBy(numberOfLosingTrades);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num numberOfLosingTrades = numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
+        if (numberOfLosingTrades.isZero()) {
+            return series.numOf(0);
+        }
+        Num grossLoss = grossLossCriterion.calculate(series, tradingRecord);
+        if (grossLoss.isZero()) {
+            return series.numOf(0);
+        }
+        return grossLoss.dividedBy(numberOfLosingTrades);
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterion.java
@@ -40,28 +40,28 @@ public class AverageLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        Num numberOfLosingTrades = numberOfLosingPositionsCriterion.calculate(series, position);
-        if (numberOfLosingTrades.isZero()) {
+        Num numberOfLosingPositions = numberOfLosingPositionsCriterion.calculate(series, position);
+        if (numberOfLosingPositions.isZero()) {
             return series.numOf(0);
         }
         Num grossLoss = grossLossCriterion.calculate(series, position);
         if (grossLoss.isZero()) {
             return series.numOf(0);
         }
-        return grossLoss.dividedBy(numberOfLosingTrades);
+        return grossLoss.dividedBy(numberOfLosingPositions);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Num numberOfLosingTrades = numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
-        if (numberOfLosingTrades.isZero()) {
+        Num numberOfLosingPositions = numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
+        if (numberOfLosingPositions.isZero()) {
             return series.numOf(0);
         }
         Num grossLoss = grossLossCriterion.calculate(series, tradingRecord);
         if (grossLoss.isZero()) {
             return series.numOf(0);
         }
-        return grossLoss.dividedBy(numberOfLosingTrades);
+        return grossLoss.dividedBy(numberOfLosingPositions);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
@@ -40,28 +40,28 @@ public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        Num numberOfWinningTrades = numberOfWinningPositionsCriterion.calculate(series, position);
-        if (numberOfWinningTrades.isZero()) {
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, position);
+        if (numberOfWinningPositions.isZero()) {
             return series.numOf(0);
         }
         Num grossProfit = grossProfitCriterion.calculate(series, position);
         if (grossProfit.isZero()) {
             return series.numOf(0);
         }
-        return grossProfit.dividedBy(numberOfWinningTrades);
+        return grossProfit.dividedBy(numberOfWinningPositions);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        Num numberOfWinningTrades = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
-        if (numberOfWinningTrades.isZero()) {
+        Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
+        if (numberOfWinningPositions.isZero()) {
             return series.numOf(0);
         }
         Num grossProfit = grossProfitCriterion.calculate(series, tradingRecord);
         if (grossProfit.isZero()) {
             return series.numOf(0);
         }
-        return grossProfit.dividedBy(numberOfWinningTrades);
+        return grossProfit.dividedBy(numberOfWinningPositions);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
@@ -1,0 +1,49 @@
+package org.ta4j.core.analysis.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.analysis.criteria.NumberOfWinningPositionsCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Average gross profit (with commissions).
+ */
+public class AverageProfitCriterion extends AbstractAnalysisCriterion {
+
+    private NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+    private GrossProfitCriterion grossProfitCriterion = new GrossProfitCriterion();
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        Num numberOfWinningTrades = numberOfWinningPositionsCriterion.calculate(series, position);
+        if (numberOfWinningTrades.isZero()) {
+            return series.numOf(0);
+        }
+        Num grossProfit = grossProfitCriterion.calculate(series, position);
+        if (grossProfit.isZero()) {
+            return series.numOf(0);
+        }
+        return grossProfit.dividedBy(numberOfWinningTrades);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num numberOfWinningTrades = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
+        if (numberOfWinningTrades.isZero()) {
+            return series.numOf(0);
+        }
+        Num grossProfit = grossProfitCriterion.calculate(series, tradingRecord);
+        if (grossProfit.isZero()) {
+            return series.numOf(0);
+        }
+        return grossProfit.dividedBy(numberOfWinningTrades);
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterion.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
@@ -39,25 +39,18 @@ import org.ta4j.core.num.Num;
 public class GrossLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the gross loss value of given position
-     *
-     * @param series   a bar series
-     * @param position a position to calculate profit
-     * @return the gross loss
-     */
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num loss = position.getGrossProfit();
             return loss.isNegative() ? loss : series.numOf(0);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
@@ -39,25 +39,18 @@ import org.ta4j.core.num.Num;
 public class GrossProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the gross profit value of given position
-     *
-     * @param series   a bar series
-     * @param position a position to calculate profit
-     * @return the gross profit
-     */
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num profit = position.getGrossProfit();
             return profit.isPositive() ? profit : series.numOf(0);
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
@@ -39,14 +39,14 @@ import org.ta4j.core.num.Num;
 public class GrossReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().map(position -> calculateProfit(series, position))
-                .reduce(series.numOf(1), Num::multipliedBy);
+    public Num calculate(BarSeries series, Position position) {
+        return calculateProfit(series, position);
     }
 
     @Override
-    public Num calculate(BarSeries series, Position position) {
-        return calculateProfit(series, position);
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().map(position -> calculateProfit(series, position))
+                .reduce(series.numOf(1), Num::multipliedBy);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
@@ -56,7 +56,6 @@ public class NetLossCriterion extends AbstractAnalysisCriterion {
         if (position.isClosed()) {
             Num loss = position.getProfit();
             return loss.isNegative() ? loss : series.numOf(0);
-
         }
         return series.numOf(0);
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
@@ -39,19 +39,6 @@ import org.ta4j.core.num.Num;
 public class NetLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the net loss of the given position
-     *
-     * @param series   a bar series
-     * @param position a position
-     * @return the net loss of the position
-     */
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num loss = position.getProfit();
@@ -59,6 +46,12 @@ public class NetLossCriterion extends AbstractAnalysisCriterion {
         }
         return series.numOf(0);
 
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
@@ -39,19 +39,6 @@ import org.ta4j.core.num.Num;
 public class NetProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the net profit of the given position
-     *
-     * @param series   a bar series
-     * @param position a position
-     * @return the net profit of the position
-     */
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num profit = position.getProfit();
@@ -59,6 +46,12 @@ public class NetProfitCriterion extends AbstractAnalysisCriterion {
         }
         return series.numOf(0);
 
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
@@ -56,7 +56,6 @@ public class NetProfitCriterion extends AbstractAnalysisCriterion {
         if (position.isClosed()) {
             Num profit = position.getProfit();
             return profit.isPositive() ? profit : series.numOf(0);
-
         }
         return series.numOf(0);
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
@@ -38,21 +38,14 @@ import org.ta4j.core.num.Num;
 public class ProfitLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
+    public Num calculate(BarSeries series, Position position) {
+        return position.getProfit();
+    }
+
+    @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         return tradingRecord.getPositions().stream().filter(Position::isClosed)
                 .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the profit or loss on the position.
-     *
-     * @param series   a bar series
-     * @param position a position
-     * @return the profit or loss on the position
-     */
-    @Override
-    public Num calculate(BarSeries series, Position position) {
-        return position.getProfit();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -40,25 +40,18 @@ import org.ta4j.core.num.Num;
 public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
 
     @Override
-    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
-    }
-
-    /**
-     * Calculates the profit or loss on a position in percentage.
-     *
-     * @param series   a bar series
-     * @param position a position
-     * @return the profit or loss on a position
-     */
-    @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num entryPrice = position.getEntry().getPricePerAsset();
             return position.getProfit().dividedBy(entryPrice).multipliedBy(series.numOf(100));
         }
         return series.numOf(0);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        return tradingRecord.getPositions().stream().filter(Position::isClosed)
+                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterion.java
@@ -1,0 +1,53 @@
+package org.ta4j.core.analysis.criteria.pnl;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.num.Num;
+
+/**
+ * Ratio Profit Loss Criterion = Average gross profit (with commissions) /
+ * Average gross loss (with commissions)
+ */
+public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {
+
+    private AverageProfitCriterion averageProfitCriterion = new AverageProfitCriterion();
+    private AverageLossCriterion averageLossCriterion = new AverageLossCriterion();
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        Num averageProfit = averageProfitCriterion.calculate(series, position);
+        if (averageProfit.isZero()) {
+            // only loosing positions means a ratio of 0
+            return series.numOf(0);
+        }
+        Num averageLoss = averageLossCriterion.calculate(series, position);
+        if (averageLoss.isZero()) {
+            // only winning positions means a ratio of 1
+            return series.numOf(1);
+        }
+        return averageProfit.dividedBy(averageLoss).abs();
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num averageProfit = averageProfitCriterion.calculate(series, tradingRecord);
+        if (averageProfit.isZero()) {
+            // only loosing positions means a ratio of 0
+            return series.numOf(0);
+        }
+        Num averageLoss = averageLossCriterion.calculate(series, tradingRecord);
+        if (averageLoss.isZero()) {
+            // only winning positions means a ratio of 1
+            return series.numOf(1);
+        }
+        return averageProfit.dividedBy(averageLoss).abs();
+    }
+
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterion.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
@@ -49,7 +49,7 @@ public abstract class RecursiveCachedIndicator<T> extends CachedIndicator<T> {
      *
      * @param series the related bar series
      */
-    public RecursiveCachedIndicator(BarSeries series) {
+    protected RecursiveCachedIndicator(BarSeries series) {
         super(series);
     }
 
@@ -58,7 +58,7 @@ public abstract class RecursiveCachedIndicator<T> extends CachedIndicator<T> {
      *
      * @param indicator a related indicator (with a bar series)
      */
-    public RecursiveCachedIndicator(Indicator<?> indicator) {
+    protected RecursiveCachedIndicator(Indicator<?> indicator) {
         this(indicator.getBarSeries());
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectancyCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectancyCriterionTest.java
@@ -1,0 +1,85 @@
+package org.ta4j.core.analysis.criteria;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class ExpectancyCriterionTest extends AbstractCriterionTest {
+
+    public ExpectancyCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new ExpectancyCriterion(), numFunction);
+    }
+
+    @Test
+    public void calculateOnlyWithProfitPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 110, 120, 130, 150, 160);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
+                Trade.buyAt(3, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(0, avgLoss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithMixedPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 110, 80, 130, 150, 160);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
+                Trade.buyAt(3, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(-1.25, avgLoss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateOnlyWithLossPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 80, 70, 60, 50);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
+                Trade.buyAt(2, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(0, avgLoss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateProfitWithShortPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 160, 140, 120, 100, 80, 60);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
+                Trade.sellAt(2, series), Trade.buyAt(5, series));
+
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(0, avgLoss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateProfitWithMixedShortPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 160, 200, 120, 100, 80, 60);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
+                Trade.sellAt(2, series), Trade.buyAt(5, series));
+
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(-1.25, avgLoss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void betterThan() {
+        AnalysisCriterion criterion = getCriterion();
+        assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
+        assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
+    }
+
+    @Test
+    public void testCalculateOneOpenPositionShouldReturnZero() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectancyCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectancyCriterionTest.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria;
 
 import static org.junit.Assert.assertFalse;

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/LosingPositionsRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/LosingPositionsRatioCriterionTest.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.analysis.criteria;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class LosingPositionsRatioCriterionTest extends AbstractCriterionTest {
+
+    public LosingPositionsRatioCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new LosingPositionsRatioCriterion(), numFunction);
+    }
+
+    @Test
+    public void calculate() {
+        BarSeries series = new MockBarSeries(numFunction, 100d, 95d, 102d, 105d, 97d, 113d);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
+                Trade.buyAt(2, series), Trade.sellAt(3, series), Trade.buyAt(4, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion average = getCriterion();
+
+        assertNumEquals(1d / 3, average.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithShortPositions() {
+        BarSeries series = new MockBarSeries(numFunction, 100d, 95d, 102d, 105d, 97d, 113d);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(2, series),
+                Trade.sellAt(3, series), Trade.buyAt(4, series));
+
+        AnalysisCriterion average = getCriterion();
+
+        assertNumEquals(0.5, average.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithOnePosition() {
+        BarSeries series = new MockBarSeries(numFunction, 100d, 95d, 102d, 105d, 97d, 113d);
+        Position position = new Position(Trade.buyAt(0, series), Trade.sellAt(1, series));
+
+        AnalysisCriterion average = getCriterion();
+        assertNumEquals(numOf(1), average.calculate(series, position));
+
+        position = new Position(Trade.buyAt(1, series), Trade.sellAt(2, series));
+        assertNumEquals(0, average.calculate(series, position));
+    }
+
+    @Test
+    public void betterThan() {
+        AnalysisCriterion criterion = getCriterion();
+        assertTrue(criterion.betterThan(numOf(12), numOf(8)));
+        assertFalse(criterion.betterThan(numOf(8), numOf(12)));
+    }
+
+    @Test
+    public void testCalculateOneOpenPositionShouldReturnZero() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterionTest.java
@@ -1,0 +1,68 @@
+package org.ta4j.core.analysis.criteria;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class NumberOfConsecutiveWinningPositionsCriterionTest extends AbstractCriterionTest {
+
+    public NumberOfConsecutiveWinningPositionsCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NumberOfConsecutiveWinningPositionsCriterion(), numFunction);
+    }
+
+    @Test
+    public void calculateWithNoPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+
+        assertNumEquals(0, getCriterion().calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void calculateWithTwoLongPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 120, 130, 140);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(1, series), Trade.sellAt(3, series),
+                Trade.buyAt(3, series), Trade.sellAt(4, series));
+
+        assertNumEquals(2, getCriterion().calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithOneLongPosition() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 120, 95, 105);
+        Position position = new Position(Trade.buyAt(1, series), Trade.sellAt(3, series));
+
+        assertNumEquals(1, getCriterion().calculate(series, position));
+    }
+
+    @Test
+    public void calculateWithTwoShortPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
+                Trade.sellAt(3, series), Trade.buyAt(5, series));
+
+        assertNumEquals(0, getCriterion().calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void betterThan() {
+        AnalysisCriterion criterion = getCriterion();
+        assertFalse(criterion.betterThan(numOf(3), numOf(6)));
+        assertTrue(criterion.betterThan(numOf(7), numOf(4)));
+    }
+
+    @Test
+    public void testCalculateOneOpenPositionShouldReturnZero() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/NumberOfConsecutiveWinningPositionsCriterionTest.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria;
 
 import static org.junit.Assert.assertFalse;

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterionTest.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
- * authors (see AUTHORS)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import static org.junit.Assert.assertFalse;
@@ -38,10 +15,10 @@ import org.ta4j.core.analysis.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class NetLossCriterionTest extends AbstractCriterionTest {
+public class AverageLossCriterionTest extends AbstractCriterionTest {
 
-    public NetLossCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new NetLossCriterion(), numFunction);
+    public AverageLossCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new AverageLossCriterion(), numFunction);
     }
 
     @Test
@@ -50,8 +27,8 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(0, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(0, avgLoss.calculate(series, tradingRecord));
     }
 
     @Test
@@ -60,8 +37,8 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(-35, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(-17.5, avgLoss.calculate(series, tradingRecord));
     }
 
     @Test
@@ -70,8 +47,8 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(-35, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgLoss = getCriterion();
+        assertNumEquals(-17.5, avgLoss.calculate(series, tradingRecord));
     }
 
     @Test
@@ -85,4 +62,5 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
     }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageLossCriterionTest.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import static org.junit.Assert.assertFalse;

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterionTest.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import static org.junit.Assert.assertFalse;

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/AverageProfitCriterionTest.java
@@ -1,26 +1,3 @@
-/**
- * The MIT License (MIT)
- *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
- * authors (see AUTHORS)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import static org.junit.Assert.assertFalse;
@@ -38,10 +15,10 @@ import org.ta4j.core.analysis.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class NetLossCriterionTest extends AbstractCriterionTest {
+public class AverageProfitCriterionTest extends AbstractCriterionTest {
 
-    public NetLossCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new NetLossCriterion(), numFunction);
+    public AverageProfitCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new AverageProfitCriterion(), numFunction);
     }
 
     @Test
@@ -50,8 +27,8 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(0, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgProfit = getCriterion();
+        assertNumEquals(7.5, avgProfit.calculate(series, tradingRecord));
     }
 
     @Test
@@ -60,18 +37,18 @@ public class NetLossCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(-35, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgProfit = getCriterion();
+        assertNumEquals(0, avgProfit.calculate(series, tradingRecord));
     }
 
     @Test
     public void calculateProfitWithShortPositions() {
-        MockBarSeries series = new MockBarSeries(numFunction, 95, 100, 70, 80, 85, 100);
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 85, 80, 70, 100, 95);
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
-        AnalysisCriterion loss = getCriterion();
-        assertNumEquals(-35, loss.calculate(series, tradingRecord));
+        AnalysisCriterion avgProfit = getCriterion();
+        assertNumEquals(15, avgProfit.calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterionTest.java
@@ -45,7 +45,7 @@ public class NetProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithGainPositions() {
+    public void calculateOnlyWithProfitPositions() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
@@ -55,7 +55,7 @@ public class NetProfitCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithProfitPositions() {
+    public void calculateOnlyWithProfitPositions2() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 100, 80, 85, 120);
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(5, series));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterionTest.java
@@ -45,7 +45,7 @@ public class ProfitLossCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateOnlyWithGainPositions() {
+    public void calculateOnlyWithProfitPositions() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series, series.numOf(50)),
                 Trade.sellAt(2, series, series.numOf(50)), Trade.buyAt(3, series, series.numOf(50)),
@@ -67,7 +67,7 @@ public class ProfitLossCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void calculateShortOnlyWithGainPositions() {
+    public void calculateShortOnlyWithProfitPositions() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series, series.numOf(50)),
                 Trade.buyAt(2, series, series.numOf(50)), Trade.sellAt(3, series, series.numOf(50)),

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterionTest.java
@@ -1,0 +1,65 @@
+package org.ta4j.core.analysis.criteria.pnl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.AbstractCriterionTest;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class ProfitLossRatioCriterionTest extends AbstractCriterionTest {
+
+    public ProfitLossRatioCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new ProfitLossRatioCriterion(), numFunction);
+    }
+
+    @Test
+    public void calculateOnlyWithProfitPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 120, 70, 100, 130, 105, 120);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
+                Trade.buyAt(3, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion avtProfit = getCriterion();
+        assertNumEquals(0, avtProfit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateOnlyWithLossPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
+                Trade.buyAt(2, series), Trade.sellAt(5, series));
+
+        AnalysisCriterion avtProfit = getCriterion();
+        assertNumEquals(0, avtProfit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateProfitWithShortPositions() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 85, 80, 70, 100, 95);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
+                Trade.sellAt(2, series), Trade.buyAt(5, series));
+
+        AnalysisCriterion avtProfit = getCriterion();
+        assertNumEquals(1, avtProfit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void betterThan() {
+        AnalysisCriterion criterion = getCriterion();
+        assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
+        assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
+    }
+
+    @Test
+    public void testCalculateOneOpenPositionShouldReturnZero() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossRatioCriterionTest.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.analysis.criteria.pnl;
 
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
Changes proposed in this pull request:
- :tada: **Enhancement** added **`AverageProfitCriterion.class`**.
- :tada: **Enhancement** added **`AverageLossCriterion.class`**.
- :tada: **Enhancement** added **`ProfitLossRatioCriterion.class`**.
- :tada: **Enhancement** added **`ExpectancyCriterion.class`**.
- :tada: **Enhancement** added **`NumberOfConsecutiveWinningPositionsCriterion.class`**.
- :tada: **Enhancement** added **`LosingPositionsRatioCriterion.class`**.
- :tada: **Enhancement** added **`Position#hasProfit()`**.
- :tada: **Enhancement** added **`Position#hasLoss()`**.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 


- The `AverageLossCriterion`, `AverageProfitCriterion`, `ProfitLossRatioCriterion` can be used standalone, but is required to calculate `ExpectancyCriterion`.

- The `NumberOfConsecutiveWinningPositionsCriterion` calculates the maximum number of consecutive winnings within a trading record. (It's a long name, maybe rename to ConsecutiveWinningPositionsCriterion?)
