### PR TITLE
Added a delay indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Added
 - :tada: **Enhancement** added possibility to use CostModels when backtesting with the BacktestExecutor
 - :tada: **Enhancement** added Num#zero, Num#one, Num#hundred
-- :tada: **Enhancement** added possibility to use CostModels when backtesting with the BacktestExecutor
 - :tada: **Enhancement** added Indicator#stream() method
 - :tada: **Enhancement** added a new CombineIndicator, which can combine the values of two Num Indicators with a given combine-function
 - **Example** added a json serialization and deserialization example of BarSeries using google-gson library
@@ -35,6 +34,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`StandardErrorCriterion`**
 - :tada: **Enhancement** added **`VarianceCriterion`**
 - :tada: **Enhancement** added **`AverageCriterion`**
+- :tada: **Enhancement** added **`DelayIndicator`**
+
 
 
 ## 0.14 (released April 25, 2021)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DelayIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DelayIndicator.java
@@ -1,0 +1,58 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import static org.ta4j.core.num.NaN.NaN;
+
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Delay indicator.
+ *
+ * Indicator, which returns as result the value of the given indicator delayed.
+ * If the delay is positive, the value from the past is returned (if available)
+ * If the delay is negative, the value in future is returned (if available) If
+ * the delay moves outside of the available bars in the series, NaN is returned.
+ */
+public class DelayIndicator extends CachedIndicator<Num> {
+    private final int delay;
+    private final Indicator<Num> indicator;
+
+    public DelayIndicator(Indicator<Num> indicator, int delay) {
+        super(indicator);
+        this.indicator = indicator;
+        this.delay = delay;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+        int delayedIndex = index - delay;
+        if (delayedIndex >= getBarSeries().getBeginIndex() && delayedIndex <= getBarSeries().getEndIndex()) {
+            return indicator.getValue(delayedIndex);
+        }
+        return NaN;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DelayIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DelayIndicatorTest.java
@@ -1,0 +1,102 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+import static org.ta4j.core.num.NaN.NaN;
+
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class DelayIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    BarSeries barSeries;
+    private ClosePriceIndicator closePriceIndicator;
+
+    public DelayIndicatorTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Before
+    public void setUp() {
+        barSeries = new MockBarSeries(numFunction);
+        closePriceIndicator = new ClosePriceIndicator(barSeries);
+    }
+
+    @Test
+    public void indicatorReturnsPastValuesOnPositiveDelay() {
+        int delay = 3;
+        DelayIndicator indicator = new DelayIndicator(closePriceIndicator, delay);
+        boolean loopCalled = false;
+        for (int i = barSeries.getBeginIndex() + delay; i <= barSeries.getEndIndex() + delay; i++) {
+            loopCalled = true;
+            assertEquals(closePriceIndicator.getValue(i - delay), indicator.getValue(i));
+        }
+        assertTrue(loopCalled);
+    }
+
+    @Test
+    public void indicatorReturnsFutureValuesOnNegativeDelay() {
+        int delay = -3;
+        DelayIndicator indicator = new DelayIndicator(closePriceIndicator, delay);
+        boolean loopCalled = false;
+        for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex() + delay; i++) {
+            loopCalled = true;
+            assertEquals(closePriceIndicator.getValue(i - delay), indicator.getValue(i));
+        }
+        assertTrue(loopCalled);
+    }
+
+    @Test
+    public void indicatorReturnsNanIfBarIsNotAvailableInPast() {
+        int delay = 3;
+        DelayIndicator indicator = new DelayIndicator(closePriceIndicator, delay);
+        boolean loopCalled = false;
+        for (int i = barSeries.getBeginIndex(); i < barSeries.getBeginIndex() + delay; i++) {
+            loopCalled = true;
+            assertEquals(NaN, indicator.getValue(i));
+        }
+        assertTrue(loopCalled);
+    }
+
+    @Test
+    public void indicatorReturnsNanIfBarIsNotAvailableInFuture() {
+        int delay = -3;
+        DelayIndicator indicator = new DelayIndicator(closePriceIndicator, delay);
+        boolean loopCalled = false;
+        for (int i = barSeries.getEndIndex() + 1 + delay; i <= barSeries.getEndIndex(); i++) {
+            loopCalled = true;
+            assertEquals(NaN, indicator.getValue(i));
+        }
+        assertTrue(loopCalled);
+    }
+}


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Added an indicator which can delay its computation.
- This DelayIndicator can be used by different indicator implementations, which rely on delayed information, such as the Ishimoku-Cloud computation
- 

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
