### PR TITLE
Feature: Simplified indicator cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BarSeriesManager** removed empty args constructor
 - **Open|High|Low|Close** do not cache price values anymore
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)
+- :tada: **Enhancement** reduced indicator caching complexity by using TreeSet as cache instead of complex index-calculations
 
 ### Removed/Deprecated
 - **Num** removed Serializable

--- a/ta4j-core/src/main/java/org/ta4j/core/Ta4jCache.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Ta4jCache.java
@@ -58,6 +58,10 @@ public class Ta4jCache<T> {
 
         actualCache.put(index, result);
 
+        removeFirstEntriesIfNeeded();
+    }
+
+    private void removeFirstEntriesIfNeeded() {
         int currentLimit = series.getMaximumBarCount();
         while (actualCache.size() > currentLimit) {
             actualCache.pollFirstEntry();

--- a/ta4j-core/src/main/java/org/ta4j/core/Ta4jCache.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Ta4jCache.java
@@ -1,0 +1,73 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import java.util.TreeMap;
+
+public class Ta4jCache<T> {
+    private final BarSeries series;
+    private final TreeMap<Integer, T> actualCache = new TreeMap<>();
+
+    public Ta4jCache(BarSeries series) {
+        this.series = series;
+    }
+
+    public boolean contains(int index) {
+        if (index == series.getEndIndex()) {
+            return false;
+        }
+        return actualCache.containsKey(index);
+    }
+
+    public T get(int index) {
+        if (index == series.getEndIndex()) {
+            return null;
+        }
+        return actualCache.get(index);
+    }
+
+    public void add(int index, T result) {
+        if (index == series.getEndIndex()) {
+            // never use cache for last index, as the corresponding bar can be updated
+            return;
+        }
+        if (contains(index)) {
+            return;
+        }
+
+        actualCache.put(index, result);
+
+        int currentLimit = series.getMaximumBarCount();
+        while (actualCache.size() > currentLimit) {
+            actualCache.pollFirstEntry();
+        }
+    }
+
+    public int lastAvailableIndex() {
+        if (actualCache.isEmpty()) {
+            return -1;
+        }
+        return actualCache.lastKey();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -23,12 +23,9 @@
  */
 package org.ta4j.core.indicators;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
+import org.ta4j.core.Ta4jCache;
 
 /**
  * Cached {@link Indicator indicator}.
@@ -39,15 +36,9 @@ import org.ta4j.core.Indicator;
 public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
 
     /**
-     * List of cached results
+     * cached results
      */
-    private final List<T> results;
-
-    /**
-     * Should always be the index of the last result in the results list. I.E. the
-     * last calculated result.
-     */
-    protected int highestResultIndex = -1;
+    private final Ta4jCache<T> cache;
 
     /**
      * Constructor.
@@ -56,8 +47,7 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
      */
     protected CachedIndicator(BarSeries series) {
         super(series);
-        int limit = series.getMaximumBarCount();
-        results = limit == Integer.MAX_VALUE ? new ArrayList<>() : new ArrayList<>(limit);
+        this.cache = new Ta4jCache<>(series);
     }
 
     /**
@@ -77,6 +67,9 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
 
     @Override
     public T getValue(int index) {
+        if (cache.contains(index)) {
+            return cache.get(index);
+        }
         BarSeries series = getBarSeries();
         if (series == null) {
             // Series is null; the indicator doesn't need cache.
@@ -88,89 +81,26 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
         }
 
         // Series is not null
-
         final int removedBarsCount = series.getRemovedBarsCount();
-        final int maximumResultCount = series.getMaximumBarCount();
 
         T result;
         if (index < removedBarsCount) {
-            // Result already removed from cache
-            log.trace("{}: result from bar {} already removed from cache, use {}-th instead",
+            // Corresponding bar already removed series
+            log.trace("{}: result from bar {} already removed from the series, use {}-th instead",
                     getClass().getSimpleName(), index, removedBarsCount);
-            increaseLengthTo(removedBarsCount, maximumResultCount);
-            highestResultIndex = removedBarsCount;
-            result = results.get(0);
-            if (result == null) {
-                // It should be "result = calculate(removedBarsCount);".
-                // We use "result = calculate(0);" as a workaround
-                // to fix issue #120 (https://github.com/mdeverdelhan/ta4j/issues/120).
-                result = calculate(0);
-                results.set(0, result);
-            }
+            // It should be "result = calculate(removedBarsCount);".
+            // We use "result = calculate(0);" as a workaround
+            // to fix issue #120 (https://github.com/mdeverdelhan/ta4j/issues/120).
+            result = calculate(0);
         } else {
-            if (index == series.getEndIndex()) {
-                // Don't cache result if last bar
-                result = calculate(index);
-            } else {
-                increaseLengthTo(index, maximumResultCount);
-                if (index > highestResultIndex) {
-                    // Result not calculated yet
-                    highestResultIndex = index;
-                    result = calculate(index);
-                    results.set(results.size() - 1, result);
-                } else {
-                    // Result covered by current cache
-                    int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);
-                    result = results.get(resultInnerIndex);
-                    if (result == null) {
-                        result = calculate(index);
-                        results.set(resultInnerIndex, result);
-                    }
-                }
-            }
-
+            result = calculate(index);
+            cache.add(index, result);
         }
         log.trace("{}({}): {}", this, index, result);
         return result;
     }
 
-    /**
-     * Increases the size of cached results buffer.
-     *
-     * @param index     the index to increase length to
-     * @param maxLength the maximum length of the results buffer
-     */
-    private void increaseLengthTo(int index, int maxLength) {
-        if (highestResultIndex > -1) {
-            int newResultsCount = Math.min(index - highestResultIndex, maxLength);
-            if (newResultsCount == maxLength) {
-                results.clear();
-                results.addAll(Collections.nCopies(maxLength, null));
-            } else if (newResultsCount > 0) {
-                results.addAll(Collections.nCopies(newResultsCount, null));
-                removeExceedingResults(maxLength);
-            }
-        } else {
-            // First use of cache
-            assert results.isEmpty() : "Cache results list should be empty";
-            results.addAll(Collections.nCopies(Math.min(index + 1, maxLength), null));
-        }
-    }
-
-    /**
-     * Removes the N first results which exceed the maximum bar count. (i.e. keeps
-     * only the last maximumResultCount results)
-     *
-     * @param maximumResultCount the number of results to keep
-     */
-    private void removeExceedingResults(int maximumResultCount) {
-        int resultCount = results.size();
-        if (resultCount > maximumResultCount) {
-            // Removing old results
-            final int nbResultsToRemove = resultCount - maximumResultCount;
-            for (int i = 0; i < nbResultsToRemove; i++) {
-                results.remove(0);
-            }
-        }
+    protected int getLastCachedIndex() {
+        return cache.lastAvailableIndex();
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
@@ -70,7 +70,7 @@ public abstract class RecursiveCachedIndicator<T> extends CachedIndicator<T> {
             if (index <= seriesEndIndex) {
                 // We are not after the end of the series
                 final int removedBarsCount = series.getRemovedBarsCount();
-                int startIndex = Math.max(removedBarsCount, highestResultIndex);
+                int startIndex = Math.max(removedBarsCount, super.getLastCachedIndex());
                 if (index - startIndex > RECURSION_THRESHOLD) {
                     // Too many uncalculated values; the risk for a StackOverflowError becomes high.
                     // Calculating the previous values iteratively


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Reduce complexity by replacing complicated cache index computations with simple TreeMap-Konstruct
- The new TA4JCache sorts automatically by indeces, and removes the least results regarding the index, if the capacity of the corresponding series is exceeded- 

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
