### PR TITLE
Improve BarSeries with numType

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -115,7 +115,8 @@ public interface BarSeries extends Serializable {
         if (!getBarData().isEmpty()) {
             Bar firstBar = getFirstBar();
             Bar lastBar = getLastBar();
-            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME)).append(" - ")
+            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME))
+                    .append(" - ")
                     .append(lastBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
         }
         return sb.toString();
@@ -355,5 +356,31 @@ public interface BarSeries extends Serializable {
      * @return a function Number -> Num
      */
     Function<Number, Num> function();
+    
+    /**
+     * @return any num to determine its Num type
+     */
+    Num numType();
+
+    /**
+     * @return the Num of 0
+     */
+    default Num zero() {
+        return numType().
+    }
+
+    /**
+     * @return the Num of 1
+     */
+    default Num one() {
+        return numOf(1);
+    }
+
+    /**
+     * @return the Num of 100
+     */
+    default Num hundred() {
+        return numOf(100);
+    }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -50,6 +50,10 @@ public class BaseBarSeries implements BarSeries {
      */
     private static final String UNNAMED_SERIES_NAME = "unnamed_series";
     /**
+     * Num to determine its type
+     */
+    protected final transient Num numType;
+    /**
      * Num type function
      **/
     protected final transient Function<Number, Num> numFunction;
@@ -125,22 +129,24 @@ public class BaseBarSeries implements BarSeries {
     /**
      * Constructor.
      *
-     * @param name        the name of the series
-     * @param numFunction a {@link Function} to convert a {@link Number} to a
-     *                    {@link Num Num implementation}
+     * @param name    the name of the series
+     * @param numType the Num type to convert a {@link Number} to a {@link Num Num
+     *                implementation}
      */
-    public BaseBarSeries(String name, Function<Number, Num> numFunction) {
-        this(name, new ArrayList<>(), numFunction);
+    public BaseBarSeries(String name, Num numType) {
+        this(name, new ArrayList<>(), numType);
     }
 
     /**
      * Constructor.
      *
-     * @param name the name of the series
-     * @param bars the list of bars of the series
+     * @param name    the name of the series
+     * @param bars    the list of bars of the series
+     * @param numType the Num type to convert a {@link Number} to a {@link Num Num
+     *                implementation}
      */
-    public BaseBarSeries(String name, List<Bar> bars, Function<Number, Num> numFunction) {
-        this(name, bars, 0, bars.size() - 1, false, numFunction);
+    public BaseBarSeries(String name, List<Bar> bars, Num numType) {
+        this(name, bars, 0, bars.size() - 1, false, numType);
     }
 
     /**
@@ -157,7 +163,7 @@ public class BaseBarSeries implements BarSeries {
      *                         change), false otherwise
      */
     private BaseBarSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
-        this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum::valueOf);
+        this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum.valueOf(0));
     }
 
     /**
@@ -169,12 +175,13 @@ public class BaseBarSeries implements BarSeries {
      * @param seriesEndIndex   the end index (inclusive) of the bar series
      * @param constrained      true to constrain the bar series (i.e. indexes cannot
      *                         change), false otherwise
-     * @param numFunction      a {@link Function} to convert a {@link Number} to a
+     * @param numType          the Num type to convert a {@link Number} to a
      *                         {@link Num Num implementation}
      */
     BaseBarSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained,
-            Function<Number, Num> numFunction) {
+            Num numType) {
         this.name = name;
+        this.numType = numType;
 
         this.bars = bars;
         if (bars.isEmpty()) {
@@ -182,7 +189,7 @@ public class BaseBarSeries implements BarSeries {
             this.seriesBeginIndex = -1;
             this.seriesEndIndex = -1;
             this.constrained = false;
-            this.numFunction = numFunction;
+            this.numFunction = numType.function();
             return;
         }
         // Bar list not empty: take Function of first bar
@@ -257,15 +264,20 @@ public class BaseBarSeries implements BarSeries {
         if (!bars.isEmpty()) {
             int start = Math.max(startIndex - getRemovedBarsCount(), this.getBeginIndex());
             int end = Math.min(endIndex - getRemovedBarsCount(), this.getEndIndex() + 1);
-            return new BaseBarSeries(getName(), cut(bars, start, end), numFunction);
+            return new BaseBarSeries(getName(), cut(bars, start, end), numType);
         }
-        return new BaseBarSeries(name, numFunction);
+        return new BaseBarSeries(name, numType);
 
     }
 
     @Override
     public Num numOf(Number number) {
         return this.numFunction.apply(number);
+    }
+
+    @Override
+    public Num numType() {
+        return numType;
     }
 
     @Override


### PR DESCRIPTION
Changes proposed in this pull request:
- Currently, all BarSeries (with its builder) needs `Function<Number, Num> function`. Instead of providing such function anywhere (where it is needed), we can replace it by providing an example of a `Num` (the property is called numType which is a common Num). Having the direct glue with Num instead of its Function (when constructing the BarSeries), provides the following benefits:
- we use `numType#function()` to get its function: no need to instantiate a new Function for every BarSeries-constructors or BarSeriesBuilders.
- we use static defined Num's (for example, `DecimalNum.ZERO`): no need to instantiate a new Num for every BarSeries-constructors or BarSeriesBuilders
- with `Function<Number, Num> function`, it's not possible to determine its (runtime) Num-Type. With numType, it is easy to determine its runtime type.
- using `numType` instead of `DecimalNum::valueOf`, we can provide both the function (by numType.function()) and also determine its type - vice versa, it's not possible.
- we can use `series.zero()`, `series.one()`, `series().hundred()` (etc.) which get its value by its static defined properties in the dedicated Num.class (this avoids the need to instantiate, for example,  `series.valueOf(1)`).
- we can use those static `series.zero()` on any other place (for example, indicators). Actually, we need at least one number to derive its constants (0,1,100, etc). Having `numType` instead of `numFunction` as a first class property in any barSeries solves this issue and we can access those static nums without the need of an instantiated num. So we can call easily `series.zero()` instead of `numberOfTen.zero()` (which is a little irritating).

Please review this PR carefully (in case I did forget something). 

By the way:
- if this PR is taken, then we can easily replace all those `valueOf(0)`, `valueOf(1)`, `valueOf(100)` by `series.zero()`, `series.one()`,  `series.hundred()` in the next step. Actually, we need at least one instantiated Num to access its constants. (A BarSeries can be empty, thus indicators cannot actually acccess the Num constants. Having numType solves this issue.).
- with `numType`, there is no more need to instantiate a `Num` and/or a `Num-function` on every construction (because both, `numType` and `function` can be easily accessed by constants defined in the Num-classes.)
- 

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
