### PR TITLE
EnterAndHoldCriterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
+- **BuyAndHoldCriterion** renamed to **`EnterAndHoldCriterion`**
 
 ### Fixed
 - **LosingPositionsRatioCriterion** correct betterThan
@@ -26,6 +27,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added Indicator#stream() method
 - :tada: **Enhancement** added a new CombineIndicator, which can combine the values of two Num Indicators with a given combine-function
 - **Example** added a json serialization and deserialization example of BarSeries using google-gson library
+- **EnterAndHoldCriterion** added constructor with TradeType to begin with buy or sell
 
 ## 0.14 (released April 25, 2021)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/criteria/EnterAndHoldReturnCriterion.java
@@ -25,44 +25,71 @@ package org.ta4j.core.analysis.criteria;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
-import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Buy and hold criterion.
+ * Enter and hold criterion.
  *
- * Calculates the return if a buy-and-hold strategy was used, buying on the
- * first bar and selling on the last bar.
+ * Calculates the return if a enter-and-hold strategy was used:
+ * 
+ * <ul>
+ * <li>For {@link #tradeType} = {@link TradeType#BUY}: buying on the first bar
+ * and selling on the last bar.
+ * <li>For {@link #tradeType} = {@link TradeType#SELL}: selling on the first bar
+ * and buying on the last bar.
+ * </ul>
  *
  * @see <a href=
  *      "http://en.wikipedia.org/wiki/Buy_and_hold">http://en.wikipedia.org/wiki/Buy_and_hold</a>
  */
-public class BuyAndHoldReturnCriterion extends AbstractAnalysisCriterion {
+public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
+
+    private final TradeType tradeType;
+
+    /**
+     * Constructor
+     * 
+     * <p>
+     * For buy-and-hold strategy.
+     */
+    public EnterAndHoldReturnCriterion() {
+        this(TradeType.BUY);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param tradeType the {@link TradeType} used to open the position
+     */
+    public EnterAndHoldReturnCriterion(TradeType tradeType) {
+        this.tradeType = tradeType;
+    }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return createBuyAndHoldPosition(series, position.getEntry().getIndex(), position.getExit().getIndex())
+        return createEnterAndHoldTrade(series, position.getEntry().getIndex(), position.getExit().getIndex())
                 .getGrossReturn(series);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return createBuyAndHoldTrade(series).getGrossReturn(series);
+        return createEnterAndHoldTrade(series).getGrossReturn(series);
     }
 
-    /** The higher the criterion value, the better. */
+    /** The higher the criterion value the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
     }
 
-    private Position createBuyAndHoldTrade(BarSeries series) {
-        return createBuyAndHoldPosition(series, series.getBeginIndex(), series.getEndIndex());
+    private Position createEnterAndHoldTrade(BarSeries series) {
+        return createEnterAndHoldTrade(series, series.getBeginIndex(), series.getEndIndex());
     }
 
-    private Position createBuyAndHoldPosition(BarSeries series, int beginIndex, int endIndex) {
-        Position position = new Position(Trade.TradeType.BUY);
+    private Position createEnterAndHoldTrade(BarSeries series, int beginIndex, int endIndex) {
+        Position position = new Position(this.tradeType);
         position.operate(beginIndex, series.getBar(beginIndex).getClosePrice(), series.numOf(1));
         position.operate(endIndex, series.getBar(endIndex).getClosePrice(), series.numOf(1));
         return position;

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
@@ -83,7 +83,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
         AbstractAnalysisCriterion c1 = new AverageReturnPerBarCriterion();
         assertEquals("Average Return Per Bar", c1.toString());
         AbstractAnalysisCriterion c2 = new EnterAndHoldReturnCriterion();
-        assertEquals("Buy And Hold Return", c2.toString());
+        assertEquals("Enter And Hold Return", c2.toString());
         AbstractAnalysisCriterion c3 = new ReturnOverMaxDrawdownCriterion();
         assertEquals("Return Over Max Drawdown", c3.toString());
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/AbstractAnalysisCriterionTest.java
@@ -82,7 +82,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     public void toStringMethod() {
         AbstractAnalysisCriterion c1 = new AverageReturnPerBarCriterion();
         assertEquals("Average Return Per Bar", c1.toString());
-        AbstractAnalysisCriterion c2 = new BuyAndHoldReturnCriterion();
+        AbstractAnalysisCriterion c2 = new EnterAndHoldReturnCriterion();
         assertEquals("Buy And Hold Return", c2.toString());
         AbstractAnalysisCriterion c3 = new ReturnOverMaxDrawdownCriterion();
         assertEquals("Return Over Max Drawdown", c3.toString());

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/EnterAndHoldReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/criteria/EnterAndHoldReturnCriterionTest.java
@@ -34,14 +34,16 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class BuyAndHoldReturnCriterionTest extends AbstractCriterionTest {
+public class EnterAndHoldReturnCriterionTest extends AbstractCriterionTest {
 
-    public BuyAndHoldReturnCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new BuyAndHoldReturnCriterion(), numFunction);
+    public EnterAndHoldReturnCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> params.length == 0 ? new EnterAndHoldReturnCriterion()
+                : new EnterAndHoldReturnCriterion((TradeType) params[0]), numFunction);
     }
 
     @Test
@@ -52,6 +54,9 @@ public class BuyAndHoldReturnCriterionTest extends AbstractCriterionTest {
 
         AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(1.05, buyAndHold.calculate(series, tradingRecord));
+
+        AnalysisCriterion sellAndHold = getCriterion(TradeType.SELL);
+        assertNumEquals(0.95, sellAndHold.calculate(series, tradingRecord));
     }
 
     @Test
@@ -62,6 +67,9 @@ public class BuyAndHoldReturnCriterionTest extends AbstractCriterionTest {
 
         AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(0.7, buyAndHold.calculate(series, tradingRecord));
+
+        AnalysisCriterion sellAndHold = getCriterion(TradeType.SELL);
+        assertNumEquals(1.3, sellAndHold.calculate(series, tradingRecord));
     }
 
     @Test
@@ -70,6 +78,9 @@ public class BuyAndHoldReturnCriterionTest extends AbstractCriterionTest {
 
         AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
+
+        AnalysisCriterion sellAndHold = getCriterion(TradeType.SELL);
+        assertNumEquals(1.3, sellAndHold.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
@@ -78,12 +89,19 @@ public class BuyAndHoldReturnCriterionTest extends AbstractCriterionTest {
         Position position = new Position(Trade.buyAt(0, series), Trade.sellAt(1, series));
         AnalysisCriterion buyAndHold = getCriterion();
         assertNumEquals(105d / 100, buyAndHold.calculate(series, position));
+
+        AnalysisCriterion sellAndHold = getCriterion(TradeType.SELL);
+        assertNumEquals(0.95, sellAndHold.calculate(series, position));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion();
-        assertTrue(criterion.betterThan(numOf(1.3), numOf(1.1)));
-        assertFalse(criterion.betterThan(numOf(0.6), numOf(0.9)));
+        AnalysisCriterion buyAndHold = getCriterion();
+        assertTrue(buyAndHold.betterThan(numOf(1.3), numOf(1.1)));
+        assertFalse(buyAndHold.betterThan(numOf(0.6), numOf(0.9)));
+
+        AnalysisCriterion sellAndHold = getCriterion(TradeType.SELL);
+        assertTrue(sellAndHold.betterThan(numOf(1.3), numOf(1.1)));
+        assertFalse(sellAndHold.betterThan(numOf(0.6), numOf(0.9)));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -28,7 +28,7 @@ import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.criteria.AverageReturnPerBarCriterion;
-import org.ta4j.core.analysis.criteria.BuyAndHoldReturnCriterion;
+import org.ta4j.core.analysis.criteria.EnterAndHoldReturnCriterion;
 import org.ta4j.core.analysis.criteria.LinearTransactionCostCriterion;
 import org.ta4j.core.analysis.criteria.MaximumDrawdownCriterion;
 import org.ta4j.core.analysis.criteria.NumberOfBarsCriterion;
@@ -83,7 +83,8 @@ public class StrategyAnalysis {
         System.out.println("Total transaction cost (from $1000): "
                 + new LinearTransactionCostCriterion(1000, 0.005).calculate(series, tradingRecord));
         // Buy-and-hold
-        System.out.println("Buy-and-hold return: " + new BuyAndHoldReturnCriterion().calculate(series, tradingRecord));
+        System.out
+                .println("Buy-and-hold return: " + new EnterAndHoldReturnCriterion().calculate(series, tradingRecord));
         // Total profit vs buy-and-hold
         System.out.println("Custom strategy return vs buy-and-hold strategy return: "
                 + new VersusBuyAndHoldCriterion(totalReturn).calculate(series, tradingRecord));


### PR DESCRIPTION
Changes proposed in this pull request:
- `BuyAndHoldCriterion` renamed to `EnterAndHoldCriterion`
- ability to measure "buy-and-hold"-strategy or "sell-and-hold"-strategy

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
