### PR TITLE
BaseTradingRecord: Compare enum with "=="

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -301,7 +301,7 @@ public class BaseTradingRecord implements TradingRecord {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("BaseTradingRecord: " + name != null ? name : "");
+        sb.append("BaseTradingRecord: " + (name == null ? "" : name));
         sb.append(System.lineSeparator());
         for (Trade trade : trades) {
             sb.append(trade.toString()).append(System.lineSeparator());

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -239,9 +239,9 @@ public class BaseTradingRecord implements TradingRecord {
 
     @Override
     public Trade getLastTrade(TradeType tradeType) {
-        if (TradeType.BUY.equals(tradeType) && !buyTrades.isEmpty()) {
+        if (TradeType.BUY == tradeType && !buyTrades.isEmpty()) {
             return buyTrades.get(buyTrades.size() - 1);
-        } else if (TradeType.SELL.equals(tradeType) && !sellTrades.isEmpty()) {
+        } else if (TradeType.SELL == tradeType && !sellTrades.isEmpty()) {
             return sellTrades.get(sellTrades.size() - 1);
         }
         return null;
@@ -283,10 +283,10 @@ public class BaseTradingRecord implements TradingRecord {
 
         // Storing the new trade in trades list
         trades.add(trade);
-        if (TradeType.BUY.equals(trade.getType())) {
+        if (TradeType.BUY == trade.getType()) {
             // Storing the new trade in buy trades list
             buyTrades.add(trade);
-        } else if (TradeType.SELL.equals(trade.getType())) {
+        } else if (TradeType.SELL == trade.getType()) {
             // Storing the new trade in sell trades list
             sellTrades.add(trade);
         }
@@ -301,9 +301,10 @@ public class BaseTradingRecord implements TradingRecord {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("BaseTradingRecord: " + name != null ? name : "" + "\n");
+        sb.append("BaseTradingRecord: " + name != null ? name : "");
+        sb.append(System.lineSeparator());
         for (Trade trade : trades) {
-            sb.append(trade.toString()).append("\n");
+            sb.append(trade.toString()).append(System.lineSeparator());
         }
         return sb.toString();
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Compare enums with "==" instead of "equals()
- Fix BaseTradingRecord#toString() (former was wrong and returned null if name was null)

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
