### PR TITLE
introduce RuleWithCtx interface (#719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Enhancement** Added BarSeriesUtils: common helpers and shortcuts for BarSeries methods.
 - **Enhancement** Improvements for PreviousValueIndicator: more descriptive toString() method, validation of n-th previous bars in
 - **Enhancement** Added Percentage Volume Oscillator Indicator, PVOIndicator.
+- **Enhancement** Added new interface RuleWithCtx to define the trade price
+- **Enhancement** AndRule, OrRule, XorRule, NotRule implementing RuleWithCtx
+- **Enhancement** new StopGainRule2 that supports percentage and fixed gain and price is used as exit price
  constructor of PreviousValueIndicator 
 - :tada: **Enhancement** added getGrossProfit() and getGrossProfit(BarSeries) on Trade.
 - :tada: **Enhancement** added getPricePerAsset(BarSeries) on Order.

--- a/ta4j-core/src/main/java/org/ta4j/core/OperationResult.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/OperationResult.java
@@ -1,0 +1,56 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * Information holder object for the {@link Strategy#shouldOperateWithContext(int, TradingRecord)}.
+ * This class is only used internally within the {@link Strategy}.
+ */
+public class OperationResult implements StrategyContext {
+	private boolean shouldOperate;
+	private Num tradeExitPrice;
+	
+	public OperationResult() {
+		this.shouldOperate = false;
+	}
+
+	public boolean shouldOperate() {
+		return shouldOperate;
+	}
+
+	public void setShouldOperate(boolean shouldOperate) {
+		this.shouldOperate = shouldOperate;
+	}
+
+	@Override
+	public void setTradeExitPrice(Num currentStopLossLimitActivation) {
+		this.tradeExitPrice = currentStopLossLimitActivation;
+	}
+	
+	public Num getTradePrice() {
+		return tradeExitPrice;
+	}
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/RuleWithCtx.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/RuleWithCtx.java
@@ -1,0 +1,39 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+/**
+ * This interface enables a {@link Rule} to interact with the strategy.
+ *
+ */
+public interface RuleWithCtx extends Rule {
+
+    /**
+     * @param index         the bar index
+     * @param tradingRecord the potentially needed trading history
+     * @return true if this rule is satisfied for the provided index, false
+     *         otherwise
+     */
+    boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx);
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/StrategyContext.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/StrategyContext.java
@@ -1,0 +1,40 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * Interface for the {@link Rule} to interact with the {@link Strategy}.
+ *
+ */
+public interface StrategyContext {
+
+	/**
+	 * 
+	 * @param price the price to be used for the order (buy or sell) instead of the close price
+	 */
+	void setTradeExitPrice(Num price);
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
@@ -26,6 +26,9 @@ package org.ta4j.core.rules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
+import org.ta4j.core.TradingRecord;
 
 /**
  * An abstract trading {@link Rule rule}.
@@ -46,5 +49,22 @@ public abstract class AbstractRule implements Rule {
      */
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
         log.trace("{}#isSatisfied({}): {}", className, index, isSatisfied);
+    }
+    
+    /**
+     * Convenient method for calling isSatisfied depending on implemented interface {@link Rule} or {@link RuleWithCtx} 
+     * 
+     * @param rule the rule
+     * @param index the current index
+     * @param tradingRecord the trading record
+     * @param ctx the context object, may be <code>null</code>
+     * @return
+     */
+    protected boolean isSatisfied(Rule rule, int index, TradingRecord tradingRecord, StrategyContext ctx) {
+    	if (rule instanceof RuleWithCtx) {
+    		return ((RuleWithCtx)rule).isSatisfied(index, tradingRecord, ctx);
+    	} else {
+    		return rule.isSatisfied(index, tradingRecord);
+    	}
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
@@ -24,6 +24,8 @@
 package org.ta4j.core.rules;
 
 import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
 import org.ta4j.core.TradingRecord;
 
 /**
@@ -32,7 +34,7 @@ import org.ta4j.core.TradingRecord;
  * Satisfied when the two provided rules are satisfied as well.<br>
  * Warning: the second rule is not tested if the first rule is not satisfied.
  */
-public class AndRule extends AbstractRule {
+public class AndRule extends AbstractRule implements RuleWithCtx {
 
     private final Rule rule1;
     private final Rule rule2;
@@ -50,10 +52,15 @@ public class AndRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = rule1.isSatisfied(index, tradingRecord) && rule2.isSatisfied(index, tradingRecord);
+        return isSatisfied(index, tradingRecord, null);
+    }
+    
+	@Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+		final boolean satisfied = isSatisfied(rule1, index, tradingRecord, ctx) && isSatisfied(rule2, index, tradingRecord, ctx);
         traceIsSatisfied(index, satisfied);
         return satisfied;
-    }
+	}
 
     public Rule getRule1() {
         return rule1;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
@@ -24,6 +24,8 @@
 package org.ta4j.core.rules;
 
 import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
 import org.ta4j.core.TradingRecord;
 
 /**
@@ -32,7 +34,7 @@ import org.ta4j.core.TradingRecord;
  * Satisfied when provided rule is not satisfied.<br>
  * Not satisfied when provided rule is satisfied.
  */
-public class NotRule extends AbstractRule {
+public class NotRule extends AbstractRule implements RuleWithCtx {
 
     private final Rule ruleToNegate;
 
@@ -47,7 +49,12 @@ public class NotRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = !ruleToNegate.isSatisfied(index, tradingRecord);
+    	return isSatisfied(index, tradingRecord, null);
+    }
+    
+    @Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+        final boolean satisfied = !isSatisfied(ruleToNegate, index, tradingRecord, ctx);
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
@@ -24,6 +24,8 @@
 package org.ta4j.core.rules;
 
 import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
 import org.ta4j.core.TradingRecord;
 
 /**
@@ -32,7 +34,7 @@ import org.ta4j.core.TradingRecord;
  * Satisfied when one of the two provided rules is satisfied.<br>
  * Warning: the second rule is not tested if the first rule is satisfied.
  */
-public class OrRule extends AbstractRule {
+public class OrRule extends AbstractRule implements RuleWithCtx {
 
     private final Rule rule1;
     private final Rule rule2;
@@ -50,7 +52,12 @@ public class OrRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = rule1.isSatisfied(index, tradingRecord) || rule2.isSatisfied(index, tradingRecord);
+        return isSatisfied(index, tradingRecord, null);
+    }
+    
+    @Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+    	final boolean satisfied = isSatisfied(rule1, index, tradingRecord, ctx) || isSatisfied(rule2, index, tradingRecord, ctx);
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule2.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule2.java
@@ -1,0 +1,146 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.rules;
+
+import org.ta4j.core.Indicator;
+import org.ta4j.core.Position;
+import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * A stop-gain rule that uses the context to promote a more precise exit price to the strategy.
+ *
+ * Satisfied when the price indicator reaches the gain threshold or absolute gain.
+ * As price indicator for stop gain within a candle (e.g. take profit market order and TP is between close and high) you should use the {@link HighPriceIndicator}.
+ * 
+ * The {@link Rule} implements the {@link RuleWithCtx} interface which sets the satified price for exit the trade.
+ * If the price shall be based on the close price use {@link StopGainRule}.
+ */
+public class StopGainRule2 extends AbstractRule implements RuleWithCtx {
+
+    /**
+     * Constant value for 100
+     */
+    private final Num HUNDRED;
+
+    /**
+     * The price indicator
+     */
+    private final Indicator<Num> priceIndicator;
+
+    /**
+     * The gain percentage
+     */
+    private final Num gainValue;
+
+    /**
+     * true for percentage usage of {@code gainValue}, false for absolute usage of {@code gainValue}
+     */
+	private boolean percentageOrAbs;
+
+    /**
+     * Constructor.
+     *
+     * @param priceIndicator     the price indicator
+     * @param gainPercentage the gain percentage
+     */
+    public StopGainRule2(Indicator<Num> priceIndicator, Number gainPercentage) {
+        this(priceIndicator, priceIndicator.numOf(gainPercentage), true);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param priceIndicator     the price indicator
+     * @param gainValue the gain value (percentage or absolute)
+     * @param percentageOrAbs true for percentage value, false for absolute value
+     */
+    public StopGainRule2(Indicator<Num> priceIndicator, Num gainValue, boolean percentageOrAbs) {
+        this.priceIndicator = priceIndicator;
+        this.gainValue = gainValue;
+		this.percentageOrAbs = percentageOrAbs;
+        HUNDRED = priceIndicator.numOf(100);
+    }
+
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        return isSatisfied(index, tradingRecord, null);
+    }
+
+    private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice, StrategyContext ctx) {
+    	Num threshold;
+    	if (percentageOrAbs) {
+    		Num lossRatioThreshold = HUNDRED.minus(gainValue).dividedBy(HUNDRED);
+    		threshold = entryPrice.multipliedBy(lossRatioThreshold);
+    	} else {
+    		threshold = entryPrice.minus(gainValue);
+    	}
+        boolean ltOrEq = currentPrice.isLessThanOrEqual(threshold);
+        if (ltOrEq && ctx != null) {
+        	ctx.setTradeExitPrice(threshold);
+        }
+		return ltOrEq;
+    }
+
+    private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice, StrategyContext ctx) {
+    	Num threshold;
+    	if (percentageOrAbs) {
+    		Num lossRatioThreshold = HUNDRED.plus(gainValue).dividedBy(HUNDRED);
+    		threshold = entryPrice.multipliedBy(lossRatioThreshold);
+    	} else {
+    		threshold = entryPrice.plus(gainValue);
+    	}
+    	boolean gtOrEq = currentPrice.isGreaterThanOrEqual(threshold);
+        if (gtOrEq && ctx != null) {
+        	ctx.setTradeExitPrice(threshold);
+        }
+		return gtOrEq;
+    }
+
+	@Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+		boolean satisfied = false;
+        // No trading history or no position opened, no loss
+        if (tradingRecord != null) {
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            if (currentPosition.isOpened()) {
+
+                Num entryPrice = currentPosition.getEntry().getNetPrice();
+                Num currentPrice = priceIndicator.getValue(index);
+
+                if (currentPosition.getEntry().isBuy()) {
+                    satisfied = isBuyGainSatisfied(entryPrice, currentPrice, ctx);
+                } else {
+                    satisfied = isSellGainSatisfied(entryPrice, currentPrice, ctx);
+                }
+            }
+        }
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+	}
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
@@ -24,6 +24,8 @@
 package org.ta4j.core.rules;
 
 import org.ta4j.core.Rule;
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
 import org.ta4j.core.TradingRecord;
 
 /**
@@ -31,7 +33,7 @@ import org.ta4j.core.TradingRecord;
  *
  * Satisfied when only of the two provided rules is satisfied.
  */
-public class XorRule extends AbstractRule {
+public class XorRule extends AbstractRule implements RuleWithCtx {
 
     private final Rule rule1;
     private final Rule rule2;
@@ -49,7 +51,12 @@ public class XorRule extends AbstractRule {
 
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        final boolean satisfied = rule1.isSatisfied(index, tradingRecord) ^ rule2.isSatisfied(index, tradingRecord);
+    	return isSatisfied(index, tradingRecord, null);
+    }
+    
+    @Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+        final boolean satisfied = isSatisfied(rule1, index, tradingRecord, ctx) ^ isSatisfied(rule2, index, tradingRecord, ctx);
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesManagerTest.java
@@ -36,9 +36,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.FixedRule;
+import org.ta4j.core.rules.StopGainRule2;
 
 public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> {
 
@@ -104,6 +106,21 @@ public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> 
 
         assertEquals(Trade.buyAt(6, seriesForRun.getBar(6).getClosePrice(), numOf(1)), positions.get(1).getEntry());
         assertEquals(Trade.sellAt(7, seriesForRun.getBar(7).getClosePrice(), numOf(1)), positions.get(1).getExit());
+    }
+    
+    @Test
+    public void runOnSeriesWithRuleWithCtx() {
+    	// prepare date
+    	seriesForRun = new MockBarSeries(numFunction);
+    	manager = new BarSeriesManager(seriesForRun);
+    	strategy = new BaseStrategy(new FixedRule(2), new StopGainRule2(new HighPriceIndicator(seriesForRun), numOf(0.3), false));
+    	strategy.setUnstablePeriod(1);
+    	//
+        List<Position> positions = manager.run(strategy, TradeType.BUY, 2, 5).getPositions();
+        assertEquals(1, positions.size());
+
+        assertEquals(Trade.buyAt(2, seriesForRun.getBar(2).getClosePrice(), numOf(1)), positions.get(0).getEntry());
+        assertEquals(Trade.sellAt(3, numOf(3.3), numOf(1)), positions.get(0).getExit());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockRule.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockRule.java
@@ -1,0 +1,39 @@
+package org.ta4j.core.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ta4j.core.Rule;
+import org.ta4j.core.TradingRecord;
+
+public class MockRule implements Rule {
+	
+	protected boolean[] results;
+	private List<Integer> calls = new ArrayList<>();
+
+	/**
+	 * Last result is taken if index is greater than size of the given results.
+	 * @param results result per index
+	 */
+	public MockRule(boolean... results) {
+		if (results == null) {
+			throw new IllegalArgumentException("results must not be empty");
+		}
+		this.results = results;
+	} 
+
+	@Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+		calls.add(index);
+		if (results.length > index) {
+			return results[index];
+		}
+		return results[results.length - 1];
+	}
+	
+	public List<Integer> getCalls() {
+		return calls;
+	}
+	
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockRuleWithCtx.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockRuleWithCtx.java
@@ -1,0 +1,39 @@
+package org.ta4j.core.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ta4j.core.RuleWithCtx;
+import org.ta4j.core.StrategyContext;
+import org.ta4j.core.TradingRecord;
+
+/**
+ * mock for testing RuleWithCtx
+ *
+ */
+public class MockRuleWithCtx extends MockRule implements RuleWithCtx {
+
+	protected List<Integer> callsWithCtx = new ArrayList<>();
+	
+	/**
+	 * Last result is taken if index is greater than size of the given results.
+	 * @param results result per index
+	 */
+	public MockRuleWithCtx(boolean... results) {
+		super(results);
+	} 
+	
+	@Override
+	public boolean isSatisfied(int index, TradingRecord tradingRecord, StrategyContext ctx) {
+		callsWithCtx.add(index);
+		if (results.length > index) {
+			return results[index];
+		}
+		return results[results.length - 1];
+	}
+	
+	
+	public List<Integer> getCallsWithCtx() {
+		return callsWithCtx;
+	}
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AbstractRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AbstractRuleTest.java
@@ -1,0 +1,39 @@
+package org.ta4j.core.rules;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.mocks.MockRule;
+import org.ta4j.core.mocks.MockRuleWithCtx;
+
+public class AbstractRuleTest {
+
+	@Test
+	public void test_that_convenient_is_satisfied_works_for_both_interfaces() {
+		AbstractRule testee = new AbstractRule() {
+
+			@Override
+			public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+				return false;
+			}
+			
+		};
+		MockRule rule = new MockRule(true);
+		MockRuleWithCtx ruleCtx = new MockRuleWithCtx(true);
+		TradingRecord tr = new BaseTradingRecord();
+		// test Rule
+		testee.isSatisfied(rule, 0, tr, null);
+		assertEquals(1, rule.getCalls().size());
+		assertEquals(Integer.valueOf(0), rule.getCalls().get(0));
+		
+		// test RuleWithCtx
+		testee.isSatisfied(ruleCtx, 1, tr, null);
+		assertEquals(1, ruleCtx.getCallsWithCtx().size());
+		assertEquals(0, ruleCtx.getCalls().size());
+		assertEquals(Integer.valueOf(1), ruleCtx.getCallsWithCtx().get(0));
+		
+	}
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRule2Test.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRule2Test.java
@@ -1,0 +1,204 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.rules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.OperationResult;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class StopGainRule2Test extends AbstractIndicatorTest<BarSeries, Num> {
+	private Indicator<Num> priceIndicator;
+
+	public StopGainRule2Test(Function<Number, Num> numFunction) {
+		super(numFunction);
+	}
+	
+    @Before
+    public void setUp() {
+    	priceIndicator = new ClosePriceIndicator(
+                new MockBarSeries(numFunction, 100, 105, 110, 120, 150, 120, 160, 180, 170, 135, 104));
+    }
+    
+    @Test
+    public void isSatisfiedWorksForBuy_with_Context_absolute() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        final Num tradedAmount = numOf(1);
+
+        // 30 points stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(30), false);
+        OperationResult ctx = new OperationResult();
+        assertFalse(rule.isSatisfied(1, tradingRecord, ctx));
+
+        // Enter at 108 +30% = 140.4
+        tradingRecord.enter(2, numOf(108), tradedAmount);
+        assertFalse(rule.isSatisfied(2, tradingRecord, ctx));
+        assertFalse(rule.isSatisfied(3, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(4, tradingRecord, ctx));
+        assertEquals(numOf(138), ctx.getTradePrice());
+    }
+    
+    @Test
+    public void isSatisfiedWorksForBuy_with_Context_percentage() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        final Num tradedAmount = numOf(1);
+
+        // 30% stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(30), true);
+        OperationResult ctx = new OperationResult();
+        assertFalse(rule.isSatisfied(1, tradingRecord, ctx));
+
+        // Enter at 108 +30% = 140.4
+        tradingRecord.enter(2, numOf(108), tradedAmount);
+        assertFalse(rule.isSatisfied(2, tradingRecord, ctx));
+        assertFalse(rule.isSatisfied(3, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(4, tradingRecord, ctx));
+        assertEquals(numOf(140.4), ctx.getTradePrice());
+        // Exit
+        tradingRecord.exit(5);
+
+        // Enter at 118 +30% = 153.4
+        tradingRecord.enter(5, numOf(118), tradedAmount);
+        assertFalse(rule.isSatisfied(5, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(6, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(7, tradingRecord, ctx));
+        assertEquals(numOf(153.4), ctx.getTradePrice());
+    }
+
+    @Test
+    public void isSatisfiedWorksForBuy_old_behavior_from_StopGainTest() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        final Num tradedAmount = numOf(1);
+
+        // 30% stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(30), true);
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+
+        // Enter at 108
+        tradingRecord.enter(2, numOf(108), tradedAmount);
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertTrue(rule.isSatisfied(4, tradingRecord));
+        // Exit
+        tradingRecord.exit(5);
+
+        // Enter at 118
+        tradingRecord.enter(5, numOf(118), tradedAmount);
+        assertFalse(rule.isSatisfied(5, tradingRecord));
+        assertTrue(rule.isSatisfied(6, tradingRecord));
+        assertTrue(rule.isSatisfied(7, tradingRecord));
+    }
+    
+    @Test
+    public void isSatisfiedWorksForSell_with_context_absolute() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        final Num tradedAmount = numOf(1);
+
+        // 10 points stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(18), false);
+        OperationResult ctx = new OperationResult();
+        // verify
+        assertFalse(rule.isSatisfied(1, tradingRecord, ctx));
+
+        // Enter at 178
+        tradingRecord.enter(7, numOf(178), tradedAmount);
+        assertFalse(rule.isSatisfied(7, tradingRecord, ctx));
+        assertFalse(rule.isSatisfied(8, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(9, tradingRecord, ctx));
+        assertEquals(numOf(160), ctx.getTradePrice());
+    }
+    
+    @Test
+    public void isSatisfiedWorksForSell_with_context_percentage() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        final Num tradedAmount = numOf(1);
+
+        // 10% stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(10), true);
+        OperationResult ctx = new OperationResult();
+        // verify
+        assertFalse(rule.isSatisfied(1, tradingRecord, ctx));
+
+        // Enter at 178
+        tradingRecord.enter(7, numOf(178), tradedAmount);
+        assertFalse(rule.isSatisfied(7, tradingRecord, ctx));
+        assertFalse(rule.isSatisfied(8, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(9, tradingRecord, ctx));
+        assertEquals(numOf(160.2), ctx.getTradePrice());
+        // Exit
+        tradingRecord.exit(10);
+
+        // Enter at 119
+        tradingRecord.enter(3, numOf(119), tradedAmount);
+        assertFalse(rule.isSatisfied(3, tradingRecord, ctx));
+        assertFalse(rule.isSatisfied(2, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(1, tradingRecord, ctx));
+        assertTrue(rule.isSatisfied(10, tradingRecord, ctx));
+        assertEquals(numOf(107.1), ctx.getTradePrice());
+    }
+
+    @Test
+    public void isSatisfiedWorksForSell_old_behavior_from_StopGainTest() {
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        final Num tradedAmount = numOf(1);
+
+        // 30% stop-gain
+        StopGainRule2 rule = new StopGainRule2(priceIndicator, numOf(10), true);
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+
+        // Enter at 178
+        tradingRecord.enter(7, numOf(178), tradedAmount);
+        assertFalse(rule.isSatisfied(7, tradingRecord));
+        assertFalse(rule.isSatisfied(8, tradingRecord));
+        assertTrue(rule.isSatisfied(9, tradingRecord));
+        // Exit
+        tradingRecord.exit(10);
+
+        // Enter at 119
+        tradingRecord.enter(3, numOf(119), tradedAmount);
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertTrue(rule.isSatisfied(1, tradingRecord));
+        assertTrue(rule.isSatisfied(10, tradingRecord));
+    }
+
+}


### PR DESCRIPTION
new interface is used for the base rules and for backward compatibility
added new StopGainRule2 that supports percentage and fixed gain and
price is used as exit price


Fixes #719 .

Changes proposed in this pull request:
- **Enhancement** Added new interface RuleWithCtx to define the trade price
- **Enhancement** AndRule, OrRule, XorRule, NotRule implementing RuleWithCtx
- **Enhancement** new StopGainRule2 that supports percentage and fixed gain and price is used as exit price