### PR TITLE
New: CriterionIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added Indicator#stream() method
 - :tada: **Enhancement** added a new CombineIndicator, which can combine the values of two Num Indicators with a given combine-function
 - **Example** added a json serialization and deserialization example of BarSeries using google-gson library
+- :tada: **Enhancement** added CriterionIndicator to use any Criterion as an Indicator
 
 ## 0.14 (released April 25, 2021)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -85,9 +85,13 @@ public class BaseTradingRecord implements TradingRecord {
     private Position currentPosition;
 
     /**
-     * Trading cost models
+     * Trading cost model
      */
     private CostModel transactionCostModel;
+
+    /**
+     * Holding cost model
+     */
     private CostModel holdingCostModel;
 
     /**
@@ -193,6 +197,16 @@ public class BaseTradingRecord implements TradingRecord {
     @Override
     public Position getCurrentPosition() {
         return currentPosition;
+    }
+
+    @Override
+    public CostModel getTransactionCostModel() {
+        return transactionCostModel;
+    }
+
+    @Override
+    public CostModel getHoldingCostModel() {
+        return holdingCostModel;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.List;
 
 import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.cost.CostModel;
 import org.ta4j.core.num.Num;
 
 /**
@@ -53,6 +54,16 @@ public interface TradingRecord extends Serializable {
      * @return the name of the TradingRecord
      */
     String getName();
+
+    /**
+     * @return the Trading cost model
+     */
+    CostModel getTransactionCostModel();
+
+    /**
+     * @return the Holding cost model
+     */
+    CostModel getHoldingCostModel();
 
     /**
      * Places a trade in the trading record.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
@@ -1,0 +1,124 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Criterion indicator.
+ * 
+ * <p>
+ * Transforms any AnalysisCriterion into an Indicator. Returns <code>true</code>
+ * if the calculated criterion value till a bar index is better than the
+ * {@link #requiredCriterionValue} or equal, otherwise returns
+ * <code>false</code>.
+ */
+public final class CriterionIndicator extends CachedIndicator<Boolean> {
+
+    private final AnalysisCriterion criterion;
+    private final Num requiredCriterionValue;
+    private final TradingRecord tradingRecord;
+    private final Position position;
+
+    /**
+     * Constructor.
+     * 
+     * @param series                 the bar series
+     * @param tradingRecord          the trading record
+     * @param criterion              the criterion to get the calculated criterion
+     *                               value on a bar index
+     * @param requiredCriterionValue the required criterion value to test against
+     *                               the calculated criterion value
+     */
+    public CriterionIndicator(BarSeries series, TradingRecord tradingRecord, AnalysisCriterion criterion,
+            Num requiredCriterionValue) {
+        super(series);
+        this.tradingRecord = tradingRecord;
+        this.criterion = criterion;
+        this.requiredCriterionValue = requiredCriterionValue;
+        this.position = null;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param series                 the bar series
+     * @param position               the position
+     * @param criterion              the criterion to get the calculated criterion
+     *                               value on a bar index
+     * @param requiredCriterionValue the required criterion value to test against
+     *                               the calculated criterion value
+     */
+    public CriterionIndicator(BarSeries series, Position position, AnalysisCriterion criterion,
+            Num requiredCriterionValue) {
+        super(series);
+        this.tradingRecord = null;
+        this.criterion = criterion;
+        this.requiredCriterionValue = requiredCriterionValue;
+        this.position = position;
+    }
+
+    @Override
+    protected Boolean calculate(int index) {
+        if (tradingRecord != null && !tradingRecord.getPositions().isEmpty()) {
+            TradingRecord tradingRecordTillIndex = new BaseTradingRecord(tradingRecord.getStartingType(),
+                    tradingRecord.getTransactionCostModel(), tradingRecord.getHoldingCostModel());
+            for (Position pos : tradingRecord.getPositions()) {
+                // consider only those positions made till index
+                if (pos.getEntry().getIndex() <= index) {
+                    Trade entry = pos.getEntry();
+                    tradingRecordTillIndex.enter(entry.getIndex(), entry.getNetPrice(), entry.getAmount());
+                }
+                if (pos.getExit() != null && pos.getExit().getIndex() <= index) {
+                    Trade exit = pos.getExit();
+                    tradingRecordTillIndex.exit(exit.getIndex(), exit.getNetPrice(), exit.getAmount());
+                }
+            }
+
+            Num calculatedCriterionValue = criterion.calculate(getBarSeries(), tradingRecordTillIndex);
+            return criterion.betterThan(calculatedCriterionValue, requiredCriterionValue)
+                    || calculatedCriterionValue.isEqual(requiredCriterionValue);
+
+        } else if (position != null) {
+            boolean entryTradeWithinIndex = position.getEntry().getIndex() <= index;
+            boolean exitTradeWithinIndex = position.getExit() == null
+                    || position.getExit() != null && position.getExit().getIndex() <= index;
+            if (entryTradeWithinIndex && exitTradeWithinIndex) {
+                Num calculatedCriterionValue = criterion.calculate(getBarSeries(), position);
+                return criterion.betterThan(calculatedCriterionValue, requiredCriterionValue)
+                        || calculatedCriterionValue.isEqual(requiredCriterionValue);
+            }
+        }
+        // empty tradingRecords or no position must return undefined
+        return false;
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
@@ -65,24 +65,6 @@ public final class CriterionIndicator extends CachedIndicator<Boolean> {
         this.requiredCriterionValue = requiredCriterionValue;
     }
 
-    /**
-     * Constructor.
-     * 
-     * @param series                 the bar series
-     * @param position               the position
-     * @param criterion              the criterion to get the calculated criterion
-     *                               value on a bar index
-     * @param requiredCriterionValue the required criterion value to test against
-     *                               the calculated criterion value
-     */
-    public CriterionIndicator(BarSeries series, Position position, AnalysisCriterion criterion,
-            Num requiredCriterionValue) {
-        super(series);
-        this.tradingRecord = null;
-        this.criterion = criterion;
-        this.requiredCriterionValue = requiredCriterionValue;
-    }
-
     @Override
     protected Boolean calculate(int index) {
         if (tradingRecord.getPositions().isEmpty()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CriterionIndicator.java
@@ -117,7 +117,6 @@ public final class CriterionIndicator extends CachedIndicator<Boolean> {
                         || calculatedCriterionValue.isEqual(requiredCriterionValue);
             }
         }
-        // empty tradingRecords or no position must return undefined
         return false;
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CriterionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CriterionIndicatorTest.java
@@ -1,0 +1,125 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.criteria.NumberOfWinningPositionsCriterion;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class CriterionIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+    private CriterionIndicator criterionIndicator;
+    private NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion;
+
+    public CriterionIndicatorTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Test
+    public void testWithEmptyTradingRecord() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+        Num requiredCriterionValue = series.numOf(1);
+        criterionIndicator = new CriterionIndicator(series, tradingRecord, numberOfWinningPositionsCriterion,
+                requiredCriterionValue);
+
+        // empty tradingRecords must return always false
+        assertFalse(criterionIndicator.getValue(0));
+        assertFalse(criterionIndicator.getValue(1));
+        assertFalse(criterionIndicator.getValue(2));
+        assertFalse(criterionIndicator.getValue(3));
+        assertFalse(criterionIndicator.getValue(4));
+        assertFalse(criterionIndicator.getValue(5));
+    }
+
+    @Test
+    public void testWithTradingRecord() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
+
+        // TradingRecord has 2 winning positions
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
+                Trade.buyAt(3, series), Trade.sellAt(5, series));
+
+        numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+
+        // you need at least 1 winning position
+        Num requiredCriterionValue = series.numOf(1);
+        criterionIndicator = new CriterionIndicator(series, tradingRecord, numberOfWinningPositionsCriterion,
+                requiredCriterionValue);
+
+        // till index 0, no winning position is made
+        assertFalse(criterionIndicator.getValue(0));
+        // till index 1, no winning position is made
+        assertFalse(criterionIndicator.getValue(1));
+        // till index 2, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(2));
+        // till index 3, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(3));
+        // till index 4, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(4));
+        // till index 5, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(5));
+    }
+
+    @Test
+    public void testWithPosition() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 115, 105, 110);
+
+        // Position is a winning position
+        Position position = new Position(Trade.buyAt(2, series), Trade.sellAt(3, series));
+
+        numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
+
+        // you need at least 1 winning position
+        Num requiredCriterionValue = series.numOf(1);
+        criterionIndicator = new CriterionIndicator(series, position, numberOfWinningPositionsCriterion,
+                requiredCriterionValue);
+
+        // till index 0, no winning position is made
+        assertFalse(criterionIndicator.getValue(0));
+        // till index 1, no winning position is made
+        assertFalse(criterionIndicator.getValue(1));
+        // till index 2, no winning position is made
+        assertFalse(criterionIndicator.getValue(2));
+        // till index 3, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(3));
+        // till index 4, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(4));
+        // till index 5, at least one winning position is made
+        assertTrue(criterionIndicator.getValue(5));
+    }
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CriterionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CriterionIndicatorTest.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.criteria.NumberOfWinningPositionsCriterion;
@@ -86,34 +85,6 @@ public class CriterionIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
         assertFalse(criterionIndicator.getValue(1));
         // till index 2, at least one winning position is made
         assertTrue(criterionIndicator.getValue(2));
-        // till index 3, at least one winning position is made
-        assertTrue(criterionIndicator.getValue(3));
-        // till index 4, at least one winning position is made
-        assertTrue(criterionIndicator.getValue(4));
-        // till index 5, at least one winning position is made
-        assertTrue(criterionIndicator.getValue(5));
-    }
-
-    @Test
-    public void testWithPosition() {
-        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 115, 105, 110);
-
-        // Position is a winning position
-        Position position = new Position(Trade.buyAt(2, series), Trade.sellAt(3, series));
-
-        numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
-
-        // you need at least 1 winning position
-        Num requiredCriterionValue = series.numOf(1);
-        criterionIndicator = new CriterionIndicator(series, position, numberOfWinningPositionsCriterion,
-                requiredCriterionValue);
-
-        // till index 0, no winning position is made
-        assertFalse(criterionIndicator.getValue(0));
-        // till index 1, no winning position is made
-        assertFalse(criterionIndicator.getValue(1));
-        // till index 2, no winning position is made
-        assertFalse(criterionIndicator.getValue(2));
         // till index 3, at least one winning position is made
         assertTrue(criterionIndicator.getValue(3));
         // till index 4, at least one winning position is made


### PR DESCRIPTION
Changes proposed in this pull request:
- `CriterionIndicator.java`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

Replaces https://github.com/ta4j/ta4j/pull/747.


Currently, in `CriterionIndicator#calculate(int index)` the part of the tradingRecord till an index will be **deep copied** on every calculation:

Ways to improve this criterion:
1. add `criterion.calculate(BarSeries series, TradingRecord record, int fromIndex, int toIndex);` in `AnalysisCriterion` and all its dedicated classes only to deserve the need for this Indicator.
2. provide method within TradingRecord to **shallow copy** a tradingRecord (`TradingRecord#getSubTradingRecord(int startIndex, int endIndex)`)
3. Any other (better) solutions welcome.

I find solution 2 more attractive as it involves only one class change and avoid the need to implement `criterion.calculate(BarSeries series, TradingRecord record, int fromIndex, int toIndex)` for every Criterion now and in the future. 

I will NOT improve that in this PR. After this PR was merged, the next PR can improve the code.