### PR TITLE
Feature/before rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`StandardErrorCriterion`**
 - :tada: **Enhancement** added **`VarianceCriterion`**
 - :tada: **Enhancement** added **`AverageCriterion`**
+- :tada: **Enhancement** added **`BeforeRule`**
 
 
 ## 0.14 (released April 25, 2021)

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BeforeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BeforeRule.java
@@ -1,0 +1,73 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.rules;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Rule;
+import org.ta4j.core.TradingRecord;
+
+/**
+ * Before rule.
+ * <p>
+ * The rule is satisfied if the first given rule was satisfied before the second
+ * rule. In between those two conditions, the given reset rule is not allowed to
+ * hold.
+ */
+public class BeforeRule extends AbstractRule {
+
+    private final BarSeries series;
+    private final Rule firstCondition;
+    private final Rule secondCondition;
+    private final Rule resetCondition;
+
+    public BeforeRule(BarSeries series, Rule firstCondition, Rule secondCondition, Rule resetCondition) {
+        super();
+        this.series = series;
+        this.firstCondition = firstCondition;
+        this.secondCondition = secondCondition;
+        this.resetCondition = resetCondition;
+    }
+
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        if (!secondCondition.isSatisfied(index, tradingRecord)) {
+            traceIsSatisfied(index, false);
+            return false;
+        }
+
+        for (int i = index; i >= series.getBeginIndex(); i--) {
+            if (resetCondition.isSatisfied(i, tradingRecord)) {
+                traceIsSatisfied(index, false);
+                return false;
+            }
+            if (firstCondition.isSatisfied(i, tradingRecord)) {
+                traceIsSatisfied(index, true);
+                return true;
+            }
+        }
+
+        traceIsSatisfied(index, false);
+        return false;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/BeforeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/BeforeRuleTest.java
@@ -1,0 +1,70 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.rules;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.Rule;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.ConstantIndicator;
+import org.ta4j.core.num.Num;
+
+public class BeforeRuleTest {
+
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void isSatisfied() {
+        BarSeries series = new BaseBarSeries(BeforeRuleTest.class.getSimpleName());
+        ZonedDateTime starttime = ZonedDateTime.now();
+        series.addBar(starttime, 1, 1, 1, 1);
+        series.addBar(starttime.plusSeconds(1), 2, 2, 2, 2);
+        series.addBar(starttime.plusSeconds(2), 1, 1, 1, 1);
+        series.addBar(starttime.plusSeconds(3), 3, 3, 3, 3);
+        series.addBar(starttime.plusSeconds(4), 4, 4, 4, 4);
+
+        ConstantIndicator<Num> constant1dot5 = new ConstantIndicator<Num>(series, series.numOf(1.5));
+        ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(series);
+        CrossedUpIndicatorRule crossUp = new CrossedUpIndicatorRule(closePriceIndicator, constant1dot5);
+        CrossedDownIndicatorRule crossDown = new CrossedDownIndicatorRule(closePriceIndicator, constant1dot5);
+        Rule alwaysTrue = BooleanRule.TRUE;
+
+        BeforeRule rule = new BeforeRule(series, crossUp, alwaysTrue, crossDown);
+
+        assertFalse(rule.isSatisfied(0));
+        assertTrue(rule.isSatisfied(1));
+        assertFalse(rule.isSatisfied(2));
+        assertTrue(rule.isSatisfied(3));
+        assertTrue(rule.isSatisfied(4));
+    }
+}


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Added a before rule, which allows to easily create conditions that must not be valid at the same time.
- E.g. a cross up is needed before some other conditions hold like in the Ichimoku indicator
- 

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
