### PR TITLE
fix: "Returns.java" calculate endIndex within loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LosingPositionsRatioCriterion** correct betterThan
 - **VersusBuyAndHoldCriterionTest** NaN-Error.
 - :tada: **Fixed** **`ChaikinOscillatorIndicatorTest`**
+- :tada: **Fixed** **`Returns.class`** include endIndex in calculation
 
 ### Changed
 - **BarSeriesManager** removed empty args constructor

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -173,7 +173,7 @@ public class Returns implements Indicator<Num> {
         // returns are per period (iterative). Base price needs to be updated
         // accordingly
         Num lastPrice = position.getEntry().getNetPrice();
-        for (int i = startingIndex; i < endIndex; i++) {
+        for (int i = startingIndex; i <= endIndex; i++) {
             Num intermediateNetPrice = CashFlow.addCost(barSeries.getBar(i).getClosePrice(), avgCost, isLongTrade);
             Num assetReturn = type.calculate(intermediateNetPrice, lastPrice);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- inlcude endIndex within loop of calculate()

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

