### PR TITLE
improve `BaseBarSeries#removeExceedingBars`

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -475,8 +475,10 @@ public class BaseBarSeries implements BarSeries {
         if (barCount > maximumBarCount) {
             // Removing old bars
             int nbBarsToRemove = barCount - maximumBarCount;
-            for (int i = 0; i < nbBarsToRemove; i++) {
+            if (nbBarsToRemove == 1) {
                 bars.remove(0);
+            } else {
+                bars.subList(0, nbBarsToRemove).clear();
             }
             // Updating removed bars count
             removedBarsCount += nbBarsToRemove;


### PR DESCRIPTION
Changes proposed in this pull request:
- improve BaseBarSeries#removeExceedingBars()

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

The improved version is faster because it uses at most one shift operation (resizing) instead of x>=1.
