### PR TITLE
Improve BarSeries with numType

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -357,4 +357,30 @@ public interface BarSeries extends Serializable {
      */
     Function<Number, Num> function();
 
+    /**
+     * @return any num to determine its Num type
+     */
+    Num numType();
+
+    /**
+     * @return the Num of 0
+     */
+    default Num zero() {
+        return numType().zero();
+    }
+
+    /**
+     * @return the Num of 1
+     */
+    default Num one() {
+        return numType().one();
+    }
+
+    /**
+     * @return the Num of 100
+     */
+    default Num hundred() {
+        return numType().hundred();
+    }
+
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -25,7 +25,6 @@ package org.ta4j.core;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 import org.ta4j.core.num.DecimalNum;
 import org.ta4j.core.num.DoubleNum;
@@ -34,12 +33,12 @@ import org.ta4j.core.num.Num;
 public class BaseBarSeriesBuilder implements BarSeriesBuilder {
 
     /**
-     * Default Num type function
+     * Default Num type to determine the Num function
      **/
-    private static Function<Number, Num> defaultFunction = DecimalNum::valueOf;
+    private static Num defaultNumType = DecimalNum.ZERO;
+    private Num numType;
     private List<Bar> bars;
     private String name;
-    private Function<Number, Num> numFunction;
     private boolean constrained;
     private int maxBarCount;
 
@@ -47,14 +46,14 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         initValues();
     }
 
-    public static void setDefaultFunction(Function<Number, Num> defaultFunction) {
-        BaseBarSeriesBuilder.defaultFunction = defaultFunction;
+    public static void setDefaultNumType(Num defaultNumType) {
+        BaseBarSeriesBuilder.defaultNumType = defaultNumType;
     }
 
     private void initValues() {
         this.bars = new ArrayList<>();
         this.name = "unnamed_series";
-        this.numFunction = BaseBarSeriesBuilder.defaultFunction;
+        this.numType = BaseBarSeriesBuilder.defaultNumType;
         this.constrained = false;
         this.maxBarCount = Integer.MAX_VALUE;
     }
@@ -67,7 +66,7 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
             beginIndex = 0;
             endIndex = bars.size() - 1;
         }
-        BaseBarSeries series = new BaseBarSeries(name, bars, beginIndex, endIndex, constrained, numFunction);
+        BaseBarSeries series = new BaseBarSeries(name, bars, beginIndex, endIndex, constrained, numType);
         series.setMaximumBarCount(maxBarCount);
         initValues(); // reinitialize values for next series
         return series;
@@ -93,25 +92,20 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         return this;
     }
 
-    public BaseBarSeriesBuilder withNumTypeOf(Num type) {
-        numFunction = type.function();
-        return this;
-    }
-
-    public BaseBarSeriesBuilder withNumTypeOf(Function<Number, Num> function) {
-        numFunction = function;
+    public BaseBarSeriesBuilder withNumTypeOf(Num numType) {
+        this.numType = numType;
         return this;
     }
 
     public BaseBarSeriesBuilder withNumTypeOf(Class<? extends Num> abstractNumClass) {
         if (abstractNumClass == DecimalNum.class) {
-            numFunction = DecimalNum::valueOf;
+            numType = DecimalNum.ZERO;
             return this;
         } else if (abstractNumClass == DoubleNum.class) {
-            numFunction = DoubleNum::valueOf;
+            numType = DoubleNum.ZERO;
             return this;
         }
-        numFunction = DecimalNum::valueOf;
+        numType = DecimalNum.ZERO;
         return this;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -74,7 +74,7 @@ public final class DecimalNum implements Num {
     private static final int DEFAULT_PRECISION = 32;
     private static final Logger log = LoggerFactory.getLogger(DecimalNum.class);
 
-    private static final DecimalNum ZERO = DecimalNum.valueOf(0);
+    public static final DecimalNum ZERO = DecimalNum.valueOf(0);
     private static final DecimalNum ONE = DecimalNum.valueOf(1);
     private static final DecimalNum HUNDRED = DecimalNum.valueOf(100);
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
  */
 public class DoubleNum implements Num {
 
-    private static final DoubleNum ZERO = DoubleNum.valueOf(0);
+    public static final DoubleNum ZERO = DoubleNum.valueOf(0);
     private static final DoubleNum ONE = DoubleNum.valueOf(1);
     private static final DoubleNum HUNDRED = DoubleNum.valueOf(100);
 

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Function;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
@@ -145,18 +144,18 @@ public final class BarSeriesUtils {
      * <code>beginIndex</code>, <code>endIndex</code> and
      * <code>maximumBarCount</code> from the provided barSeries.
      * 
-     * @param barSeries          the BarSeries
-     * @param conversionFunction the conversionFunction
-     * @return new cloned BarSeries with bars converted by conversionFunction
+     * @param barSeries the BarSeries
+     * @param numType   any Num to determine its type
+     * @return new cloned BarSeries with bars converted by numType
      */
-    public static BarSeries convertBarSeries(BarSeries barSeries, Function<Number, Num> conversionFunction) {
+    public static BarSeries convertBarSeries(BarSeries barSeries, Num numType) {
         List<Bar> bars = barSeries.getBarData();
         if (bars == null || bars.isEmpty())
             return barSeries;
         List<Bar> convertedBars = new ArrayList<>();
         for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex(); i++) {
             Bar bar = bars.get(i);
-            Bar convertedBar = new ConvertibleBaseBarBuilder<Number>(conversionFunction::apply)
+            Bar convertedBar = new ConvertibleBaseBarBuilder<Number>(numType.function()::apply)
                     .timePeriod(bar.getTimePeriod())
                     .endTime(bar.getEndTime())
                     .openPrice(bar.getOpenPrice().getDelegate())
@@ -169,7 +168,7 @@ public final class BarSeriesUtils {
                     .build();
             convertedBars.add(convertedBar);
         }
-        BarSeries convertedBarSeries = new BaseBarSeries(barSeries.getName(), convertedBars, conversionFunction);
+        BarSeries convertedBarSeries = new BaseBarSeries(barSeries.getName(), convertedBars, numType);
         if (barSeries.getMaximumBarCount() > 0) {
             convertedBarSeries.setMaximumBarCount(barSeries.getMaximumBarCount());
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -82,13 +82,13 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         defaultName = "Series Name";
 
-        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
+        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0))
                 .withName(defaultName)
                 .withBars(bars)
                 .build();
 
         subSeries = defaultSeries.getSubSeries(2, 5);
-        emptySeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        emptySeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
 
         Strategy strategy = new BaseStrategy(new FixedRule(0, 2, 3, 6), new FixedRule(1, 4, 7, 8));
         strategy.setUnstablePeriod(2); // Strategy would need a real test class
@@ -100,7 +100,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
      */
     @Test
     public void replaceBarTest() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()), 1d, numFunction), true);
         assertEquals(1, series.getBarCount());
         TestUtils.assertNumEquals(series.getLastBar().getClosePrice(), series.numOf(1));
@@ -273,7 +273,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void addBarTest() {
-        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        defaultSeries = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         Bar bar1 = new MockBar(ZonedDateTime.of(2014, 6, 13, 0, 0, 0, 0, ZoneId.systemDefault()), 1d, numFunction);
         Bar bar2 = new MockBar(ZonedDateTime.of(2014, 6, 14, 0, 0, 0, 0, ZoneId.systemDefault()), 2d, numFunction);
 
@@ -325,7 +325,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
      */
     @Test
     public void addTradeTest() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         series.addBar(new MockBar(ZonedDateTime.now(ZoneId.systemDefault()), 1d, numFunction));
         series.addTrade(200, 11.5);
         TestUtils.assertNumEquals(series.numOf(200), series.getLastBar().getVolume());
@@ -343,13 +343,13 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test(expected = IllegalArgumentException.class)
     public void wrongBarTypeBigDecimalTest() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(DecimalNum::valueOf).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(DecimalNum.valueOf(0)).build();
         series.addBar(new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), 1, 1, 1, 1, 1, 1, 1, DoubleNum::valueOf));
     }
 
     @Test
     public void subSeriesOfMaxBarCountSeriesTest() {
-        final BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction)
+        final BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0))
                 .withName("Series with maxBar count")
                 .withMaxBarCount(20)
                 .build();

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -42,7 +42,7 @@ public class SeriesBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         super(numFunction);
     }
 
-    private final BaseBarSeriesBuilder seriesBuilder = new BaseBarSeriesBuilder().withNumTypeOf(numFunction);
+    private final BaseBarSeriesBuilder seriesBuilder = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0));
 
     @Test
     public void testBuilder() {

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -74,7 +74,7 @@ public class TestUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     private BarSeries randomSeries() {
         BaseBarSeriesBuilder builder = new BaseBarSeriesBuilder();
-        BarSeries series = builder.withNumTypeOf(numFunction).build();
+        BarSeries series = builder.withNumTypeOf(numOf(0)).build();
         ZonedDateTime time = ZonedDateTime.of(1970, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault());
         double random;
         for (int i = 0; i < 1000; i++) {

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -112,14 +112,15 @@ public class XlsTestsUtils {
      *
      * @param clazz    class containing the file resources
      * @param fileName file name of the file resource
+     * @param numType  any Num to determine its type
      * @return BarSeries of the data
      * @throws IOException         if getSheet throws IOException
      * @throws DataFormatException if getSeries throws DataFormatException
      */
-    public static BarSeries getSeries(Class<?> clazz, String fileName, Function<Number, Num> numFunction)
+    public static BarSeries getSeries(Class<?> clazz, String fileName, Num numType)
             throws IOException, DataFormatException {
         Sheet sheet = getSheet(clazz, fileName);
-        return getSeries(sheet, numFunction);
+        return getSeries(sheet, numType);
     }
 
     /**
@@ -127,13 +128,14 @@ public class XlsTestsUtils {
      * data section header and appears in the first six columns to the end of the
      * file. Empty cells in the data are forbidden.
      *
-     * @param sheet mutable Sheet
+     * @param sheet   mutable Sheet
+     * @param numType any Num to determine its type
      * @return BarSeries of the data
      * @throws DataFormatException if getData throws DataFormatException or if the
      *                             data contains empty cells
      */
-    private static BarSeries getSeries(Sheet sheet, Function<Number, Num> numFunction) throws DataFormatException {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+    private static BarSeries getSeries(Sheet sheet, Num numType) throws DataFormatException {
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numType).build();
         FormulaEvaluator evaluator = sheet.getWorkbook().getCreationHelper().createFormulaEvaluator();
         List<Row> rows = getData(sheet);
         int minInterval = Integer.MAX_VALUE;
@@ -166,11 +168,11 @@ public class XlsTestsUtils {
                     ZoneId.systemDefault());
             series.addBar(duration, endDateTime,
                     // open, high, low, close, volume
-                    numFunction.apply(new BigDecimal(cellValues[1].formatAsString())),
-                    numFunction.apply(new BigDecimal(cellValues[2].formatAsString())),
-                    numFunction.apply(new BigDecimal(cellValues[3].formatAsString())),
-                    numFunction.apply(new BigDecimal(cellValues[4].formatAsString())),
-                    numFunction.apply(new BigDecimal(cellValues[5].formatAsString())), numFunction.apply(0));
+                    numType.numOf(new BigDecimal(cellValues[1].formatAsString())),
+                    numType.numOf(new BigDecimal(cellValues[2].formatAsString())),
+                    numType.numOf(new BigDecimal(cellValues[3].formatAsString())),
+                    numType.numOf(new BigDecimal(cellValues[4].formatAsString())),
+                    numType.numOf(new BigDecimal(cellValues[5].formatAsString())), numType.numOf(0));
         }
         return series;
     }
@@ -287,16 +289,17 @@ public class XlsTestsUtils {
      * @param clazz    class containing the file resource
      * @param fileName file name of the file resource
      * @param column   column number of the indicator values
+     * @param numType  any Num to determine its type
      * @param params   indicator parameters
      * @return Indicator<Num> as calculated by the XLS file given the parameters
      * @throws IOException         if getSheet throws IOException
      * @throws DataFormatException if getSeries or getValues throws
      *                             DataFormatException
      */
-    public static Indicator<Num> getIndicator(Class<?> clazz, String fileName, int column,
-            Function<Number, Num> numFunction, Object... params) throws IOException, DataFormatException {
+    public static Indicator<Num> getIndicator(Class<?> clazz, String fileName, int column, Num numType,
+            Object... params) throws IOException, DataFormatException {
         Sheet sheet = getSheet(clazz, fileName);
-        return new MockIndicator(getSeries(sheet, numFunction), getValues(sheet, column, numFunction, params));
+        return new MockIndicator(getSeries(sheet, numType), getValues(sheet, column, numType.function(), params));
     }
 
     /**

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/XLSCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/XLSCriterionTest.java
@@ -67,7 +67,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
      */
     public BarSeries getSeries() throws Exception {
         if (cachedSeries == null) {
-            cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction);
+            cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction.apply(0));
         }
         return cachedSeries;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
@@ -49,7 +49,7 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void testDummy() throws Exception {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         series.addBar(new MockBar(ZonedDateTime.now().minusSeconds(5), 0, 12, 15, 8, 0, 0, 0, numFunction));
         series.addBar(new MockBar(ZonedDateTime.now().minusSeconds(4), 0, 8, 11, 6, 0, 0, 0, numFunction));
         series.addBar(new MockBar(ZonedDateTime.now().minusSeconds(3), 0, 15, 17, 14, 0, 0, 0, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AroonDownIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AroonDownIndicatorTest.java
@@ -47,7 +47,7 @@ public class AroonDownIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
 
     @Before
     public void init() {
-        data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("Aroon data").build();
+        data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Aroon data").build();
         data.addBar(ZonedDateTime.now().plusDays(1), 168.28, 169.87, 167.15, 169.64, 0);
         data.addBar(ZonedDateTime.now().plusDays(2), 168.84, 169.36, 168.2, 168.71, 0);
         data.addBar(ZonedDateTime.now().plusDays(3), 168.88, 169.29, 166.41, 167.74, 0);
@@ -93,7 +93,7 @@ public class AroonDownIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
 
     @Test
     public void onlyNaNValues() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("NaN test").build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("NaN test").build();
         for (long i = 0; i <= 1000; i++) {
             series.addBar(ZonedDateTime.now().plusDays(i), NaN, NaN, NaN, NaN, NaN);
         }
@@ -106,7 +106,7 @@ public class AroonDownIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
 
     @Test
     public void naNValuesInIntervall() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("NaN test").build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("NaN test").build();
         for (long i = 10; i >= 0; i--) { // (10, NaN, 9, NaN, 8, NaN, 7, NaN)
             Num lowPrice = i % 2 == 0 ? series.numOf(i) : NaN;
             series.addBar(ZonedDateTime.now().plusDays(10 - i), NaN, NaN, lowPrice, NaN, NaN);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -72,7 +72,7 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void getValueWithNullBarSeries() {
 
         ConstantIndicator<Num> constant = new ConstantIndicator<>(
-                new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build(), numFunction.apply(10));
+                new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build(), numFunction.apply(10));
         assertEquals(numFunction.apply(10), constant.getValue(0));
         assertEquals(numFunction.apply(10), constant.getValue(100));
         assertNotNull(constant.getBarSeries());

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -44,7 +44,7 @@ import org.ta4j.core.num.Num;
 public class ChopIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
     protected BarSeries series;
-    protected final BaseBarSeriesBuilder BarSeriesBuilder = new BaseBarSeriesBuilder().withNumTypeOf(numFunction);
+    protected final BaseBarSeriesBuilder BarSeriesBuilder = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0));
 
     public ChopIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
@@ -55,7 +55,7 @@ public class ChopIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
      */
     @Test
     public void testChoppy() {
-        series = BarSeriesBuilder.withName("low volatility series").withNumTypeOf(numFunction).build();
+        series = BarSeriesBuilder.withName("low volatility series").withNumTypeOf(numFunction.apply(0)).build();
         for (int i = 0; i < 50; i++) {
             ZonedDateTime date = ZonedDateTime.now().minusSeconds(100000 - i);
             series.addBar(date, 21.5, 21.5 + 1, 21.5 - 1, 21.5);
@@ -71,7 +71,7 @@ public class ChopIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
      */
     @Test
     public void testTradeableTrend() {
-        series = BarSeriesBuilder.withName("low volatility series").withNumTypeOf(numFunction).build();
+        series = BarSeriesBuilder.withName("low volatility series").withNumTypeOf(numFunction.apply(0)).build();
         float value = 21.5f;
         for (int i = 0; i < 50; i++) {
             ZonedDateTime date = ZonedDateTime.now().minusSeconds(100000 - i);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -44,7 +44,8 @@ import org.ta4j.core.num.Num;
 public class ChopIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
     protected BarSeries series;
-    protected final BaseBarSeriesBuilder BarSeriesBuilder = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0));
+    protected final BaseBarSeriesBuilder BarSeriesBuilder = new BaseBarSeriesBuilder()
+            .withNumTypeOf(numFunction.apply(0));
 
     public ChopIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
@@ -47,7 +47,7 @@ public class FisherIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     @Before
     public void setUp() {
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("NaN test").build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("NaN test").build();
         int i = 20;
         // open, close, max, min
         series.addBar(

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -61,7 +61,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
      */
     public BarSeries getSeries() throws Exception {
         if (cachedSeries == null) {
-            cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction);
+            cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction.apply(0));
         }
         return cachedSeries;
     }
@@ -74,7 +74,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
      * @throws Exception if getIndicator throws IOException or DataFormatException
      */
     public Indicator<Num> getIndicator(Object... params) throws Exception {
-        return XlsTestsUtils.getIndicator(clazz, fileName, column, getSeries().function(), params);
+        return XlsTestsUtils.getIndicator(clazz, fileName, column, getSeries().function().apply(0), params);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
@@ -54,7 +54,7 @@ public class TransformIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
 
     @Before
     public void setUp() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numOf(0)).build();
         ConstantIndicator<Num> constantIndicator = new ConstantIndicator<>(series, numOf(4));
 
         transPlus = TransformIndicator.plus(constantIndicator, 10);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
@@ -50,7 +50,7 @@ public class CorrelationCoefficientIndicatorTest extends AbstractIndicatorTest<I
 
     @Before
     public void setUp() {
-        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         int i = 20;
         // close, volume
         data.addBar(new MockBar(ZonedDateTime.now().minusSeconds(i--), 6, 100, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
@@ -49,7 +49,7 @@ public class CovarianceIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
     @Before
     public void setUp() {
-        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         int i = 20;
         // close, volume
         data.addBar(new MockBar(ZonedDateTime.now().minusSeconds(i--), 6, 100, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
@@ -49,7 +49,7 @@ public class PearsonCorrelationIndicatorTest extends AbstractIndicatorTest<Indic
 
     @Before
     public void setUp() {
-        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).build();
+        BarSeries data = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).build();
         int i = 20;
         // close, volume
         data.addBar(new MockBar(ZonedDateTime.now().minusSeconds(i--), 6, 100, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -154,23 +154,23 @@ public class DecimalNumTest {
             superPrecisionNum = superPrecisionNum.plus(DecimalNum.valueOf(deltas[i % 6]));
         }
         superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision")
-                .withNumTypeOf(superPrecisionFunc)
+                .withNumTypeOf(superPrecisionFunc.apply(0))
                 .withBars(superPrecisionBarList)
                 .build();
         precisionSeries = new BaseBarSeriesBuilder().withName("precision")
-                .withNumTypeOf(precisionFunc)
+                .withNumTypeOf(precisionFunc.apply(0))
                 .withBars(precisionBarList)
                 .build();
         precision32Series = new BaseBarSeriesBuilder().withName("precision32")
-                .withNumTypeOf(precision32Func)
+                .withNumTypeOf(precision32Func.apply(0))
                 .withBars(precision32BarList)
                 .build();
         doubleSeries = new BaseBarSeriesBuilder().withName("double")
-                .withNumTypeOf(doubleFunc)
+                .withNumTypeOf(doubleFunc.apply(0))
                 .withBars(doubleBarList)
                 .build();
         lowPrecisionSeries = new BaseBarSeriesBuilder().withName("lowPrecision")
-                .withNumTypeOf(lowPrecisionFunc)
+                .withNumTypeOf(lowPrecisionFunc.apply(0))
                 .withBars(lowPrecisionBarList)
                 .build();
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -81,7 +81,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar5);
         bars.add(bar6);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
 
         final Bar newBar3 = new MockBar(bar3.getEndTime(), 1d, 1d, 1d, 1d, 1d, 1d, 33, numFunction);
         final Bar newBar5 = new MockBar(bar5.getEndTime(), 1d, 1d, 1d, 1d, 1d, 1d, 55, numFunction);
@@ -138,7 +138,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar7);
         bars.add(bar8);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
 
         // return the beginTime of each missing bar
         List<ZonedDateTime> missingBars = BarSeriesUtils.findMissingBars(series, false);
@@ -171,14 +171,14 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         // convert barSeries with DecimalNum to barSeries with DoubleNum
-        final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries, doubleNumFunction);
+        final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries, doubleNumFunction.apply(0));
 
         // convert barSeries with DoubleNum to barSeries with DecimalNum
         final BarSeries doubleToDecimalSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries,
-                decimalNumFunction);
+                decimalNumFunction.apply(0));
 
         // convert barSeries with DoubleNum to barSeries with NaNNum
-        final BarSeries doubleToNaNSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries, nanNumFunction);
+        final BarSeries doubleToNaNSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries, nanNumFunction.apply(0));
 
         assertEquals(decimalBarSeries.getFirstBar().getClosePrice().getClass(), DecimalNum.class);
         assertEquals(decimalToDoubleSeries.getFirstBar().getClosePrice().getClass(), DoubleNum.class);
@@ -208,7 +208,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar1);
         bars.add(bar8);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
         List<Bar> overlappingBars = BarSeriesUtils.findOverlappingBars(series);
 
         // there must be 1 overlapping bars (bar1)
@@ -217,7 +217,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void addBars() {
-        BarSeries barSeries = new BaseBarSeries("1day", numFunction);
+        BarSeries barSeries = new BaseBarSeries("1day", numFunction.apply(0));
 
         List<Bar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -81,7 +81,10 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar5);
         bars.add(bar6);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0))
+                .withName("Series Name")
+                .withBars(bars)
+                .build();
 
         final Bar newBar3 = new MockBar(bar3.getEndTime(), 1d, 1d, 1d, 1d, 1d, 1d, 33, numFunction);
         final Bar newBar5 = new MockBar(bar5.getEndTime(), 1d, 1d, 1d, 1d, 1d, 1d, 55, numFunction);
@@ -138,7 +141,10 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar7);
         bars.add(bar8);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0))
+                .withName("Series Name")
+                .withBars(bars)
+                .build();
 
         // return the beginTime of each missing bar
         List<ZonedDateTime> missingBars = BarSeriesUtils.findMissingBars(series, false);
@@ -171,14 +177,16 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         // convert barSeries with DecimalNum to barSeries with DoubleNum
-        final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries, doubleNumFunction.apply(0));
+        final BarSeries decimalToDoubleSeries = BarSeriesUtils.convertBarSeries(decimalBarSeries,
+                doubleNumFunction.apply(0));
 
         // convert barSeries with DoubleNum to barSeries with DecimalNum
         final BarSeries doubleToDecimalSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries,
                 decimalNumFunction.apply(0));
 
         // convert barSeries with DoubleNum to barSeries with NaNNum
-        final BarSeries doubleToNaNSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries, nanNumFunction.apply(0));
+        final BarSeries doubleToNaNSeries = BarSeriesUtils.convertBarSeries(decimalToDoubleSeries,
+                nanNumFunction.apply(0));
 
         assertEquals(decimalBarSeries.getFirstBar().getClosePrice().getClass(), DecimalNum.class);
         assertEquals(decimalToDoubleSeries.getFirstBar().getClosePrice().getClass(), DoubleNum.class);
@@ -208,7 +216,10 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.add(bar1);
         bars.add(bar8);
 
-        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0)).withName("Series Name").withBars(bars).build();
+        series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction.apply(0))
+                .withName("Series Name")
+                .withBars(bars)
+                .build();
         List<Bar> overlappingBars = BarSeriesUtils.findOverlappingBars(series);
 
         // there must be 1 overlapping bars (bar1)

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -49,7 +49,7 @@ public class BuildBarSeries {
     public static void main(String[] args) {
         BarSeries a = buildAndAddData();
         System.out.println("a: " + a.getBar(0).getClosePrice().getName());
-        BaseBarSeriesBuilder.setDefaultFunction(DoubleNum::valueOf);
+        BaseBarSeriesBuilder.setDefaultNumType(DoubleNum.valueOf(0));
         a = buildAndAddData();
         System.out.println("a: " + a.getBar(0).getClosePrice().getName());
         BarSeries b = buildWithDouble();
@@ -60,7 +60,7 @@ public class BuildBarSeries {
         BarSeries g = buildAndAddBarsFromList();
         // Fix: Reset default function, such that this test case does not influence the
         // following test cases in a combined test run
-        BaseBarSeriesBuilder.setDefaultFunction(DecimalNum::valueOf);
+        BaseBarSeriesBuilder.setDefaultNumType(DecimalNum.valueOf(0));
     }
 
     private static BarSeries buildAndAddData() {
@@ -111,7 +111,7 @@ public class BuildBarSeries {
     }
 
     private static BarSeries buildManuallyDoubleNum() {
-        BarSeries series = new BaseBarSeries("mySeries", DoubleNum::valueOf); // uses DoubleNum
+        BarSeries series = new BaseBarSeries("mySeries", DoubleNum.valueOf(0)); // uses DoubleNum
         ZonedDateTime endTime = ZonedDateTime.now();
         series.addBar(endTime, 105.42, 112.99, 104.01, 111.42, 1337);
         series.addBar(endTime.plusDays(1), 111.43, 112.83, 107.77, 107.99, 1234);
@@ -122,7 +122,7 @@ public class BuildBarSeries {
     }
 
     private static BarSeries buildManuallyAndAddBarManually() {
-        BarSeries series = new BaseBarSeries("mySeries", DoubleNum::valueOf); // uses DoubleNum
+        BarSeries series = new BaseBarSeries("mySeries", DoubleNum.valueOf(0)); // uses DoubleNum
 
         // create bars and add them to the series. The bars must have the same Num type
         // as the series
@@ -194,7 +194,7 @@ public class BuildBarSeries {
         List<Bar> bars = Arrays.asList(b1, b2, b3);
 
         return new BaseBarSeriesBuilder().withName("mySeries")
-                .withNumTypeOf(DoubleNum::valueOf)
+                .withNumTypeOf(DoubleNum.valueOf(0))
                 .withMaxBarCount(5)
                 .withBars(bars)
                 .build();

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -54,13 +54,13 @@ public class CompareNumTypes {
     public static void main(String args[]) {
         BaseBarSeriesBuilder barSeriesBuilder = new BaseBarSeriesBuilder();
         BarSeries seriesD = barSeriesBuilder.withName("Sample Series Double    ")
-                .withNumTypeOf(DoubleNum::valueOf)
+                .withNumTypeOf(DoubleNum.valueOf(0))
                 .build();
         BarSeries seriesP = barSeriesBuilder.withName("Sample Series DecimalNum 32")
-                .withNumTypeOf(DecimalNum::valueOf)
+                .withNumTypeOf(DecimalNum.valueOf(0))
                 .build();
         BarSeries seriesPH = barSeriesBuilder.withName("Sample Series DecimalNum 256")
-                .withNumTypeOf(number -> DecimalNum.valueOf(number.toString(), 256))
+                .withNumTypeOf(DecimalNum.valueOf("0", 256))
                 .build();
 
         int[] randoms = new Random().ints(NUMBARS, 80, 100).toArray();


### PR DESCRIPTION
Changes proposed in this pull request:

- Currently, all BarSeries (with its builder) needs `Function<Number, Num> function`. Instead of providing such function anywhere (where it is needed), we can replace it by providing an example of a `Num` (the property is called numType which is a common Num). Having the direct glue with Num instead of its Function (when constructing the BarSeries), provides the following benefits:
- we use `numType#function()` to get its function: no need to instantiate a new Function for every BarSeries-constructors or BarSeriesBuilders.
- we use static defined Num's (for example, `DecimalNum.ZERO`): no need to instantiate a new Num for every BarSeries-constructors or BarSeriesBuilders
- with `Function<Number, Num> function`, it's not possible to determine its (runtime) Num-Type. With numType, it is easy to determine its runtime type.
- using `numType` instead of `DecimalNum::valueOf`, we can provide both the function (by numType.function()) and also determine its type - vice versa, it's not possible.
- we can use `series.zero()`, `series.one()`, `series().hundred()` (etc.) which get its value by its static defined properties in the dedicated Num.class (this avoids the need to instantiate, for example,  `series.valueOf(1)`).
- we can use those static `series.zero()` on any other place (for example, indicators). Actually, we need at least one number to derive its constants (0,1,100, etc). Having `numType` instead of `numFunction` as a first class property in any barSeries solves this issue and we can access those static nums without the need of an instantiated num. So we can call easily `series.zero()` instead of `numberOfTen.zero()` (which is a little irritating).

Please review this PR carefully (in case I did forget something). 

By the way:
- if this PR is taken, then we can easily replace all those `valueOf(0)`, `valueOf(1)`, `valueOf(100)` by `series.zero()`, `series.one()`,  `series.hundred()` in the next step. Actually, we need at least one instantiated Num to access its constants. (A BarSeries can be empty, thus indicators cannot actually acccess the Num constants. Having numType solves this issue.).
- with `numType`, there is no more need to instantiate a `Num` and/or a `Num-function` on every construction (because both, `numType` and `function` can be easily accessed by constants defined in the Num-classes.)

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
