### PR TITLE
Exposed both EMAs in MACD indicator to be usable in strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`GrossLossCriterion.class`**.
 - :tada: **Enhancement** added **`NetProfitCriterion.class`**.
 - :tada: **Enhancement** added chooseBest() method with parameter tradeType in AnalysisCriterion.
+- :tada: **Enhancement** exposed both EMAs in MACD indicator
 
 
 ## 0.13 (released November 5, 2019)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -36,6 +36,8 @@ import org.ta4j.core.num.Num;
  */
 public class MACDIndicator extends CachedIndicator<Num> {
 
+    private static final long serialVersionUID = -6899062131135971403L;
+
     private final EMAIndicator shortTermEma;
     private final EMAIndicator longTermEma;
 
@@ -62,6 +64,24 @@ public class MACDIndicator extends CachedIndicator<Num> {
         }
         shortTermEma = new EMAIndicator(indicator, shortBarCount);
         longTermEma = new EMAIndicator(indicator, longBarCount);
+    }
+
+    /**
+     * Short term EMA indicator
+     *
+     * @return the Short term EMA indicator
+     */
+    public EMAIndicator getShortTermEma() {
+        return shortTermEma;
+    }
+
+    /**
+     * Long term EMA indicator
+     *
+     * @return the Long term EMA indicator
+     */
+    public EMAIndicator getLongTermEma() {
+        return longTermEma;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -36,8 +36,6 @@ import org.ta4j.core.num.Num;
  */
 public class MACDIndicator extends CachedIndicator<Num> {
 
-    private static final long serialVersionUID = -6899062131135971403L;
-
     private final EMAIndicator shortTermEma;
     private final EMAIndicator longTermEma;
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -1,0 +1,78 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+public class MACDIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public MACDIndicatorTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    private BarSeries data;
+
+    @Before
+    public void setUp() {
+        data = new MockBarSeries(numFunction, 37.08, 36.7, 36.11, 35.85, 35.71, 36.04, 36.41, 37.67, 38.01, 37.79,
+                36.83, 37.10, 38.01, 38.50, 38.99);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsErrorOnIllegalArguments() {
+        new MACDIndicator(new ClosePriceIndicator(data), 10, 5);
+    }
+
+    @Test
+    public void macdUsingPeriod5And10() {
+        MACDIndicator macdIndicator = new MACDIndicator(new ClosePriceIndicator(data), 5, 10);
+        assertNumEquals(0.0, macdIndicator.getValue(0));
+        assertNumEquals(-0.05757, macdIndicator.getValue(1));
+        assertNumEquals(-0.17488, macdIndicator.getValue(2));
+        assertNumEquals(-0.26766, macdIndicator.getValue(3));
+        assertNumEquals(-0.32326, macdIndicator.getValue(4));
+        assertNumEquals(-0.28399, macdIndicator.getValue(5));
+        assertNumEquals(-0.18930, macdIndicator.getValue(6));
+        assertNumEquals(0.06472, macdIndicator.getValue(7));
+        assertNumEquals(0.25087, macdIndicator.getValue(8));
+        assertNumEquals(0.30387, macdIndicator.getValue(9));
+        assertNumEquals(0.16891, macdIndicator.getValue(10));
+
+        assertNumEquals(36.4098, macdIndicator.getLongTermEma().getValue(5));
+        assertNumEquals(36.1258, macdIndicator.getShortTermEma().getValue(5));
+
+        assertNumEquals(37.0118, macdIndicator.getLongTermEma().getValue(10));
+        assertNumEquals(37.1807, macdIndicator.getShortTermEma().getValue(10));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2019 Ta4j Organization & respective
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
-  Exposed both EMAs in MACD indicator to be usable in strategy

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
