### PR TITLE
TradingRecord#getPositions: add javadoc

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -264,7 +264,7 @@ public class BaseTradingRecord implements TradingRecord {
     }
 
     /**
-     * Records an trade and the corresponding position (if closed).
+     * Records a trade and the corresponding position (if closed).
      *
      * @param trade   the trade to be recorded
      * @param isEntry true if the trade is an entry, false otherwise (exit)

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -120,24 +120,24 @@ public interface TradingRecord extends Serializable {
     }
 
     /**
-     * @return the recorded positions
+     * @return the recorded closed positions
      */
     List<Position> getPositions();
 
     /**
-     * @return the number of recorded positions
+     * @return the number of recorded closed positions
      */
     default int getPositionCount() {
         return getPositions().size();
     }
 
     /**
-     * @return the current position
+     * @return the current (open) position
      */
     Position getCurrentPosition();
 
     /**
-     * @return the last position recorded
+     * @return the last closed position recorded
      */
     default Position getLastPosition() {
         List<Position> positions = getPositions();


### PR DESCRIPTION
Changes proposed in this pull request:
- Add javadoc to `TradingRecord#getPositions()` to make clear that `getPositions()` consists of only **closed** position (it does **NOT** contain the currentPosition/latest open position).

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
