### PR TITLE
Keltner construction/uncaching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Changed
 - **KeltnerChannelMiddleIndicator** changed superclass to AbstractIndicator; add GetBarCount() and toString()
-- **KeltnerChannelUpperIndicator** changed superclass to AbstractIndicator; add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
-- **KeltnerChannelLowerIndicator** changed superclass to AbstractIndicator; add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
+- **KeltnerChannelUpperIndicator** add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
+- **KeltnerChannelLowerIndicator** add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
 - **BarSeriesManager** removed empty args constructor
 - **Open|High|Low|Close** do not cache price values anymore
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Fixed** **`ChaikinOscillatorIndicatorTest`**
 
 ### Changed
+- **KeltnerChannelMiddleIndicator** changed superclass to AbstractIndicator; add GetBarCount() and toString()
+- **KeltnerChannelUpperIndicator** changed superclass to AbstractIndicator; add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
+- **KeltnerChannelLowerIndicator** changed superclass to AbstractIndicator; add constructor to accept pre-constructed ATR; add GetBarCount() and toString()
 - **BarSeriesManager** removed empty args constructor
 - **Open|High|Low|Close** do not cache price values anymore
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.indicators.keltner;
 
 import org.ta4j.core.indicators.ATRIndicator;
-import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.AbstractIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
  *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels">
  *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels</a>
  */
-public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
+public class KeltnerChannelLowerIndicator extends AbstractIndicator<Num> {
 
     private final ATRIndicator averageTrueRangeIndicator;
 
@@ -42,18 +42,29 @@ public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
 
     private final Num ratio;
 
-    public KeltnerChannelLowerIndicator(KeltnerChannelMiddleIndicator keltnerMiddleIndicator, double ratio,
-            int barCountATR) {
-        super(keltnerMiddleIndicator);
+    public KeltnerChannelLowerIndicator(KeltnerChannelMiddleIndicator middle, double ratio, int barCountATR) {
+        this(middle, new ATRIndicator(middle.getBarSeries(), barCountATR), ratio);
+    }
+
+    public KeltnerChannelLowerIndicator(KeltnerChannelMiddleIndicator middle, ATRIndicator atr, double ratio) {
+        super(middle.getBarSeries());
+        this.keltnerMiddleIndicator = middle;
+        this.averageTrueRangeIndicator = atr;
         this.ratio = numOf(ratio);
-        this.keltnerMiddleIndicator = keltnerMiddleIndicator;
-        averageTrueRangeIndicator = new ATRIndicator(keltnerMiddleIndicator.getBarSeries(), barCountATR);
     }
 
     @Override
-    protected Num calculate(int index) {
+    public Num getValue(int index) {
         return keltnerMiddleIndicator.getValue(index)
                 .minus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
     }
 
+    public int getBarCount() {
+        return keltnerMiddleIndicator.getBarCount();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " barCount: " + getBarCount();
+    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.indicators.keltner;
 
 import org.ta4j.core.indicators.ATRIndicator;
-import org.ta4j.core.indicators.AbstractIndicator;
+import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
  *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels">
  *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels</a>
  */
-public class KeltnerChannelLowerIndicator extends AbstractIndicator<Num> {
+public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
 
     private final ATRIndicator averageTrueRangeIndicator;
 
@@ -54,7 +54,7 @@ public class KeltnerChannelLowerIndicator extends AbstractIndicator<Num> {
     }
 
     @Override
-    public Num getValue(int index) {
+    protected Num calculate(int index) {
         return keltnerMiddleIndicator.getValue(index)
                 .minus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
@@ -25,7 +25,7 @@ package org.ta4j.core.indicators.keltner;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.AbstractIndicator;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.helpers.TypicalPriceIndicator;
 import org.ta4j.core.num.Num;
@@ -37,7 +37,7 @@ import org.ta4j.core.num.Num;
  *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels">
  *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels</a>
  */
-public class KeltnerChannelMiddleIndicator extends CachedIndicator<Num> {
+public class KeltnerChannelMiddleIndicator extends AbstractIndicator<Num> {
 
     private final EMAIndicator emaIndicator;
 
@@ -46,13 +46,21 @@ public class KeltnerChannelMiddleIndicator extends CachedIndicator<Num> {
     }
 
     public KeltnerChannelMiddleIndicator(Indicator<Num> indicator, int barCountEMA) {
-        super(indicator);
+        super(indicator.getBarSeries());
         emaIndicator = new EMAIndicator(indicator, barCountEMA);
     }
 
     @Override
-    protected Num calculate(int index) {
+    public Num getValue(int index) {
         return emaIndicator.getValue(index);
     }
 
+    public int getBarCount() {
+        return emaIndicator.getBarCount();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " barCount: " + getBarCount();
+    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.indicators.keltner;
 
 import org.ta4j.core.indicators.ATRIndicator;
-import org.ta4j.core.indicators.AbstractIndicator;
+import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
  *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels">
  *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels</a>
  */
-public class KeltnerChannelUpperIndicator extends AbstractIndicator<Num> {
+public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
 
     private final ATRIndicator averageTrueRangeIndicator;
 
@@ -54,7 +54,7 @@ public class KeltnerChannelUpperIndicator extends AbstractIndicator<Num> {
     }
 
     @Override
-    public Num getValue(int index) {
+    protected Num calculate(int index) {
         return keltnerMiddleIndicator.getValue(index)
                 .plus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.indicators.keltner;
 
 import org.ta4j.core.indicators.ATRIndicator;
-import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.indicators.AbstractIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
  *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels">
  *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:keltner_channels</a>
  */
-public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
+public class KeltnerChannelUpperIndicator extends AbstractIndicator<Num> {
 
     private final ATRIndicator averageTrueRangeIndicator;
 
@@ -42,18 +42,29 @@ public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
 
     private final Num ratio;
 
-    public KeltnerChannelUpperIndicator(KeltnerChannelMiddleIndicator keltnerMiddleIndicator, double ratio,
-            int barCountATR) {
-        super(keltnerMiddleIndicator);
+    public KeltnerChannelUpperIndicator(KeltnerChannelMiddleIndicator middle, double ratio, int barCountATR) {
+        this(middle, new ATRIndicator(middle.getBarSeries(), barCountATR), ratio);
+    }
+
+    public KeltnerChannelUpperIndicator(KeltnerChannelMiddleIndicator middle, ATRIndicator atr, double ratio) {
+        super(middle.getBarSeries());
+        this.keltnerMiddleIndicator = middle;
+        this.averageTrueRangeIndicator = atr;
         this.ratio = numOf(ratio);
-        this.keltnerMiddleIndicator = keltnerMiddleIndicator;
-        averageTrueRangeIndicator = new ATRIndicator(keltnerMiddleIndicator.getBarSeries(), barCountATR);
     }
 
     @Override
-    protected Num calculate(int index) {
+    public Num getValue(int index) {
         return keltnerMiddleIndicator.getValue(index)
                 .plus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
     }
 
+    public int getBarCount() {
+        return keltnerMiddleIndicator.getBarCount();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " barCount: " + getBarCount();
+    }
 }


### PR DESCRIPTION
Uncached Keltner middle; it completely delegates calculation to its EMA

Uncached upper and lower; the calculations are simple and do not need to be cached, IMO; I can undo this if you want.  If you agree with this uncaching for Keltner upper/lower, there are quite a few others I can uncache the same way

Added constructors so upper/lower can share an ATR instance; possible small performance gain

Added getBarCount() and toString() for consistency.  

