### PR TITLE
improve `CachedIndicator#removeExceedingResults`

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -168,8 +168,10 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
         if (resultCount > maximumResultCount) {
             // Removing old results
             final int nbResultsToRemove = resultCount - maximumResultCount;
-            for (int i = 0; i < nbResultsToRemove; i++) {
+            if (nbResultsToRemove == 1) {
                 results.remove(0);
+            } else {
+                results.subList(0, nbResultsToRemove).clear();
             }
         }
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- improve `CachedIndicator#removeExceedingResults`

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 


The improved version is faster because it uses at most one shift operation (resizing) instead of x>=1.
