### PR TITLE
Formatter: enhance formatting for chaining methods

### DIFF
--- a/ta4j-core/code-formatter.xml
+++ b/ta4j-core/code-formatter.xml
@@ -182,7 +182,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -115,7 +115,8 @@ public interface BarSeries extends Serializable {
         if (!getBarData().isEmpty()) {
             Bar firstBar = getFirstBar();
             Bar lastBar = getLastBar();
-            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)).append(" - ")
+            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                    .append(" - ")
                     .append(lastBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
         }
         return sb.toString();

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
@@ -37,7 +37,10 @@ public class NumberOfBarsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed).map(t -> calculate(series, t))
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(t -> calculate(series, t))
                 .reduce(series.numOf(0), Num::plus);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
@@ -35,8 +35,11 @@ public class NumberOfBreakEvenPositionsCriterion extends AbstractAnalysisCriteri
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfBreakEvenTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isBreakEvenTrade).count();
+        long numberOfBreakEvenTrades = tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .filter(this::isBreakEvenTrade)
+                .count();
         return series.numOf(numberOfBreakEvenTrades);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfLosingPositionsCriterion.java
@@ -35,8 +35,11 @@ public class NumberOfLosingPositionsCriterion extends AbstractAnalysisCriterion 
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfLosingTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isLosingTrade).count();
+        long numberOfLosingTrades = tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .filter(this::isLosingTrade)
+                .count();
         return series.numOf(numberOfLosingTrades);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfWinningPositionsCriterion.java
@@ -35,8 +35,11 @@ public class NumberOfWinningPositionsCriterion extends AbstractAnalysisCriterion
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfWinningTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isWinningTrade).count();
+        long numberOfWinningTrades = tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .filter(this::isWinningTrade)
+                .count();
         return series.numOf(numberOfWinningTrades);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/WinningPositionsRatioCriterion.java
@@ -50,7 +50,9 @@ public class WinningPositionsRatioCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfProfitable = tradingRecord.getPositions().stream().filter(t -> isProfitablePosition(series, t))
+        long numberOfProfitable = tradingRecord.getPositions()
+                .stream()
+                .filter(t -> isProfitablePosition(series, t))
                 .count();
         return series.numOf(numberOfProfitable).dividedBy(series.numOf(tradingRecord.getPositionCount()));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
@@ -40,8 +40,11 @@ public class GrossLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
@@ -40,8 +40,11 @@ public class GrossProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
@@ -40,7 +40,9 @@ public class GrossReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().map(position -> calculateProfit(series, position))
+        return tradingRecord.getPositions()
+                .stream()
+                .map(position -> calculateProfit(series, position))
                 .reduce(series.numOf(1), Num::multipliedBy);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
@@ -40,8 +40,11 @@ public class NetLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
@@ -40,8 +40,11 @@ public class NetProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
@@ -39,8 +39,11 @@ public class ProfitLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -41,8 +41,11 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -99,19 +99,19 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         if (index == getBarSeries().getBeginIndex()) {
             return sar; // no trend detection possible for the first value
         } else if (index == getBarSeries().getBeginIndex() + 1) {// start trend detection
-            currentTrend = getBarSeries().getBar(getBarSeries().getBeginIndex()).getClosePrice()
+            currentTrend = getBarSeries().getBar(getBarSeries().getBeginIndex())
+                    .getClosePrice()
                     .isLessThan(getBarSeries().getBar(index).getClosePrice());
             if (!currentTrend) { // down trend
-                sar = new HighestValueIndicator(highPriceIndicator, 2).getValue(index); // put the highest high value of
-                                                                                        // two first bars
+                // put the highest high value of two first bars
+                sar = new HighestValueIndicator(highPriceIndicator, 2).getValue(index);
                 currentExtremePoint = sar;
                 minMaxExtremePoint = currentExtremePoint;
             } else { // up trend
-                sar = new LowestValueIndicator(lowPriceIndicator, 2).getValue(index); // put the lowest low value of two
-                                                                                      // first bars
+                // put the lowest low value of two first bars
+                sar = new LowestValueIndicator(lowPriceIndicator, 2).getValue(index);
                 currentExtremePoint = sar;
                 minMaxExtremePoint = currentExtremePoint;
-
             }
             return sar;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -71,7 +71,9 @@ public class StochasticOscillatorKIndicator extends CachedIndicator<Num> {
         Num highestHighPrice = highestHigh.getValue(index);
         Num lowestLowPrice = lowestMin.getValue(index);
 
-        return indicator.getValue(index).minus(lowestLowPrice).dividedBy(highestHighPrice.minus(lowestLowPrice))
+        return indicator.getValue(index)
+                .minus(lowestLowPrice)
+                .dividedBy(highestHighPrice.minus(lowestLowPrice))
                 .multipliedBy(numOf(100));
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -51,8 +51,9 @@ public class TimeRangeRule extends AbstractRule {
         boolean satisfied = false;
         ZonedDateTime dateTime = this.timeIndicator.getValue(index);
         LocalTime localTime = dateTime.toLocalTime();
-        satisfied = this.timeRanges.stream().anyMatch(
-                timeRange -> !localTime.isBefore(timeRange.getFrom()) && !localTime.isAfter(timeRange.getTo()));
+        satisfied = this.timeRanges.stream()
+                .anyMatch(
+                        timeRange -> !localTime.isBefore(timeRange.getFrom()) && !localTime.isAfter(timeRange.getTo()));
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -157,10 +157,15 @@ public final class BarSeriesUtils {
         for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex(); i++) {
             Bar bar = bars.get(i);
             Bar convertedBar = new ConvertibleBaseBarBuilder<Number>(conversionFunction::apply)
-                    .timePeriod(bar.getTimePeriod()).endTime(bar.getEndTime())
-                    .openPrice(bar.getOpenPrice().getDelegate()).highPrice(bar.getHighPrice().getDelegate())
-                    .lowPrice(bar.getLowPrice().getDelegate()).closePrice(bar.getClosePrice().getDelegate())
-                    .volume(bar.getVolume().getDelegate()).amount(bar.getAmount().getDelegate()).trades(bar.getTrades())
+                    .timePeriod(bar.getTimePeriod())
+                    .endTime(bar.getEndTime())
+                    .openPrice(bar.getOpenPrice().getDelegate())
+                    .highPrice(bar.getHighPrice().getDelegate())
+                    .lowPrice(bar.getLowPrice().getDelegate())
+                    .closePrice(bar.getClosePrice().getDelegate())
+                    .volume(bar.getVolume().getDelegate())
+                    .amount(bar.getAmount().getDelegate())
+                    .trades(bar.getTrades())
                     .build();
             convertedBars.add(convertedBar);
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -82,7 +82,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         defaultName = "Series Name";
 
-        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName(defaultName).withBars(bars)
+        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
+                .withName(defaultName)
+                .withBars(bars)
                 .build();
 
         subSeries = defaultSeries.getSubSeries(2, 5);
@@ -147,8 +149,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
         // Default series
         assertTrue(defaultSeries.getSeriesPeriodDescription()
                 .endsWith(bars.get(defaultSeries.getEndIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
-        assertTrue(defaultSeries.getSeriesPeriodDescription().startsWith(
-                bars.get(defaultSeries.getBeginIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
+        assertTrue(defaultSeries.getSeriesPeriodDescription()
+                .startsWith(
+                        bars.get(defaultSeries.getBeginIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
         // Constrained series
         assertTrue(subSeries.getSeriesPeriodDescription()
                 .endsWith(bars.get(4).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
@@ -347,7 +350,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void subSeriesOfMaxBarCountSeriesTest() {
         final BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
-                .withName("Series with maxBar count").withMaxBarCount(20).build();
+                .withName("Series with maxBar count")
+                .withMaxBarCount(20)
+                .build();
         final int timespan = 5;
 
         IntStream.range(0, 100).forEach(i -> {

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -46,9 +46,16 @@ public class BaseBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
         final Duration duration = Duration.between(beginTime, endTime);
 
-        final BaseBar bar = new BaseBarBuilder().timePeriod(duration).endTime(endTime).openPrice(numOf(101))
-                .highPrice(numOf(103)).lowPrice(numOf(100)).closePrice(numOf(102)).trades(4).volume(numOf(40))
-                .amount(numOf(4020)).build();
+        final BaseBar bar = new BaseBarBuilder().timePeriod(duration)
+                .endTime(endTime)
+                .openPrice(numOf(101))
+                .highPrice(numOf(103))
+                .lowPrice(numOf(100))
+                .closePrice(numOf(102))
+                .trades(4)
+                .volume(numOf(40))
+                .amount(numOf(4020))
+                .build();
 
         assertEquals(duration, bar.getTimePeriod());
         assertEquals(beginTime, bar.getBeginTime());

--- a/ta4j-core/src/test/java/org/ta4j/core/ConvertibleBaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConvertibleBaseBarBuilderTest.java
@@ -54,10 +54,16 @@ public class ConvertibleBaseBarBuilderTest extends AbstractIndicatorTest<BarSeri
         final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
         final Duration duration = Duration.between(beginTime, endTime);
 
-        final BaseBar bar = new ConvertibleBaseBarBuilder<BigDecimal>(this::numOf).timePeriod(duration).endTime(endTime)
-                .openPrice(BigDecimal.valueOf(101.0)).highPrice(BigDecimal.valueOf(103))
-                .lowPrice(BigDecimal.valueOf(100)).closePrice(BigDecimal.valueOf(102)).trades(4)
-                .volume(BigDecimal.valueOf(40)).amount(BigDecimal.valueOf(4020)).build();
+        final BaseBar bar = new ConvertibleBaseBarBuilder<BigDecimal>(this::numOf).timePeriod(duration)
+                .endTime(endTime)
+                .openPrice(BigDecimal.valueOf(101.0))
+                .highPrice(BigDecimal.valueOf(103))
+                .lowPrice(BigDecimal.valueOf(100))
+                .closePrice(BigDecimal.valueOf(102))
+                .trades(4)
+                .volume(BigDecimal.valueOf(40))
+                .amount(BigDecimal.valueOf(4020))
+                .build();
 
         assertEquals(duration, bar.getTimePeriod());
         assertEquals(beginTime, bar.getBeginTime());

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -49,10 +49,14 @@ public class SeriesBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         BarSeries defaultSeries = seriesBuilder.build(); // build a new empty unnamed bar series
         BarSeries defaultSeriesName = seriesBuilder.withName("default").build(); // build a new empty bar series using
                                                                                  // BigDecimal as delegate
-        BarSeries doubleSeries = seriesBuilder.withMaxBarCount(100).withNumTypeOf(DoubleNum.class)
-                .withName("useDoubleNum").build();
-        BarSeries precisionSeries = seriesBuilder.withMaxBarCount(100).withNumTypeOf(DecimalNum.class)
-                .withName("usePrecisionNum").build();
+        BarSeries doubleSeries = seriesBuilder.withMaxBarCount(100)
+                .withNumTypeOf(DoubleNum.class)
+                .withName("useDoubleNum")
+                .build();
+        BarSeries precisionSeries = seriesBuilder.withMaxBarCount(100)
+                .withNumTypeOf(DecimalNum.class)
+                .withName("usePrecisionNum")
+                .build();
 
         for (int i = 1000; i >= 0; i--) {
             defaultSeries.addBar(ZonedDateTime.now().minusSeconds(i), i, i, i, i, i);

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -97,7 +97,8 @@ public class XlsTestsUtils {
             if (evaluator.evaluate(row.getCell(0)).formatAsString().contains("Param")) {
                 // stream parameters into the second column of subsequent rows
                 // overwrites data section if there is not a large enough gap
-                Arrays.stream(params).mapToDouble(Num::doubleValue)
+                Arrays.stream(params)
+                        .mapToDouble(Num::doubleValue)
                         .forEach(d -> iterator.next().getCell(1).setCellValue(d));
                 return;
             }
@@ -186,7 +187,8 @@ public class XlsTestsUtils {
      */
     private static List<Num> getValues(Sheet sheet, int column, Function<Number, Num> numFunction, Object... params)
             throws DataFormatException {
-        Num[] NumParams = Arrays.stream(params).map(p -> numFunction.apply(new BigDecimal(p.toString())))
+        Num[] NumParams = Arrays.stream(params)
+                .map(p -> numFunction.apply(new BigDecimal(p.toString())))
                 .toArray(Num[]::new);
         return getValues(sheet, column, numFunction, NumParams);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterionTest.java
@@ -72,7 +72,10 @@ public class ExpectedShortfallCriterionTest extends AbstractCriterionTest {
     @Test
     public void calculateOnlyWithLossPosition() {
         // regularly decreasing prices
-        List<Double> prices = IntStream.rangeClosed(1, 100).asDoubleStream().boxed().sorted(Collections.reverseOrder())
+        List<Double> prices = IntStream.rangeClosed(1, 100)
+                .asDoubleStream()
+                .boxed()
+                .sorted(Collections.reverseOrder())
                 .collect(Collectors.toList());
         series = new MockBarSeries(numFunction, prices);
         Position position = new Position(Trade.buyAt(series.getBeginIndex(), series),

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -23,6 +23,10 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -30,10 +34,6 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.function.Function;
-
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class MACDIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
@@ -23,6 +23,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
@@ -31,13 +37,6 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class PVOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -154,11 +154,17 @@ public class RSIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         // TATestsUtils.GENERAL_OFFSET);
         // second online calculation uses MMAs
         // MMA of average gain
-        double dividend = avgGain.getValue(14).multipliedBy(series.numOf(13)).plus(gain.getValue(15))
-                .dividedBy(series.numOf(14)).doubleValue();
+        double dividend = avgGain.getValue(14)
+                .multipliedBy(series.numOf(13))
+                .plus(gain.getValue(15))
+                .dividedBy(series.numOf(14))
+                .doubleValue();
         // MMA of average loss
-        double divisor = avgLoss.getValue(14).multipliedBy(series.numOf(13)).plus(loss.getValue(15))
-                .dividedBy(series.numOf(14)).doubleValue();
+        double divisor = avgLoss.getValue(14)
+                .multipliedBy(series.numOf(13))
+                .plus(loss.getValue(15))
+                .dividedBy(series.numOf(14))
+                .doubleValue();
         onlineRs = dividend / divisor;
         assertEquals(0.9409, onlineRs, TestUtils.GENERAL_OFFSET);
         onlineRsi = 100d - (100d / (1d + onlineRs));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -71,7 +71,9 @@ public class MedianPriceIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     public void indicatorShouldRetrieveBarClosePrice() {
         Num result;
         for (int i = 0; i < 10; i++) {
-            result = barSeries.getBar(i).getHighPrice().plus(barSeries.getBar(i).getLowPrice())
+            result = barSeries.getBar(i)
+                    .getHighPrice()
+                    .plus(barSeries.getBar(i).getLowPrice())
                     .dividedBy(barSeries.numOf(2));
             assertEquals(average.getValue(i), result);
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
@@ -56,7 +56,9 @@ public class TypicalPriceIndicatorTest extends AbstractIndicatorTest<Indicator<N
     public void indicatorShouldRetrieveBarHighPrice() {
         for (int i = 0; i < 10; i++) {
             Bar bar = barSeries.getBar(i);
-            Num typicalPrice = bar.getHighPrice().plus(bar.getLowPrice()).plus(bar.getClosePrice())
+            Num typicalPrice = bar.getHighPrice()
+                    .plus(bar.getLowPrice())
+                    .plus(bar.getClosePrice())
                     .dividedBy(barSeries.numOf(3));
             assertEquals(typicalPrice, typicalPriceIndicator.getValue(i));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1390,18 +1390,30 @@ public class PivotPointIndicatorTest {
         assertEquals(fibS2.getValue(series1Hours.getBeginIndex()), NaN);
         assertEquals(fibS3.getValue(6), NaN);
 
-        assertEquals(fibR3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(1).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibR2.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(0.618).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibR1.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(0.382).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS1.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(0.382).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS2.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(0.618).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(1).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR3.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(1)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR2.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(0.618)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR1.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(0.382)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS1.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(0.382)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS2.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(0.618)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS3.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(1)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
 
         DeMarkPivotPointIndicator deMarkpp = new DeMarkPivotPointIndicator(series1Hours, WEEK);
         DeMarkReversalIndicator deMarkR1 = new DeMarkReversalIndicator(deMarkpp,

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -153,16 +153,26 @@ public class DecimalNumTest {
             endTime = endTime.plus(timePeriod);
             superPrecisionNum = superPrecisionNum.plus(DecimalNum.valueOf(deltas[i % 6]));
         }
-        superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision").withNumTypeOf(superPrecisionFunc)
-                .withBars(superPrecisionBarList).build();
-        precisionSeries = new BaseBarSeriesBuilder().withName("precision").withNumTypeOf(precisionFunc)
-                .withBars(precisionBarList).build();
-        precision32Series = new BaseBarSeriesBuilder().withName("precision32").withNumTypeOf(precision32Func)
-                .withBars(precision32BarList).build();
-        doubleSeries = new BaseBarSeriesBuilder().withName("double").withNumTypeOf(doubleFunc).withBars(doubleBarList)
+        superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision")
+                .withNumTypeOf(superPrecisionFunc)
+                .withBars(superPrecisionBarList)
                 .build();
-        lowPrecisionSeries = new BaseBarSeriesBuilder().withName("lowPrecision").withNumTypeOf(lowPrecisionFunc)
-                .withBars(lowPrecisionBarList).build();
+        precisionSeries = new BaseBarSeriesBuilder().withName("precision")
+                .withNumTypeOf(precisionFunc)
+                .withBars(precisionBarList)
+                .build();
+        precision32Series = new BaseBarSeriesBuilder().withName("precision32")
+                .withNumTypeOf(precision32Func)
+                .withBars(precision32BarList)
+                .build();
+        doubleSeries = new BaseBarSeriesBuilder().withName("double")
+                .withNumTypeOf(doubleFunc)
+                .withBars(doubleBarList)
+                .build();
+        lowPrecisionSeries = new BaseBarSeriesBuilder().withName("lowPrecision")
+                .withNumTypeOf(lowPrecisionFunc)
+                .withBars(lowPrecisionBarList)
+                .build();
     }
 
     public void test() {

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -121,9 +121,15 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         final Bar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
         final Bar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
         final Bar bar7 = new MockBar(time.plusDays(7), 0, 0, 0, 0, 0, 0, 0, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(time.plusDays(8)).openPrice(NaN.NaN).highPrice(NaN.NaN).lowPrice(NaN.NaN).closePrice(NaN.NaN)
-                .volume(NaN.NaN).build();
+        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(time.plusDays(8))
+                .openPrice(NaN.NaN)
+                .highPrice(NaN.NaN)
+                .lowPrice(NaN.NaN)
+                .closePrice(NaN.NaN)
+                .volume(NaN.NaN)
+                .build();
 
         bars.add(bar0);
         bars.add(bar1);
@@ -158,8 +164,11 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, decimalNumFunction));
         bars.add(new MockBar(time.plusDays(2), 2d, 2d, 2d, 2d, 2d, 2d, 2, decimalNumFunction));
 
-        final BarSeries decimalBarSeries = new BaseBarSeriesBuilder().withBars(bars).withMaxBarCount(100)
-                .withNumTypeOf(DecimalNum.class).withName("useDecimalNum").build();
+        final BarSeries decimalBarSeries = new BaseBarSeriesBuilder().withBars(bars)
+                .withMaxBarCount(100)
+                .withNumTypeOf(DecimalNum.class)
+                .withName("useDecimalNum")
+                .build();
 
         // convert barSeries with DecimalNum to barSeries with DoubleNum
         final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries, doubleNumFunction);
@@ -185,9 +194,15 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
         final Bar bar1 = new MockBar(time, 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(time.plusDays(8)).openPrice(NaN.NaN).highPrice(NaN.NaN).lowPrice(NaN.NaN).closePrice(NaN.NaN)
-                .volume(NaN.NaN).build();
+        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(time.plusDays(8))
+                .openPrice(NaN.NaN)
+                .highPrice(NaN.NaN)
+                .lowPrice(NaN.NaN)
+                .closePrice(NaN.NaN)
+                .volume(NaN.NaN)
+                .build();
 
         bars.add(bar0);
         bars.add(bar1);

--- a/ta4j-examples/code-formatter.xml
+++ b/ta4j-examples/code-formatter.xml
@@ -182,7 +182,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -87,7 +87,8 @@ public class Quickstart {
         // - or if the price loses more than 3%
         // - or if the price earns more than 2%
         Rule sellingRule = new CrossedDownIndicatorRule(shortSma, longSma)
-                .or(new StopLossRule(closePrice, series.numOf(3))).or(new StopGainRule(closePrice, series.numOf(2)));
+                .or(new StopLossRule(closePrice, series.numOf(3)))
+                .or(new StopGainRule(closePrice, series.numOf(2)));
 
         // Running our juicy trading strategy...
         BarSeriesManager seriesManager = new BarSeriesManager(series);

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -84,8 +84,14 @@ public class SimpleMovingAverageBacktest {
 
     private static BaseBar createBar(ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice,
             Number closePrice, Number volume) {
-        return BaseBar.builder(DecimalNum::valueOf, Number.class).timePeriod(Duration.ofDays(1)).endTime(endTime)
-                .openPrice(openPrice).highPrice(highPrice).lowPrice(lowPrice).closePrice(closePrice).volume(volume)
+        return BaseBar.builder(DecimalNum::valueOf, Number.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime)
+                .openPrice(openPrice)
+                .highPrice(highPrice)
+                .lowPrice(lowPrice)
+                .closePrice(closePrice)
+                .volume(volume)
                 .build();
     }
 

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -124,14 +124,33 @@ public class BuildBarSeries {
         // create bars and add them to the series. The bars must have the same Num type
         // as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar b1 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1)).endTime(endTime)
-                .openPrice(105.42).highPrice(112.99).lowPrice(104.01).closePrice(111.42).volume(1337.0).build();
-        Bar b2 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(1)).openPrice(111.43).highPrice(112.83).lowPrice(107.77).closePrice(107.99)
-                .volume(1234.0).build();
-        Bar b3 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(2)).openPrice(107.90).highPrice(117.50).lowPrice(107.90).closePrice(115.42)
-                .volume(4242.0).build();
+        Bar b1 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime)
+                .openPrice(105.42)
+                .highPrice(112.99)
+                .lowPrice(104.01)
+                .closePrice(111.42)
+                .volume(1337.0)
+                .build();
+        Bar b2 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(1))
+                .openPrice(111.43)
+                .highPrice(112.83)
+                .lowPrice(107.77)
+                .closePrice(107.99)
+                .volume(1234.0)
+                .build();
+        Bar b3 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(2))
+                .openPrice(107.90)
+                .highPrice(117.50)
+                .lowPrice(107.90)
+                .closePrice(115.42)
+                .volume(4242.0)
+                .build();
         // ...
 
         series.addBar(b1);
@@ -145,16 +164,37 @@ public class BuildBarSeries {
         // Store Bars in a list and add them later. The bars must have the same Num type
         // as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar b1 = barBuilderFromString().timePeriod(Duration.ofDays(1)).endTime(endTime).openPrice("105.42")
-                .highPrice("112.99").lowPrice("104.01").closePrice("111.42").volume("1337").build();
-        Bar b2 = barBuilderFromString().timePeriod(Duration.ofDays(1)).endTime(endTime.plusDays(1)).openPrice("111.43")
-                .highPrice("112.83").lowPrice("107.77").closePrice("107.99").volume("1234").build();
-        Bar b3 = barBuilderFromString().timePeriod(Duration.ofDays(1)).endTime(endTime.plusDays(2)).openPrice("107.90")
-                .highPrice("117.50").lowPrice("107.90").closePrice("115.42").volume("4242").build();
+        Bar b1 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+                .endTime(endTime)
+                .openPrice("105.42")
+                .highPrice("112.99")
+                .lowPrice("104.01")
+                .closePrice("111.42")
+                .volume("1337")
+                .build();
+        Bar b2 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(1))
+                .openPrice("111.43")
+                .highPrice("112.83")
+                .lowPrice("107.77")
+                .closePrice("107.99")
+                .volume("1234")
+                .build();
+        Bar b3 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+                .endTime(endTime.plusDays(2))
+                .openPrice("107.90")
+                .highPrice("117.50")
+                .lowPrice("107.90")
+                .closePrice("115.42")
+                .volume("4242")
+                .build();
         List<Bar> bars = Arrays.asList(b1, b2, b3);
 
-        return new BaseBarSeriesBuilder().withName("mySeries").withNumTypeOf(DoubleNum::valueOf).withMaxBarCount(5)
-                .withBars(bars).build();
+        return new BaseBarSeriesBuilder().withName("mySeries")
+                .withNumTypeOf(DoubleNum::valueOf)
+                .withMaxBarCount(5)
+                .withBars(bars)
+                .build();
     }
 
     private static ConvertibleBaseBarBuilder<String> barBuilderFromString() {

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
@@ -96,13 +96,34 @@ public class IndicatorsToCsv {
          */
         final int nbBars = series.getBarCount();
         for (int i = 0; i < nbBars; i++) {
-            sb.append(series.getBar(i).getEndTime()).append(',').append(closePrice.getValue(i)).append(',')
-                    .append(typicalPrice.getValue(i)).append(',').append(priceVariation.getValue(i)).append(',')
-                    .append(shortSma.getValue(i)).append(',').append(longSma.getValue(i)).append(',')
-                    .append(shortEma.getValue(i)).append(',').append(longEma.getValue(i)).append(',')
-                    .append(ppo.getValue(i)).append(',').append(roc.getValue(i)).append(',').append(rsi.getValue(i))
-                    .append(',').append(williamsR.getValue(i)).append(',').append(atr.getValue(i)).append(',')
-                    .append(sd.getValue(i)).append('\n');
+            sb.append(series.getBar(i).getEndTime())
+                    .append(',')
+                    .append(closePrice.getValue(i))
+                    .append(',')
+                    .append(typicalPrice.getValue(i))
+                    .append(',')
+                    .append(priceVariation.getValue(i))
+                    .append(',')
+                    .append(shortSma.getValue(i))
+                    .append(',')
+                    .append(longSma.getValue(i))
+                    .append(',')
+                    .append(shortEma.getValue(i))
+                    .append(',')
+                    .append(longEma.getValue(i))
+                    .append(',')
+                    .append(ppo.getValue(i))
+                    .append(',')
+                    .append(roc.getValue(i))
+                    .append(',')
+                    .append(rsi.getValue(i))
+                    .append(',')
+                    .append(williamsR.getValue(i))
+                    .append(',')
+                    .append(atr.getValue(i))
+                    .append(',')
+                    .append(sd.getValue(i))
+                    .append('\n');
         }
 
         /*

--- a/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
@@ -60,8 +60,8 @@ public class StrategyExecutionLogging {
         try {
             configurator.doConfigure(LOGBACK_CONF_FILE);
         } catch (JoranException je) {
-            Logger.getLogger(StrategyExecutionLogging.class.getName()).log(Level.SEVERE,
-                    "Unable to load Logback configuration", je);
+            Logger.getLogger(StrategyExecutionLogging.class.getName())
+                    .log(Level.SEVERE, "Unable to load Logback configuration", je);
         }
     }
 

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -53,12 +53,15 @@ public class CompareNumTypes {
 
     public static void main(String args[]) {
         BaseBarSeriesBuilder barSeriesBuilder = new BaseBarSeriesBuilder();
-        BarSeries seriesD = barSeriesBuilder.withName("Sample Series Double    ").withNumTypeOf(DoubleNum::valueOf)
+        BarSeries seriesD = barSeriesBuilder.withName("Sample Series Double    ")
+                .withNumTypeOf(DoubleNum::valueOf)
                 .build();
-        BarSeries seriesP = barSeriesBuilder.withName("Sample Series DecimalNum 32").withNumTypeOf(DecimalNum::valueOf)
+        BarSeries seriesP = barSeriesBuilder.withName("Sample Series DecimalNum 32")
+                .withNumTypeOf(DecimalNum::valueOf)
                 .build();
         BarSeries seriesPH = barSeriesBuilder.withName("Sample Series DecimalNum 256")
-                .withNumTypeOf(number -> DecimalNum.valueOf(number.toString(), 256)).build();
+                .withNumTypeOf(number -> DecimalNum.valueOf(number.toString(), 256))
+                .build();
 
         int[] randoms = new Random().ints(NUMBARS, 80, 100).toArray();
         for (int i = 0; i < randoms.length; i++) {

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
@@ -80,8 +80,9 @@ public class UnstableIndicatorStrategy {
 
     public static void test(String name, Stream<Double> closePrices) {
         // Getting the bar series
-        BarSeries series = new BaseBarSeriesBuilder().withBars(
-                closePrices.map(close -> new BaseBar(MINUTE, TIME, 0, 0, 0, close, 0)).collect(Collectors.toList()))
+        BarSeries series = new BaseBarSeriesBuilder()
+                .withBars(closePrices.map(close -> new BaseBar(MINUTE, TIME, 0, 0, 0, close, 0))
+                        .collect(Collectors.toList()))
                 .build();
 
         // Building the trading strategy


### PR DESCRIPTION
Changes proposed in this pull request:
- enhance `code-formatter.xml`: org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation (which provides better readability for method chaining (in stream operations, builder patterns,..)

For example, this format:

```
// before
long numberOfBreakEvenTrades = tradingRecord.getPositions().stream().filter(Position::isClosed).filter(this::isBreakEvenTrade)
                .count();
```

becomes this format:

```
// after (each method invocation on a new line)
long numberOfBreakEvenTrades = tradingRecord.getPositions()
                .stream()
                .filter(Position::isClosed)
                .filter(this::isBreakEvenTrade)
                .count();
```

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
