### PR TITLE
DXIndicator: moved to adx-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
+- **DXIndicator** moved to adx-package
 
 ### Fixed
 - **LosingPositionsRatioCriterion** correct betterThan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
 - **DXIndicator** moved to adx-package
+- **PlusDMIndicator** moved to adx-package
+- **MinusDMIndicator** moved to adx-package
 
 ### Fixed
 - **LosingPositionsRatioCriterion** correct betterThan

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
@@ -26,7 +26,6 @@ package org.ta4j.core.indicators.adx;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.MMAIndicator;
-import org.ta4j.core.indicators.helpers.DXIndicator;
 import org.ta4j.core.num.Num;
 
 /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -21,12 +21,10 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators.helpers;
+package org.ta4j.core.indicators.adx;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.indicators.adx.MinusDIIndicator;
-import org.ta4j.core.indicators.adx.PlusDIIndicator;
 import org.ta4j.core.num.Num;
 
 /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -27,7 +27,6 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.MMAIndicator;
-import org.ta4j.core.indicators.helpers.MinusDMIndicator;
 import org.ta4j.core.num.Num;
 
 /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
@@ -21,7 +21,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators.helpers;
+package org.ta4j.core.indicators.adx;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -27,7 +27,6 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.MMAIndicator;
-import org.ta4j.core.indicators.helpers.PlusDMIndicator;
 import org.ta4j.core.num.Num;
 
 /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
@@ -21,7 +21,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators.helpers;
+package org.ta4j.core.indicators.adx;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
@@ -21,7 +21,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators.helpers;
+package org.ta4j.core.indicators.adx;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -33,13 +33,14 @@ import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.adx.MinusDMIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
-    public PlusDMIndicatorTest(Function<Number, Num> numFunction) {
+    public MinusDMIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
     }
 
@@ -51,8 +52,8 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        PlusDMIndicator dup = new PlusDMIndicator(series);
-        assertNumEquals(0, dup.getValue(1));
+        MinusDMIndicator down = new MinusDMIndicator(series);
+        assertNumEquals(0, down.getValue(1));
     }
 
     @Test
@@ -63,31 +64,31 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        PlusDMIndicator dup = new PlusDMIndicator(series);
-        assertNumEquals(0, dup.getValue(1));
+        MinusDMIndicator down = new MinusDMIndicator(series);
+        assertNumEquals(0, down.getValue(1));
     }
 
     @Test
     public void zeroDirectionalMovement3() {
-        MockBar yesterdayBar = new MockBar(0, 0, 6, 20, numFunction);
-        MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
-        bars.add(yesterdayBar);
-        bars.add(todayBar);
-        MockBarSeries series = new MockBarSeries(bars);
-        PlusDMIndicator dup = new PlusDMIndicator(series);
-        assertNumEquals(0, dup.getValue(1));
-    }
-
-    @Test
-    public void positiveDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 6, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
         List<Bar> bars = new ArrayList<Bar>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        PlusDMIndicator dup = new PlusDMIndicator(series);
-        assertNumEquals(6, dup.getValue(1));
+        MinusDMIndicator down = new MinusDMIndicator(series);
+        assertNumEquals(0, down.getValue(1));
+    }
+
+    @Test
+    public void positiveDirectionalMovement() {
+        MockBar yesterdayBar = new MockBar(0, 0, 6, 20, numFunction);
+        MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
+        List<Bar> bars = new ArrayList<Bar>();
+        bars.add(yesterdayBar);
+        bars.add(todayBar);
+        MockBarSeries series = new MockBarSeries(bars);
+        MinusDMIndicator down = new MinusDMIndicator(series);
+        assertNumEquals(16, down.getValue(1));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
@@ -21,7 +21,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators.helpers;
+package org.ta4j.core.indicators.adx;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -33,13 +33,14 @@ import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.adx.PlusDMIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
-    public MinusDMIndicatorTest(Function<Number, Num> numFunction) {
+    public PlusDMIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
     }
 
@@ -51,8 +52,8 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        MinusDMIndicator down = new MinusDMIndicator(series);
-        assertNumEquals(0, down.getValue(1));
+        PlusDMIndicator dup = new PlusDMIndicator(series);
+        assertNumEquals(0, dup.getValue(1));
     }
 
     @Test
@@ -63,31 +64,31 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        MinusDMIndicator down = new MinusDMIndicator(series);
-        assertNumEquals(0, down.getValue(1));
+        PlusDMIndicator dup = new PlusDMIndicator(series);
+        assertNumEquals(0, dup.getValue(1));
     }
 
     @Test
     public void zeroDirectionalMovement3() {
-        MockBar yesterdayBar = new MockBar(0, 0, 6, 6, numFunction);
-        MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
-        bars.add(yesterdayBar);
-        bars.add(todayBar);
-        MockBarSeries series = new MockBarSeries(bars);
-        MinusDMIndicator down = new MinusDMIndicator(series);
-        assertNumEquals(0, down.getValue(1));
-    }
-
-    @Test
-    public void positiveDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 20, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
         List<Bar> bars = new ArrayList<Bar>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
-        MinusDMIndicator down = new MinusDMIndicator(series);
-        assertNumEquals(16, down.getValue(1));
+        PlusDMIndicator dup = new PlusDMIndicator(series);
+        assertNumEquals(0, dup.getValue(1));
+    }
+
+    @Test
+    public void positiveDirectionalMovement() {
+        MockBar yesterdayBar = new MockBar(0, 0, 6, 6, numFunction);
+        MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
+        List<Bar> bars = new ArrayList<Bar>();
+        bars.add(yesterdayBar);
+        bars.add(todayBar);
+        MockBarSeries series = new MockBarSeries(bars);
+        PlusDMIndicator dup = new PlusDMIndicator(series);
+        assertNumEquals(6, dup.getValue(1));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

﻿- **DXIndicator** moved to adx-package
﻿- **PlusDMIndicator** moved to adx-package
﻿- **MinusDMIndicator** moved to adx-package

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
