### PR TITLE
Num: remove serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **PrecisionNum**: improve performance for methods isZero/isPositive/isPositiveOrZero/isNegative/isNegativeOrZero.
 - **BaseTimeSeriesBuilder** moved from inner class to own class
 - **TrailingStopLossRule** added ability to look back the last x bars for calculating the trailing stop loss
+- **Num** removed Serializable
 
 ### Added
 - **Enhancement** Added getters for AroonDownIndicator and AroonUpIndicator in AroonOscillatorIndicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 
 ### Changed
-- **Num** removed Serializable
 
 ### Removed/Deprecated
+- **Num** removed Serializable
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 
 ### Changed
+- **Num** removed Serializable
 
 ### Removed/Deprecated
 
@@ -129,7 +130,6 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **PrecisionNum**: improve performance for methods isZero/isPositive/isPositiveOrZero/isNegative/isNegativeOrZero.
 - **BaseTimeSeriesBuilder** moved from inner class to own class
 - **TrailingStopLossRule** added ability to look back the last x bars for calculating the trailing stop loss
-- **Num** removed Serializable
 
 ### Added
 - **Enhancement** Added getters for AroonDownIndicator and AroonUpIndicator in AroonOscillatorIndicator

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
@@ -23,14 +23,13 @@
  */
 package org.ta4j.core.indicators;
 
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.num.Num;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.num.Num;
 
 /**
  * Distance From Moving Average (close - MA)/MA

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -71,8 +71,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class DecimalNum implements Num {
 
-    private static final long serialVersionUID = 785564782721079992L;
-
     private static final int DEFAULT_PRECISION = 32;
     private static final Logger log = LoggerFactory.getLogger(DecimalNum.class);
     private final MathContext mathContext;

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
  */
 public class DoubleNum implements Num {
 
-    private static final long serialVersionUID = -2611177221813615070L;
     private final static double EPS = 0.00001; // precision
     private final double delegate;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -43,8 +43,6 @@ import java.util.function.Function;
  */
 public class NaN implements Num {
 
-    private static final long serialVersionUID = 9161474401436305600L;
-
     /** static Not-a-Number instance */
     public static final Num NaN = new NaN();
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -23,7 +23,6 @@
  */
 package org.ta4j.core.num;
 
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
  * @see DecimalNum
  * 
  */
-public interface Num extends Comparable<Num>, Serializable {
+public interface Num extends Comparable<Num> {
 
     /**
      * @return the delegate used from this <code>Num</code> implementation

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
@@ -23,7 +23,10 @@
  */
 package org.ta4j.core.indicators;
 
-import org.junit.Assert;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -31,10 +34,6 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.function.Function;
-
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class DistanceFromMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
     private BarSeries data;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
@@ -23,16 +23,16 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.function.Function;
-
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class KSTIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
     private MockBarSeries data;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -23,6 +23,10 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -30,10 +34,6 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.function.Function;
-
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class MACDIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
@@ -23,6 +23,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.Bar;
@@ -31,13 +37,6 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
-import static org.junit.Assert.assertEquals;
-import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class PVOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 


### PR DESCRIPTION
Changes proposed in this pull request:
- remove `Serializable` in `Num.class`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md`


It does not make any sense to have `Serializable` in Num (and its dedicated implementations). It's the same as if I would add Serializable to BigDecimal (which does also not make any sense). Thus, remove it.
