### PR TITLE
Added IndicatorUtils with streamOf to create a stream from indicator values

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
@@ -49,27 +49,4 @@ public interface Indicator<T> {
      */
     Num numOf(Number number);
 
-    /**
-     * Returns all values from an {@link Indicator} as an array of Doubles. The
-     * returned doubles could have a minor loss of precise, if {@link Indicator} was
-     * based on {@link Num Num}.
-     *
-     * @param ref      the indicator
-     * @param index    the index
-     * @param barCount the barCount
-     * @return array of Doubles within the barCount
-     */
-    static Double[] toDouble(Indicator<Num> ref, int index, int barCount) {
-
-        Double[] all = new Double[barCount];
-
-        int startIndex = Math.max(0, index - barCount + 1);
-        for (int i = 0; i < barCount; i++) {
-            Num number = ref.getValue(i + startIndex);
-            all[i] = number.doubleValue();
-        }
-
-        return all;
-    }
-
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -25,6 +25,7 @@ package org.ta4j.core.utils;
 
 import org.ta4j.core.Indicator;
 
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -32,12 +33,49 @@ public final class IndicatorUtils {
 
     /**
      * Creates a stream from the indicator values
-     * 
+     *
      * @param indicator indicator to be used
      * @param <T>       Indicator type
      * @return the stream of values
      */
-    public static <T> Stream<T> streamOf(Indicator<T> indicator) {
-        return IntStream.range(0, indicator.getBarSeries().getBarCount()).mapToObj(indicator::getValue);
+    public static <T> Stream<T> streamOf(final Indicator<T> indicator) {
+        return IntStream.range(0, indicator.getBarSeries()
+                .getBarCount())
+                .mapToObj(indicator::getValue);
+    }
+
+    /**
+     * Creates a stream from the indicator values and applies a mapping function on each element.
+     * Indicator context is passed together with the index, so other values could be used for mapping.
+     * @param indicator indicator to be used
+     * @param mapFunction function that is applied in mapping receives a tuple in argument; that contains the indicator
+     *                   and integer index
+     * @param <T> type of indicator value
+     * @param <R> result type
+     * @return the resulting type
+     */
+    public static <T, R> Stream<R> streamOf(final Indicator<T> indicator,
+                                            final Function<IndicatorContext<T>, R> mapFunction) {
+        return IntStream.range(0, indicator.getBarSeries()
+                .getBarCount())
+                .mapToObj((int i) -> mapFunction.apply(new IndicatorContext<>(indicator, i)));
+    }
+
+    public static final class IndicatorContext<T> {
+        private final Indicator<T> indicator;
+        private final int index;
+
+        public IndicatorContext(Indicator<T> indicator, int index) {
+            this.indicator = indicator;
+            this.index = index;
+        }
+
+        public Indicator<T> getIndicator() {
+            return indicator;
+        }
+
+        public int getIndex() {
+            return index;
+        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.utils;
+
+import org.ta4j.core.Indicator;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public final class IndicatorUtils {
+
+    /**
+     * Creates a stream from the indicator values
+     * 
+     * @param indicator indicator to be used
+     * @param <T>       Indicator type
+     * @return the stream of values
+     */
+    public static <T> Stream<T> streamOf(Indicator<T> indicator) {
+        return IntStream.range(0, indicator.getBarSeries().getBarCount()).mapToObj(indicator::getValue);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -97,9 +97,7 @@ public final class IndicatorUtils {
      */
     public static Double[] toDouble(Indicator<Num> ref, int index, int barCount) {
         int startIndex = Math.max(0, index - barCount + 1);
-        return IntStream.range(startIndex, startIndex + barCount)
-                .mapToObj(ref::getValue)
-                .map(Num::doubleValue)
+        return IntStream.range(startIndex, startIndex + barCount).mapToObj(ref::getValue).map(Num::doubleValue)
                 .toArray(Double[]::new);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -39,25 +39,24 @@ public final class IndicatorUtils {
      * @return the stream of values
      */
     public static <T> Stream<T> streamOf(final Indicator<T> indicator) {
-        return IntStream.range(0, indicator.getBarSeries()
-                .getBarCount())
-                .mapToObj(indicator::getValue);
+        return IntStream.range(0, indicator.getBarSeries().getBarCount()).mapToObj(indicator::getValue);
     }
 
     /**
-     * Creates a stream from the indicator values and applies a mapping function on each element.
-     * Indicator context is passed together with the index, so other values could be used for mapping.
-     * @param indicator indicator to be used
-     * @param mapFunction function that is applied in mapping receives a tuple in argument; that contains the indicator
-     *                   and integer index
-     * @param <T> type of indicator value
-     * @param <R> result type
+     * Creates a stream from the indicator values and applies a mapping function on
+     * each element. Indicator context is passed together with the index, so other
+     * values could be used for mapping.
+     * 
+     * @param indicator   indicator to be used
+     * @param mapFunction function that is applied in mapping receives a tuple in
+     *                    argument; that contains the indicator and integer index
+     * @param <T>         type of indicator value
+     * @param <R>         result type
      * @return the resulting type
      */
     public static <T, R> Stream<R> streamOf(final Indicator<T> indicator,
-                                            final Function<IndicatorContext<T>, R> mapFunction) {
-        return IntStream.range(0, indicator.getBarSeries()
-                .getBarCount())
+            final Function<IndicatorContext<T>, R> mapFunction) {
+        return IntStream.range(0, indicator.getBarSeries().getBarCount())
                 .mapToObj((int i) -> mapFunction.apply(new IndicatorContext<>(indicator, i)));
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -24,6 +24,7 @@
 package org.ta4j.core.utils;
 
 import org.ta4j.core.Indicator;
+import org.ta4j.core.num.Num;
 
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -82,5 +83,23 @@ public final class IndicatorUtils {
         public int getIndex() {
             return index;
         }
+    }
+
+    /**
+     * Returns all values from an {@link Indicator} as an array of Doubles. The
+     * returned doubles could have a minor loss of precise, if {@link Indicator} was
+     * based on {@link Num Num}.
+     *
+     * @param ref      the indicator
+     * @param index    the index
+     * @param barCount the barCount
+     * @return array of Doubles within the barCount
+     */
+    public static Double[] toDouble(Indicator<Num> ref, int index, int barCount) {
+        int startIndex = Math.max(0, index - barCount + 1);
+        return IntStream.range(startIndex, startIndex + barCount)
+                .mapToObj(ref::getValue)
+                .map(Num::doubleValue)
+                .toArray(Double[]::new);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/IndicatorUtils.java
@@ -29,7 +29,13 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+/**
+ * Common utilities and helper methods for Indicator.
+ */
 public final class IndicatorUtils {
+
+    private IndicatorUtils() {
+    }
 
     /**
      * Creates a stream from the indicator values
@@ -46,13 +52,13 @@ public final class IndicatorUtils {
      * Creates a stream from the indicator values and applies a mapping function on
      * each element. Indicator context is passed together with the index, so other
      * values could be used for mapping.
-     * 
+     *
      * @param indicator   indicator to be used
      * @param mapFunction function that is applied in mapping receives a tuple in
      *                    argument; that contains the indicator and integer index
      * @param <T>         type of indicator value
      * @param <R>         result type
-     * @return the resulting type
+     * @return the resulting value
      */
     public static <T, R> Stream<R> streamOf(final Indicator<T> indicator,
             final Function<IndicatorContext<T>, R> mapFunction) {

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.Test;
 import org.ta4j.core.mocks.MockIndicator;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.utils.IndicatorUtils;
 
 /**
  * Tests for {@link Indicator}.
@@ -51,7 +52,7 @@ public class IndicatorTest {
         int index = 10;
         int barCount = 3;
 
-        Double[] doubles = Indicator.toDouble(indicator, index, barCount);
+        Double[] doubles = IndicatorUtils.toDouble(indicator, index, barCount);
 
         assertTrue(doubles.length == barCount);
         assertTrue(doubles[0] == 8d);

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/IndicatorUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/IndicatorUtilsTest.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class IndicatorUtilsTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -78,7 +79,7 @@ public class IndicatorUtilsTest extends AbstractIndicatorTest<Indicator<Num>, Nu
 
         Assert.assertNotNull(stream);
         Assert.assertNotNull(collectedValues);
-        Assert.assertEquals(30, collectedValues.size());
+        assertEquals(30, collectedValues.size());
         assertNumEquals(typicalPrices[0], collectedValues.get(0));
         assertNumEquals(typicalPrices[1], collectedValues.get(1));
         assertNumEquals(typicalPrices[2], collectedValues.get(2));
@@ -91,16 +92,18 @@ public class IndicatorUtilsTest extends AbstractIndicatorTest<Indicator<Num>, Nu
     public void shouldProvideStreamWithMapping() {
         ClosePriceIndicator indicator = new ClosePriceIndicator(series);
 
-        final Function<IndicatorUtils.IndicatorContext<Num>, ValueWithTimestamp> mapFunction = (IndicatorUtils.IndicatorContext<Num> ctx) -> new ValueWithTimestamp(
-                indicator.getValue(ctx.getIndex()),
-                ctx.getIndicator().getBarSeries().getBar(ctx.getIndex()).getEndTime().toInstant());
+        final Function<IndicatorUtils.IndicatorContext<Num>, ValueWithTimestamp> mapFunction = (
+                IndicatorUtils.IndicatorContext<Num> ctx) -> new ValueWithTimestamp(indicator.getValue(ctx.getIndex()),
+                        ctx.getIndicator().getBarSeries().getBar(ctx.getIndex()).getEndTime().toInstant());
 
         Stream<ValueWithTimestamp> stream = IndicatorUtils.streamOf(indicator, mapFunction);
         List<ValueWithTimestamp> collectedValues = stream.collect(Collectors.toList());
 
         Assert.assertNotNull(stream);
         Assert.assertNotNull(collectedValues);
-        Assert.assertEquals(30, collectedValues.size());
+        assertEquals(30, collectedValues.size());
+        assertNumEquals(typicalPrices[0], collectedValues.get(0).value);
+        assertEquals(series.getBar(0).getEndTime().toInstant(), collectedValues.get(0).getTimestamp());
 
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/IndicatorUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/IndicatorUtilsTest.java
@@ -1,0 +1,89 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBar;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+public class IndicatorUtilsTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    private double[] typicalPrices = new double[] { 23.98, 23.92, 23.79, 23.67, 23.54, 23.36, 23.65, 23.72, 24.16,
+            23.91, 23.81, 23.92, 23.74, 24.68, 24.94, 24.93, 25.10, 25.12, 25.20, 25.06, 24.50, 24.31, 24.57, 24.62,
+            24.49, 24.37, 24.41, 24.35, 23.75, 24.09 };
+
+    private MockBarSeries series;
+
+    /**
+     * Constructor.
+     *
+     * @param function
+     */
+    public IndicatorUtilsTest(Function<Number, Num> function) {
+        super(function);
+    }
+
+    @Before
+    public void setUp() {
+        ArrayList<Bar> bars = new ArrayList<>();
+        for (Double price : typicalPrices) {
+            bars.add(new MockBar(price, price, price, price, numFunction));
+        }
+        series = new MockBarSeries(bars);
+    }
+
+    @Test
+    public void shouldProvideStream() {
+        ClosePriceIndicator indicator = new ClosePriceIndicator(series);
+
+        Stream<Num> stream = IndicatorUtils.streamOf(indicator);
+        List<Num> collectedValues = stream.collect(Collectors.toList());
+
+        Assert.assertNotNull(stream);
+        Assert.assertNotNull(collectedValues);
+        Assert.assertEquals(30, collectedValues.size());
+        assertNumEquals(typicalPrices[0], collectedValues.get(0));
+        assertNumEquals(typicalPrices[1], collectedValues.get(1));
+        assertNumEquals(typicalPrices[2], collectedValues.get(2));
+        assertNumEquals(typicalPrices[10], collectedValues.get(10));
+        assertNumEquals(typicalPrices[20], collectedValues.get(20));
+        assertNumEquals(typicalPrices[29], collectedValues.get(29));
+
+    }
+}


### PR DESCRIPTION
Would this addition be useful? Sometimes, I need to process indicator values in a stream. This helps to convert to stream. 
Perhaps other location is better... no strong opinion.

Changes proposed in this pull request:
- Added streamOf utility function in _ IndicatorUtils_


- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
