### PR TITLE
Provide common static Num's

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -115,7 +115,8 @@ public interface BarSeries extends Serializable {
         if (!getBarData().isEmpty()) {
             Bar firstBar = getFirstBar();
             Bar lastBar = getLastBar();
-            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)).append(" - ")
+            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                    .append(" - ")
                     .append(lastBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
         }
         return sb.toString();

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBarsCriterion.java
@@ -47,7 +47,10 @@ public class NumberOfBarsCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed).map(t -> calculate(series, t))
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(t -> calculate(series, t))
                 .reduce(series.numOf(0), Num::plus);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/NumberOfBreakEvenPositionsCriterion.java
@@ -40,8 +40,11 @@ public class NumberOfBreakEvenPositionsCriterion extends AbstractAnalysisCriteri
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        long numberOfBreakEvenTrades = tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .filter(this::isBreakEvenTrade).count();
+        long numberOfBreakEvenTrades = tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .filter(this::isBreakEvenTrade)
+                .count();
         return series.numOf(numberOfBreakEvenTrades);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossLossCriterion.java
@@ -49,8 +49,11 @@ public class GrossLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossProfitCriterion.java
@@ -49,8 +49,11 @@ public class GrossProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/GrossReturnCriterion.java
@@ -45,7 +45,9 @@ public class GrossReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().map(position -> calculateProfit(series, position))
+        return tradingRecord.getPositions()
+                .stream()
+                .map(position -> calculateProfit(series, position))
                 .reduce(series.numOf(1), Num::multipliedBy);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetLossCriterion.java
@@ -50,8 +50,11 @@ public class NetLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/NetProfitCriterion.java
@@ -50,8 +50,11 @@ public class NetProfitCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossCriterion.java
@@ -44,8 +44,11 @@ public class ProfitLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -51,8 +51,11 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return tradingRecord.getPositions().stream().filter(Position::isClosed)
-                .map(position -> calculate(series, position)).reduce(series.numOf(0), Num::plus);
+        return tradingRecord.getPositions()
+                .stream()
+                .filter(Position::isClosed)
+                .map(position -> calculate(series, position))
+                .reduce(series.numOf(0), Num::plus);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
@@ -64,7 +64,7 @@ public class CCIIndicator extends CachedIndicator<Num> {
         final Num typicalPriceAvg = smaInd.getValue(index);
         final Num meanDeviation = meanDeviationInd.getValue(index);
         if (meanDeviation.isZero()) {
-            return numOf(0);
+            return Num.ONE(typicalPrice);
         }
         return (typicalPrice.minus(typicalPriceAvg)).dividedBy(meanDeviation.multipliedBy(factor));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -99,7 +99,8 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         if (index == getBarSeries().getBeginIndex()) {
             return sar; // no trend detection possible for the first value
         } else if (index == getBarSeries().getBeginIndex() + 1) {// start trend detection
-            currentTrend = getBarSeries().getBar(getBarSeries().getBeginIndex()).getClosePrice()
+            currentTrend = getBarSeries().getBar(getBarSeries().getBeginIndex())
+                    .getClosePrice()
                     .isLessThan(getBarSeries().getBar(index).getClosePrice());
             if (!currentTrend) { // down trend
                 sar = new HighestValueIndicator(highPriceIndicator, 2).getValue(index); // put the highest high value of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -71,7 +71,9 @@ public class StochasticOscillatorKIndicator extends CachedIndicator<Num> {
         Num highestHighPrice = highestHigh.getValue(index);
         Num lowestLowPrice = lowestMin.getValue(index);
 
-        return indicator.getValue(index).minus(lowestLowPrice).dividedBy(highestHighPrice.minus(lowestLowPrice))
+        return indicator.getValue(index)
+                .minus(lowestLowPrice)
+                .dividedBy(highestHighPrice.minus(lowestLowPrice))
                 .multipliedBy(numOf(100));
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -75,6 +75,11 @@ public final class DecimalNum implements Num {
 
     private static final int DEFAULT_PRECISION = 32;
     private static final Logger log = LoggerFactory.getLogger(DecimalNum.class);
+
+    public static final DecimalNum ZERO = DecimalNum.valueOf(0);
+    public static final DecimalNum ONE = DecimalNum.valueOf(1);
+    public static final DecimalNum HUNDRED = DecimalNum.valueOf(100);
+
     private final MathContext mathContext;
     private final BigDecimal delegate;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -36,7 +36,13 @@ import java.util.function.Function;
 public class DoubleNum implements Num {
 
     private static final long serialVersionUID = -2611177221813615070L;
+
     private final static double EPS = 0.00001; // precision
+
+    public static final DoubleNum ZERO = DoubleNum.valueOf(0);
+    public static final DoubleNum ONE = DoubleNum.valueOf(1);
+    public static final DoubleNum HUNDRED = DoubleNum.valueOf(100);
+
     private final double delegate;
 
     private DoubleNum(double val) {

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -42,6 +42,19 @@ import java.util.function.Function;
 public interface Num extends Comparable<Num>, Serializable {
 
     /**
+     * @param anyNum any Num (used only to determine the Num type)
+     * @return 1 with type of anyNum
+     */
+    static Num ONE(Num anyNum) {
+        if (anyNum.getClass() == DecimalNum.class) {
+            return DecimalNum.ONE;
+        } else if (anyNum.getClass() == DoubleNum.class) {
+            return DoubleNum.ONE;
+        }
+        return NaN.NaN;
+    }
+
+    /**
      * @return the delegate used from this <code>Num</code> implementation
      */
     Number getDelegate();

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -51,8 +51,9 @@ public class TimeRangeRule extends AbstractRule {
         boolean satisfied = false;
         ZonedDateTime dateTime = this.timeIndicator.getValue(index);
         LocalTime localTime = dateTime.toLocalTime();
-        satisfied = this.timeRanges.stream().anyMatch(
-                timeRange -> !localTime.isBefore(timeRange.getFrom()) && !localTime.isAfter(timeRange.getTo()));
+        satisfied = this.timeRanges.stream()
+                .anyMatch(
+                        timeRange -> !localTime.isBefore(timeRange.getFrom()) && !localTime.isAfter(timeRange.getTo()));
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -157,10 +157,15 @@ public final class BarSeriesUtils {
         for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex(); i++) {
             Bar bar = bars.get(i);
             Bar convertedBar = new ConvertibleBaseBarBuilder<Number>(conversionFunction::apply)
-                    .timePeriod(bar.getTimePeriod()).endTime(bar.getEndTime())
-                    .openPrice(bar.getOpenPrice().getDelegate()).highPrice(bar.getHighPrice().getDelegate())
-                    .lowPrice(bar.getLowPrice().getDelegate()).closePrice(bar.getClosePrice().getDelegate())
-                    .volume(bar.getVolume().getDelegate()).amount(bar.getAmount().getDelegate()).trades(bar.getTrades())
+                    .timePeriod(bar.getTimePeriod())
+                    .endTime(bar.getEndTime())
+                    .openPrice(bar.getOpenPrice().getDelegate())
+                    .highPrice(bar.getHighPrice().getDelegate())
+                    .lowPrice(bar.getLowPrice().getDelegate())
+                    .closePrice(bar.getClosePrice().getDelegate())
+                    .volume(bar.getVolume().getDelegate())
+                    .amount(bar.getAmount().getDelegate())
+                    .trades(bar.getTrades())
                     .build();
             convertedBars.add(convertedBar);
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -82,7 +82,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         defaultName = "Series Name";
 
-        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName(defaultName).withBars(bars)
+        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
+                .withName(defaultName)
+                .withBars(bars)
                 .build();
 
         subSeries = defaultSeries.getSubSeries(2, 5);
@@ -147,8 +149,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
         // Default series
         assertTrue(defaultSeries.getSeriesPeriodDescription()
                 .endsWith(bars.get(defaultSeries.getEndIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
-        assertTrue(defaultSeries.getSeriesPeriodDescription().startsWith(
-                bars.get(defaultSeries.getBeginIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
+        assertTrue(defaultSeries.getSeriesPeriodDescription()
+                .startsWith(
+                        bars.get(defaultSeries.getBeginIndex()).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
         // Constrained series
         assertTrue(subSeries.getSeriesPeriodDescription()
                 .endsWith(bars.get(4).getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)));
@@ -347,7 +350,9 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void subSeriesOfMaxBarCountSeriesTest() {
         final BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
-                .withName("Series with maxBar count").withMaxBarCount(20).build();
+                .withName("Series with maxBar count")
+                .withMaxBarCount(20)
+                .build();
         final int timespan = 5;
 
         IntStream.range(0, 100).forEach(i -> {

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -46,9 +46,16 @@ public class BaseBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
         final Duration duration = Duration.between(beginTime, endTime);
 
-        final BaseBar bar = new BaseBarBuilder().timePeriod(duration).endTime(endTime).openPrice(numOf(101))
-                .highPrice(numOf(103)).lowPrice(numOf(100)).closePrice(numOf(102)).trades(4).volume(numOf(40))
-                .amount(numOf(4020)).build();
+        final BaseBar bar = new BaseBarBuilder().timePeriod(duration)
+                .endTime(endTime)
+                .openPrice(numOf(101))
+                .highPrice(numOf(103))
+                .lowPrice(numOf(100))
+                .closePrice(numOf(102))
+                .trades(4)
+                .volume(numOf(40))
+                .amount(numOf(4020))
+                .build();
 
         assertEquals(duration, bar.getTimePeriod());
         assertEquals(beginTime, bar.getBeginTime());

--- a/ta4j-core/src/test/java/org/ta4j/core/ConvertibleBaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConvertibleBaseBarBuilderTest.java
@@ -54,10 +54,16 @@ public class ConvertibleBaseBarBuilderTest extends AbstractIndicatorTest<BarSeri
         final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
         final Duration duration = Duration.between(beginTime, endTime);
 
-        final BaseBar bar = new ConvertibleBaseBarBuilder<BigDecimal>(this::numOf).timePeriod(duration).endTime(endTime)
-                .openPrice(BigDecimal.valueOf(101.0)).highPrice(BigDecimal.valueOf(103))
-                .lowPrice(BigDecimal.valueOf(100)).closePrice(BigDecimal.valueOf(102)).trades(4)
-                .volume(BigDecimal.valueOf(40)).amount(BigDecimal.valueOf(4020)).build();
+        final BaseBar bar = new ConvertibleBaseBarBuilder<BigDecimal>(this::numOf).timePeriod(duration)
+                .endTime(endTime)
+                .openPrice(BigDecimal.valueOf(101.0))
+                .highPrice(BigDecimal.valueOf(103))
+                .lowPrice(BigDecimal.valueOf(100))
+                .closePrice(BigDecimal.valueOf(102))
+                .trades(4)
+                .volume(BigDecimal.valueOf(40))
+                .amount(BigDecimal.valueOf(4020))
+                .build();
 
         assertEquals(duration, bar.getTimePeriod());
         assertEquals(beginTime, bar.getBeginTime());

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -49,10 +49,14 @@ public class SeriesBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         BarSeries defaultSeries = seriesBuilder.build(); // build a new empty unnamed bar series
         BarSeries defaultSeriesName = seriesBuilder.withName("default").build(); // build a new empty bar series using
                                                                                  // BigDecimal as delegate
-        BarSeries doubleSeries = seriesBuilder.withMaxBarCount(100).withNumTypeOf(DoubleNum.class)
-                .withName("useDoubleNum").build();
-        BarSeries precisionSeries = seriesBuilder.withMaxBarCount(100).withNumTypeOf(DecimalNum.class)
-                .withName("usePrecisionNum").build();
+        BarSeries doubleSeries = seriesBuilder.withMaxBarCount(100)
+                .withNumTypeOf(DoubleNum.class)
+                .withName("useDoubleNum")
+                .build();
+        BarSeries precisionSeries = seriesBuilder.withMaxBarCount(100)
+                .withNumTypeOf(DecimalNum.class)
+                .withName("usePrecisionNum")
+                .build();
 
         for (int i = 1000; i >= 0; i--) {
             defaultSeries.addBar(ZonedDateTime.now().minusSeconds(i), i, i, i, i, i);

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -97,7 +97,8 @@ public class XlsTestsUtils {
             if (evaluator.evaluate(row.getCell(0)).formatAsString().contains("Param")) {
                 // stream parameters into the second column of subsequent rows
                 // overwrites data section if there is not a large enough gap
-                Arrays.stream(params).mapToDouble(Num::doubleValue)
+                Arrays.stream(params)
+                        .mapToDouble(Num::doubleValue)
                         .forEach(d -> iterator.next().getCell(1).setCellValue(d));
                 return;
             }
@@ -186,7 +187,8 @@ public class XlsTestsUtils {
      */
     private static List<Num> getValues(Sheet sheet, int column, Function<Number, Num> numFunction, Object... params)
             throws DataFormatException {
-        Num[] NumParams = Arrays.stream(params).map(p -> numFunction.apply(new BigDecimal(p.toString())))
+        Num[] NumParams = Arrays.stream(params)
+                .map(p -> numFunction.apply(new BigDecimal(p.toString())))
                 .toArray(Num[]::new);
         return getValues(sheet, column, numFunction, NumParams);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/ExpectedShortfallCriterionTest.java
@@ -72,7 +72,10 @@ public class ExpectedShortfallCriterionTest extends AbstractCriterionTest {
     @Test
     public void calculateOnlyWithLossPosition() {
         // regularly decreasing prices
-        List<Double> prices = IntStream.rangeClosed(1, 100).asDoubleStream().boxed().sorted(Collections.reverseOrder())
+        List<Double> prices = IntStream.rangeClosed(1, 100)
+                .asDoubleStream()
+                .boxed()
+                .sorted(Collections.reverseOrder())
                 .collect(Collectors.toList());
         series = new MockBarSeries(numFunction, prices);
         Position position = new Position(Trade.buyAt(series.getBeginIndex(), series),

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -154,11 +154,17 @@ public class RSIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         // TATestsUtils.GENERAL_OFFSET);
         // second online calculation uses MMAs
         // MMA of average gain
-        double dividend = avgGain.getValue(14).multipliedBy(series.numOf(13)).plus(gain.getValue(15))
-                .dividedBy(series.numOf(14)).doubleValue();
+        double dividend = avgGain.getValue(14)
+                .multipliedBy(series.numOf(13))
+                .plus(gain.getValue(15))
+                .dividedBy(series.numOf(14))
+                .doubleValue();
         // MMA of average loss
-        double divisor = avgLoss.getValue(14).multipliedBy(series.numOf(13)).plus(loss.getValue(15))
-                .dividedBy(series.numOf(14)).doubleValue();
+        double divisor = avgLoss.getValue(14)
+                .multipliedBy(series.numOf(13))
+                .plus(loss.getValue(15))
+                .dividedBy(series.numOf(14))
+                .doubleValue();
         onlineRs = dividend / divisor;
         assertEquals(0.9409, onlineRs, TestUtils.GENERAL_OFFSET);
         onlineRsi = 100d - (100d / (1d + onlineRs));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -71,7 +71,9 @@ public class MedianPriceIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     public void indicatorShouldRetrieveBarClosePrice() {
         Num result;
         for (int i = 0; i < 10; i++) {
-            result = barSeries.getBar(i).getHighPrice().plus(barSeries.getBar(i).getLowPrice())
+            result = barSeries.getBar(i)
+                    .getHighPrice()
+                    .plus(barSeries.getBar(i).getLowPrice())
                     .dividedBy(barSeries.numOf(2));
             assertEquals(average.getValue(i), result);
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
@@ -56,7 +56,9 @@ public class TypicalPriceIndicatorTest extends AbstractIndicatorTest<Indicator<N
     public void indicatorShouldRetrieveBarHighPrice() {
         for (int i = 0; i < 10; i++) {
             Bar bar = barSeries.getBar(i);
-            Num typicalPrice = bar.getHighPrice().plus(bar.getLowPrice()).plus(bar.getClosePrice())
+            Num typicalPrice = bar.getHighPrice()
+                    .plus(bar.getLowPrice())
+                    .plus(bar.getClosePrice())
                     .dividedBy(barSeries.numOf(3));
             assertEquals(typicalPrice, typicalPriceIndicator.getValue(i));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1390,18 +1390,30 @@ public class PivotPointIndicatorTest {
         assertEquals(fibS2.getValue(series1Hours.getBeginIndex()), NaN);
         assertEquals(fibS3.getValue(6), NaN);
 
-        assertEquals(fibR3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(1).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibR2.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(0.618).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibR1.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).plus(
-                series1Hours.numOf(0.382).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS1.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(0.382).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS2.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(0.618).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex()).minus(
-                series1Hours.numOf(1).multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR3.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(1)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR2.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(0.618)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR1.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .plus(series1Hours.numOf(0.382)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS1.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(0.382)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS2.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(0.618)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS3.getValue(series1Hours.getEndIndex()),
+                pp.getValue(series1Hours.getEndIndex())
+                        .minus(series1Hours.numOf(1)
+                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
 
         DeMarkPivotPointIndicator deMarkpp = new DeMarkPivotPointIndicator(series1Hours, WEEK);
         DeMarkReversalIndicator deMarkR1 = new DeMarkReversalIndicator(deMarkpp,

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -153,16 +153,26 @@ public class DecimalNumTest {
             endTime = endTime.plus(timePeriod);
             superPrecisionNum = superPrecisionNum.plus(DecimalNum.valueOf(deltas[i % 6]));
         }
-        superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision").withNumTypeOf(superPrecisionFunc)
-                .withBars(superPrecisionBarList).build();
-        precisionSeries = new BaseBarSeriesBuilder().withName("precision").withNumTypeOf(precisionFunc)
-                .withBars(precisionBarList).build();
-        precision32Series = new BaseBarSeriesBuilder().withName("precision32").withNumTypeOf(precision32Func)
-                .withBars(precision32BarList).build();
-        doubleSeries = new BaseBarSeriesBuilder().withName("double").withNumTypeOf(doubleFunc).withBars(doubleBarList)
+        superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision")
+                .withNumTypeOf(superPrecisionFunc)
+                .withBars(superPrecisionBarList)
                 .build();
-        lowPrecisionSeries = new BaseBarSeriesBuilder().withName("lowPrecision").withNumTypeOf(lowPrecisionFunc)
-                .withBars(lowPrecisionBarList).build();
+        precisionSeries = new BaseBarSeriesBuilder().withName("precision")
+                .withNumTypeOf(precisionFunc)
+                .withBars(precisionBarList)
+                .build();
+        precision32Series = new BaseBarSeriesBuilder().withName("precision32")
+                .withNumTypeOf(precision32Func)
+                .withBars(precision32BarList)
+                .build();
+        doubleSeries = new BaseBarSeriesBuilder().withName("double")
+                .withNumTypeOf(doubleFunc)
+                .withBars(doubleBarList)
+                .build();
+        lowPrecisionSeries = new BaseBarSeriesBuilder().withName("lowPrecision")
+                .withNumTypeOf(lowPrecisionFunc)
+                .withBars(lowPrecisionBarList)
+                .build();
     }
 
     public void test() {

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -55,6 +55,16 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
     }
 
     @Test
+    public void testDefaultNums() {
+        Function<Number, Num> decimalNum = DecimalNum::valueOf;
+        Function<Number, Num> doubleNum = DoubleNum::valueOf;
+        Num decimalOne = decimalNum.apply(1);
+        assertNumEquals(1, decimalOne);
+        Num doubleOne = doubleNum.apply(1);
+        assertNumEquals(1, doubleOne);
+    }
+
+    @Test
     public void testStringNumPass() {
         assertNumEquals("1.234", numOf(1.234));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -121,9 +121,15 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         final Bar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
         final Bar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
         final Bar bar7 = new MockBar(time.plusDays(7), 0, 0, 0, 0, 0, 0, 0, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(time.plusDays(8)).openPrice(NaN.NaN).highPrice(NaN.NaN).lowPrice(NaN.NaN).closePrice(NaN.NaN)
-                .volume(NaN.NaN).build();
+        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(time.plusDays(8))
+                .openPrice(NaN.NaN)
+                .highPrice(NaN.NaN)
+                .lowPrice(NaN.NaN)
+                .closePrice(NaN.NaN)
+                .volume(NaN.NaN)
+                .build();
 
         bars.add(bar0);
         bars.add(bar1);
@@ -158,8 +164,11 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, decimalNumFunction));
         bars.add(new MockBar(time.plusDays(2), 2d, 2d, 2d, 2d, 2d, 2d, 2, decimalNumFunction));
 
-        final BarSeries decimalBarSeries = new BaseBarSeriesBuilder().withBars(bars).withMaxBarCount(100)
-                .withNumTypeOf(DecimalNum.class).withName("useDecimalNum").build();
+        final BarSeries decimalBarSeries = new BaseBarSeriesBuilder().withBars(bars)
+                .withMaxBarCount(100)
+                .withNumTypeOf(DecimalNum.class)
+                .withName("useDecimalNum")
+                .build();
 
         // convert barSeries with DecimalNum to barSeries with DoubleNum
         final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries, doubleNumFunction);
@@ -185,9 +194,15 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
         final Bar bar1 = new MockBar(time, 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class).timePeriod(Duration.ofDays(1))
-                .endTime(time.plusDays(8)).openPrice(NaN.NaN).highPrice(NaN.NaN).lowPrice(NaN.NaN).closePrice(NaN.NaN)
-                .volume(NaN.NaN).build();
+        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(time.plusDays(8))
+                .openPrice(NaN.NaN)
+                .highPrice(NaN.NaN)
+                .lowPrice(NaN.NaN)
+                .closePrice(NaN.NaN)
+                .volume(NaN.NaN)
+                .build();
 
         bars.add(bar0);
         bars.add(bar1);


### PR DESCRIPTION
Changes proposed in this pull request:
- provide common static Num's for `DecimalNum` and `DoubleNum`
- provide static methods in `Num`-Interface to discriminate between those static Num's

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
