### PR TITLE
#737 - Avoid NPE by removing empty args constructor, make barSeries a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Removed/Deprecated
 
 ### Added
-
+- **BarSeriesManager**: Removed empty args constructor.
 
 ## 0.14 (released April 25, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 
 ### Changed
+- **BarSeriesManager** removed empty args constructor
 
 ### Removed/Deprecated
 - **Num** removed Serializable

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
@@ -42,18 +42,11 @@ public class BarSeriesManager {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     /** The managed bar series */
-    private BarSeries barSeries;
+    private final BarSeries barSeries;
 
     /** The trading cost models */
     private CostModel transactionCostModel;
     private CostModel holdingCostModel;
-
-    /**
-     * Constructor.
-     */
-    public BarSeriesManager() {
-        this(null, new ZeroCostModel(), new ZeroCostModel());
-    }
 
     /**
      * Constructor.
@@ -75,13 +68,6 @@ public class BarSeriesManager {
         this.barSeries = barSeries;
         this.transactionCostModel = transactionCostModel;
         this.holdingCostModel = holdingCostModel;
-    }
-
-    /**
-     * @param barSeries the bar series to be managed
-     */
-    public void setBarSeries(BarSeries barSeries) {
-        this.barSeries = barSeries;
     }
 
     /**

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesManagerTest.java
@@ -77,7 +77,7 @@ public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> 
     @Test
     public void runOnWholeSeries() {
         BarSeries series = new MockBarSeries(numFunction, 20d, 40d, 60d, 10d, 30d, 50d, 0d, 20d, 40d);
-        manager.setBarSeries(series);
+        manager = new BarSeriesManager(series);
         List<Position> allPositions = manager.run(strategy).getPositions();
         assertEquals(2, allPositions.size());
     }
@@ -85,7 +85,7 @@ public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> 
     @Test
     public void runOnWholeSeriesWithAmount() {
         BarSeries series = new MockBarSeries(numFunction, 20d, 40d, 60d, 10d, 30d, 50d, 0d, 20d, 40d);
-        manager.setBarSeries(series);
+        manager = new BarSeriesManager(series);
         List<Position> allPositions = manager.run(strategy, TradeType.BUY, HUNDRED).getPositions();
 
         assertEquals(2, allPositions.size());
@@ -151,7 +151,7 @@ public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> 
                         dateTime.withYear(2001), dateTime.withYear(2002), dateTime.withYear(2002),
                         dateTime.withYear(2002), dateTime.withYear(2003), dateTime.withYear(2004),
                         dateTime.withYear(2005) });
-        manager.setBarSeries(series);
+        manager = new BarSeriesManager(series);
 
         Strategy aStrategy = new BaseStrategy(new FixedRule(0, 3, 5, 7), new FixedRule(2, 4, 6, 9));
 


### PR DESCRIPTION
Fixes #737.

Avoid NPE by removing empty args constructor, make barSeries attribute final
- [ x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
