### PR TITLE
uncache ATRIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **PriceIndicator** removed
 
 ### Added
+- **AbstractEMAIndicator** added getBarCount() to support future enhancements 
+- **ATRIndicator** "uncached" by changing superclass to AbstractIndicator; added constructor to accept TRIndicator and getter for same; added toString(); added getBarCount() to support future enhancements
 - :tada: **Enhancement** added possibility to use CostModels when backtesting with the BacktestExecutor
 - :tada: **Enhancement** added Num#zero, Num#one, Num#hundred
 - :tada: **Enhancement** added possibility to use CostModels when backtesting with the BacktestExecutor

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -30,17 +30,36 @@ import org.ta4j.core.num.Num;
 /**
  * Average true range indicator.
  */
-public class ATRIndicator extends CachedIndicator<Num> {
+public class ATRIndicator extends AbstractIndicator<Num> {
 
+    private final TRIndicator trIndicator;
     private final MMAIndicator averageTrueRangeIndicator;
 
     public ATRIndicator(BarSeries series, int barCount) {
-        super(series);
-        this.averageTrueRangeIndicator = new MMAIndicator(new TRIndicator(series), barCount);
+        this(new TRIndicator(series), barCount);
+    }
+
+    public ATRIndicator(TRIndicator tr, int barCount) {
+        super(tr.getBarSeries());
+        this.trIndicator = tr;
+        this.averageTrueRangeIndicator = new MMAIndicator(new TRIndicator(tr.getBarSeries()), barCount);
     }
 
     @Override
-    protected Num calculate(int index) {
+    public Num getValue(int index) {
         return averageTrueRangeIndicator.getValue(index);
+    }
+
+    public TRIndicator getTRIndicator() {
+        return trIndicator;
+    }
+
+    public int getBarCount() {
+        return averageTrueRangeIndicator.getBarCount();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " barCount: " + getBarCount();
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
@@ -55,4 +55,8 @@ public abstract class AbstractEMAIndicator extends RecursiveCachedIndicator<Num>
     public String toString() {
         return getClass().getSimpleName() + " barCount: " + barCount;
     }
+
+    public int getBarCount() {
+        return barCount;
+    }
 }


### PR DESCRIPTION
Small changes to remove caching for the ATRIndicator.
Also adds a constructor so multiple ATR instances can share a single TRIndicator.
Adds getters to support future enhancements to ADX and other subsystems.