### PR TITLE
Feature/useable ichimoku indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LosingPositionsRatioCriterion** correct betterThan
 - **VersusBuyAndHoldCriterionTest** NaN-Error.
 - :tada: **Fixed** **`ChaikinOscillatorIndicatorTest`**
+- :tada: **Fixed** IchimokuIndicators can be used in rules. No moew incorrect offsets and future time indeces
 
 ### Changed
 - **BarSeriesManager** removed empty args constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LosingPositionsRatioCriterion** correct betterThan
 - **VersusBuyAndHoldCriterionTest** NaN-Error.
 - :tada: **Fixed** **`ChaikinOscillatorIndicatorTest`**
-- :tada: **Fixed** IchimokuIndicators can be used in rules. No moew incorrect offsets and future time indeces
+- :tada: **Fixed** IchimokuIndicators can be used in rules. No incorrect offsets and future time indeces anymore
 
 ### Changed
 - **BarSeriesManager** removed empty args constructor
@@ -43,6 +43,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`StandardErrorCriterion`**
 - :tada: **Enhancement** added **`VarianceCriterion`**
 - :tada: **Enhancement** added **`AverageCriterion`**
+- :tada: **Example** added **`IchimokuCloudStrategy`**
 
 ## 0.14 (released April 25, 2021)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
@@ -44,39 +44,25 @@ public class IchimokuChikouSpanIndicator extends CachedIndicator<Num> {
     private final ClosePriceIndicator closePriceIndicator;
 
     /**
-     * The time delay
-     */
-    private final int timeDelay;
-
-    /**
-     * Constructor.
+     * Constructor. The ichimoku chikou span returns for an index i always the
+     * current close price for i. Only its usage and comparison against other prices
+     * takes into account the past. E.g. new OverIndicatorRule(chikouSpanIndicator,
+     * new PreviousValueIndicator(closePriceIndicator, chikouSpanDelay)) This rule
+     * is satisfied, if the current value of the span is over the old close price.
+     *
+     * The chikou span calculation is always based on the current values, but only
+     * printed into the past!
      *
      * @param series the series
      */
     public IchimokuChikouSpanIndicator(BarSeries series) {
-        this(series, 26);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param series    the series
-     * @param timeDelay the time delay (usually 26)
-     */
-    public IchimokuChikouSpanIndicator(BarSeries series, int timeDelay) {
         super(series);
         this.closePriceIndicator = new ClosePriceIndicator(series);
-        this.timeDelay = timeDelay;
     }
 
     @Override
-    protected Num calculate(int index) {
-        int spanIndex = index + timeDelay;
-        if (spanIndex <= getBarSeries().getEndIndex()) {
-            return closePriceIndicator.getValue(spanIndex);
-        } else {
-            return NaN.NaN;
-        }
+    protected Num calculate(int i) {
+        return closePriceIndicator.getValue(i);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
@@ -29,7 +29,6 @@ import static org.ta4j.core.indicators.helpers.TransformIndicator.divide;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.helpers.TransformIndicator;
-import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
@@ -37,13 +37,11 @@ import org.ta4j.core.num.Num;
  */
 public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
 
-    // ichimoku avg line indicator
-    IchimokuLineIndicator lineIndicator;
-
     /**
-     * Displacement on the chart (usually 26)
+     * The actual indicator which contains the calculation ( ichimoku avg line
+     * indicator )
      */
-    private final int offset;
+    IchimokuLineIndicator senkouSpanBFutureCalculator;
 
     /**
      * Constructor.
@@ -52,7 +50,7 @@ public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
      */
     public IchimokuSenkouSpanBIndicator(BarSeries series) {
 
-        this(series, 52, 26);
+        this(series, 52);
     }
 
     /**
@@ -62,31 +60,12 @@ public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
      * @param barCount the time frame (usually 52)
      */
     public IchimokuSenkouSpanBIndicator(BarSeries series, int barCount) {
-
-        this(series, barCount, 26);
-    }
-
-    /**
-     * Constructor.
-     * 
-     * @param series   the series
-     * @param barCount the time frame (usually 52)
-     * @param offset   displacement on the chart
-     */
-    public IchimokuSenkouSpanBIndicator(BarSeries series, int barCount, int offset) {
-
         super(series);
-        lineIndicator = new IchimokuLineIndicator(series, barCount);
-        this.offset = offset;
+        senkouSpanBFutureCalculator = new IchimokuLineIndicator(series, barCount);
     }
 
     @Override
     protected Num calculate(int index) {
-        int spanIndex = index - offset + 1;
-        if (spanIndex >= getBarSeries().getBeginIndex()) {
-            return lineIndicator.getValue(spanIndex);
-        } else {
-            return NaN.NaN;
-        }
+        return senkouSpanBFutureCalculator.getValue(index);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
@@ -25,7 +25,6 @@ package org.ta4j.core.indicators.ichimoku;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.CachedIndicator;
-import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
@@ -45,7 +44,7 @@ public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the series
      */
     public IchimokuSenkouSpanBIndicator(BarSeries series) {
@@ -54,8 +53,19 @@ public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
     }
 
     /**
-     * Constructor.
-     * 
+     * Constructor. This indicator returns the values in dependency to the current
+     * time 'index'. This means, it is the 'future' cloud indicator (when printed)
+     * The values are calculated for the current bar, but the values are printed
+     * into the future
+     *
+     * To create an indicator which returns the values of the 'current' cloud (when
+     * printed), use new PreviousValueIndicator(ichimokuSenkouSpanBIndicator,
+     * senkunSpanBarCount/2))
+     *
+     * To create an indicator which contains the values of the 'past' cloud (when
+     * printed), use new PreviousValueIndicator(ichimokuSenkouSpanBIndicator,
+     * senkunSpanBarCount))
+     *
      * @param series   the series
      * @param barCount the time frame (usually 52)
      */

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -25,6 +25,7 @@ package org.ta4j.core.indicators.ichimoku;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.function.Function;
@@ -35,6 +36,7 @@ import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
@@ -55,57 +57,24 @@ public class IchimokuChikouSpanIndicatorTest extends AbstractIndicatorTest<BarSe
     }
 
     @Test
-    public void testCalculateWithDefaultParam() {
+    public void testCalculateReturnsTheClosePriceAsItIs() {
         final BarSeries barSeries = barSeries(27);
 
-        final IchimokuChikouSpanIndicator indicator = new IchimokuChikouSpanIndicator(barSeries);
+        // the span indicator returns always the value of the current close price.
+        // The indicator is only PRINTED in the past.
+        // In strategies, this indicator should therefore be compared to past values,
+        // e.g. new OverIndicatorRule(chikouSpanIndicator, new PreviousValueIndicator(closePrice, 26))
+        final IchimokuChikouSpanIndicator chikouSpanIndicator = new IchimokuChikouSpanIndicator(barSeries);
+        final ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(barSeries);
 
-        assertEquals(numOf(26), indicator.getValue(0));
-        assertEquals(NaN.NaN, indicator.getValue(1));
-        assertEquals(NaN.NaN, indicator.getValue(2));
-        assertEquals(NaN.NaN, indicator.getValue(3));
-        assertEquals(NaN.NaN, indicator.getValue(4));
-        assertEquals(NaN.NaN, indicator.getValue(5));
-        assertEquals(NaN.NaN, indicator.getValue(6));
-        assertEquals(NaN.NaN, indicator.getValue(7));
-        assertEquals(NaN.NaN, indicator.getValue(8));
-        assertEquals(NaN.NaN, indicator.getValue(9));
-        assertEquals(NaN.NaN, indicator.getValue(10));
-        assertEquals(NaN.NaN, indicator.getValue(11));
-        assertEquals(NaN.NaN, indicator.getValue(12));
-        assertEquals(NaN.NaN, indicator.getValue(13));
-        assertEquals(NaN.NaN, indicator.getValue(14));
-        assertEquals(NaN.NaN, indicator.getValue(15));
-        assertEquals(NaN.NaN, indicator.getValue(16));
-        assertEquals(NaN.NaN, indicator.getValue(17));
-        assertEquals(NaN.NaN, indicator.getValue(18));
-        assertEquals(NaN.NaN, indicator.getValue(19));
-        assertEquals(NaN.NaN, indicator.getValue(20));
-        assertEquals(NaN.NaN, indicator.getValue(21));
-        assertEquals(NaN.NaN, indicator.getValue(22));
-        assertEquals(NaN.NaN, indicator.getValue(23));
-        assertEquals(NaN.NaN, indicator.getValue(24));
-        assertEquals(NaN.NaN, indicator.getValue(25));
-        assertEquals(NaN.NaN, indicator.getValue(26));
-    }
+        boolean loopEntered = false;
 
-    @Test
-    public void testCalculateWithSpecifiedValue() {
-        final BarSeries barSeries = barSeries(11);
+        for(int i = barSeries.getBeginIndex(); i<=barSeries.getEndIndex(); i++) {
+            assertEquals(closePriceIndicator.getValue(i), chikouSpanIndicator.getValue(i));
+            loopEntered=true;
+        }
 
-        final IchimokuChikouSpanIndicator indicator = new IchimokuChikouSpanIndicator(barSeries);
-
-        assertEquals(numOf(3), indicator.getValue(0));
-        assertEquals(numOf(4), indicator.getValue(1));
-        assertEquals(numOf(5), indicator.getValue(2));
-        assertEquals(numOf(6), indicator.getValue(3));
-        assertEquals(numOf(7), indicator.getValue(4));
-        assertEquals(numOf(8), indicator.getValue(5));
-        assertEquals(numOf(9), indicator.getValue(6));
-        assertEquals(numOf(10), indicator.getValue(7));
-        assertEquals(NaN.NaN, indicator.getValue(8));
-        assertEquals(NaN.NaN, indicator.getValue(9));
-        assertEquals(NaN.NaN, indicator.getValue(10));
+        assertTrue(loopEntered);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -93,7 +93,7 @@ public class IchimokuChikouSpanIndicatorTest extends AbstractIndicatorTest<BarSe
     public void testCalculateWithSpecifiedValue() {
         final BarSeries barSeries = barSeries(11);
 
-        final IchimokuChikouSpanIndicator indicator = new IchimokuChikouSpanIndicator(barSeries, 3);
+        final IchimokuChikouSpanIndicator indicator = new IchimokuChikouSpanIndicator(barSeries);
 
         assertEquals(numOf(3), indicator.getValue(0));
         assertEquals(numOf(4), indicator.getValue(1));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -63,15 +63,16 @@ public class IchimokuChikouSpanIndicatorTest extends AbstractIndicatorTest<BarSe
         // the span indicator returns always the value of the current close price.
         // The indicator is only PRINTED in the past.
         // In strategies, this indicator should therefore be compared to past values,
-        // e.g. new OverIndicatorRule(chikouSpanIndicator, new PreviousValueIndicator(closePrice, 26))
+        // e.g. new OverIndicatorRule(chikouSpanIndicator, new
+        // PreviousValueIndicator(closePrice, 26))
         final IchimokuChikouSpanIndicator chikouSpanIndicator = new IchimokuChikouSpanIndicator(barSeries);
         final ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(barSeries);
 
         boolean loopEntered = false;
 
-        for(int i = barSeries.getBeginIndex(); i<=barSeries.getEndIndex(); i++) {
+        for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex(); i++) {
             assertEquals(closePriceIndicator.getValue(i), chikouSpanIndicator.getValue(i));
-            loopEntered=true;
+            loopEntered = true;
         }
 
         assertTrue(loopEntered);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -79,9 +79,7 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
         IchimokuTenkanSenIndicator tenkanSen = new IchimokuTenkanSenIndicator(data, 3);
         IchimokuKijunSenIndicator kijunSen = new IchimokuKijunSenIndicator(data, 5);
         IchimokuSenkouSpanAIndicator senkouSpanA = new IchimokuSenkouSpanAIndicator(tenkanSen, kijunSen);
-        IchimokuSenkouSpanBIndicator senkouSpanB = new IchimokuSenkouSpanBIndicator(data, 9);
-        final int chikouSpanTimeDelay = 5;
-        IchimokuChikouSpanIndicator chikouSpan = new IchimokuChikouSpanIndicator(data);
+        IchimokuSenkouSpanBIndicator senkouSpanB = new IchimokuSenkouSpanBIndicator(data, 5);
 
         assertNumEquals(45.155, tenkanSen.getValue(3));
         assertNumEquals(45.18, tenkanSen.getValue(4));
@@ -103,45 +101,22 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
         assertNumEquals(44.305, kijunSen.getValue(17));
         assertNumEquals(44.05, kijunSen.getValue(18));
 
-        assertNumEquals(NaN.NaN, senkouSpanA.getValue(3));
-        assertNumEquals(45.065, senkouSpanA.getValue(4));
-        assertNumEquals(45.1475, senkouSpanA.getValue(7));
-        assertNumEquals(45.16, senkouSpanA.getValue(8));
-        assertNumEquals(45.15, senkouSpanA.getValue(9));
-        assertNumEquals(45.1575, senkouSpanA.getValue(10));
-        assertNumEquals(45.4275, senkouSpanA.getValue(16));
-        assertNumEquals(45.205, senkouSpanA.getValue(17));
-        assertNumEquals(44.89, senkouSpanA.getValue(18));
+        for (int i = data.getBeginIndex(); i <= data.getEndIndex(); i++) {
+            assertNumEquals(
+                    tenkanSen.getValue(i)
+                            .plus(kijunSen.getValue(i))
+                            .dividedBy(numOf(2)),
+                    senkouSpanA.getValue(i));
+        }
 
-        assertNumEquals(NaN.NaN, senkouSpanB.getValue(3));
-        assertNumEquals(45.065, senkouSpanB.getValue(4));
-        assertNumEquals(45.065, senkouSpanB.getValue(5));
-        assertNumEquals(45.14, senkouSpanB.getValue(6));
-        assertNumEquals(45.14, senkouSpanB.getValue(7));
-        assertNumEquals(45.22, senkouSpanB.getValue(13));
-        assertNumEquals(45.34, senkouSpanB.getValue(16));
-        assertNumEquals(45.205, senkouSpanB.getValue(17));
-        assertNumEquals(44.89, senkouSpanB.getValue(18));
+        Num lowestInFive = numOf(44.96);
+        Num highestInFive = numOf(45.32);
 
-        assertNumEquals(data.getBar(chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(0));
-        assertNumEquals(data.getBar(1 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(1));
-        assertNumEquals(data.getBar(2 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(2));
-        assertNumEquals(data.getBar(3 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(3));
-        assertNumEquals(data.getBar(4 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(4));
-        assertNumEquals(data.getBar(5 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(5));
-        assertNumEquals(data.getBar(6 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(6));
-        assertNumEquals(data.getBar(7 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(7));
-        assertNumEquals(data.getBar(8 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(8));
-        assertNumEquals(data.getBar(9 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(9));
-        assertNumEquals(data.getBar(10 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(10));
-        assertNumEquals(data.getBar(11 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(11));
-        assertNumEquals(data.getBar(12 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(12));
-        assertNumEquals(data.getBar(13 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(13));
-        assertNumEquals(data.getBar(14 + chikouSpanTimeDelay).getClosePrice(), chikouSpan.getValue(14));
-        assertNumEquals(NaN.NaN, chikouSpan.getValue(15));
-        assertNumEquals(NaN.NaN, chikouSpan.getValue(16));
-        assertNumEquals(NaN.NaN, chikouSpan.getValue(17));
-        assertNumEquals(NaN.NaN, chikouSpan.getValue(18));
-        assertNumEquals(NaN.NaN, chikouSpan.getValue(19));
+        assertNumEquals(lowestInFive.plus(highestInFive).dividedBy(numOf(2)), senkouSpanB.getValue(4));
+        assertNumEquals((44.99+45.32)/2, senkouSpanB.getValue(5));
+        assertNumEquals((44.8+45.61)/2, senkouSpanB.getValue(13));
+        assertNumEquals((43.08+45.61)/2, senkouSpanB.getValue(16));
+        assertNumEquals((43.06+45.55)/2, senkouSpanB.getValue(17));
+        assertNumEquals((43.06+45.04)/2, senkouSpanB.getValue(18));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -102,10 +102,7 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
         assertNumEquals(44.05, kijunSen.getValue(18));
 
         for (int i = data.getBeginIndex(); i <= data.getEndIndex(); i++) {
-            assertNumEquals(
-                    tenkanSen.getValue(i)
-                            .plus(kijunSen.getValue(i))
-                            .dividedBy(numOf(2)),
+            assertNumEquals(tenkanSen.getValue(i).plus(kijunSen.getValue(i)).dividedBy(numOf(2)),
                     senkouSpanA.getValue(i));
         }
 
@@ -113,10 +110,10 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
         Num highestInFive = numOf(45.32);
 
         assertNumEquals(lowestInFive.plus(highestInFive).dividedBy(numOf(2)), senkouSpanB.getValue(4));
-        assertNumEquals((44.99+45.32)/2, senkouSpanB.getValue(5));
-        assertNumEquals((44.8+45.61)/2, senkouSpanB.getValue(13));
-        assertNumEquals((43.08+45.61)/2, senkouSpanB.getValue(16));
-        assertNumEquals((43.06+45.55)/2, senkouSpanB.getValue(17));
-        assertNumEquals((43.06+45.04)/2, senkouSpanB.getValue(18));
+        assertNumEquals((44.99 + 45.32) / 2, senkouSpanB.getValue(5));
+        assertNumEquals((44.8 + 45.61) / 2, senkouSpanB.getValue(13));
+        assertNumEquals((43.08 + 45.61) / 2, senkouSpanB.getValue(16));
+        assertNumEquals((43.06 + 45.55) / 2, senkouSpanB.getValue(17));
+        assertNumEquals((43.06 + 45.04) / 2, senkouSpanB.getValue(18));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -78,10 +78,10 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
     public void ichimoku() {
         IchimokuTenkanSenIndicator tenkanSen = new IchimokuTenkanSenIndicator(data, 3);
         IchimokuKijunSenIndicator kijunSen = new IchimokuKijunSenIndicator(data, 5);
-        IchimokuSenkouSpanAIndicator senkouSpanA = new IchimokuSenkouSpanAIndicator(data, tenkanSen, kijunSen, 5);
-        IchimokuSenkouSpanBIndicator senkouSpanB = new IchimokuSenkouSpanBIndicator(data, 9, 5);
+        IchimokuSenkouSpanAIndicator senkouSpanA = new IchimokuSenkouSpanAIndicator(tenkanSen, kijunSen);
+        IchimokuSenkouSpanBIndicator senkouSpanB = new IchimokuSenkouSpanBIndicator(data, 9);
         final int chikouSpanTimeDelay = 5;
-        IchimokuChikouSpanIndicator chikouSpan = new IchimokuChikouSpanIndicator(data, chikouSpanTimeDelay);
+        IchimokuChikouSpanIndicator chikouSpan = new IchimokuChikouSpanIndicator(data);
 
         assertNumEquals(45.155, tenkanSen.getValue(3));
         assertNumEquals(45.18, tenkanSen.getValue(4));

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/IchimokuCloudStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/IchimokuCloudStrategy.java
@@ -1,0 +1,171 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package ta4jexamples.strategies;
+
+import static org.ta4j.core.indicators.helpers.CombineIndicator.max;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BarSeriesManager;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Strategy;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
+import org.ta4j.core.indicators.UnstableIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.PreviousValueIndicator;
+import org.ta4j.core.indicators.ichimoku.IchimokuChikouSpanIndicator;
+import org.ta4j.core.indicators.ichimoku.IchimokuKijunSenIndicator;
+import org.ta4j.core.indicators.ichimoku.IchimokuSenkouSpanAIndicator;
+import org.ta4j.core.indicators.ichimoku.IchimokuSenkouSpanBIndicator;
+import org.ta4j.core.indicators.ichimoku.IchimokuTenkanSenIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.CrossedDownIndicatorRule;
+import org.ta4j.core.rules.CrossedUpIndicatorRule;
+import org.ta4j.core.rules.OverIndicatorRule;
+
+import ta4jexamples.loaders.CsvTradesLoader;
+
+public class IchimokuCloudStrategy {
+
+    private static Strategy buildStrategy(BarSeries series) {
+        int tenkanSenBarcount = 9;
+        int kijunSenBarCount = 26;
+        int senkunSpanBarCount = kijunSenBarCount * 2; // 52
+        int chikouSpanDelay = kijunSenBarCount; // 26
+
+        // create all the indicators
+        IchimokuIndicators ichimokuIndicators = new IchimokuIndicators(series, tenkanSenBarcount, kijunSenBarCount,
+                senkunSpanBarCount, chikouSpanDelay);
+
+        // create the entry rule (its just an easy example strategy. The internet is
+        // full of ideas how to use the ichimoku idnocators)
+        Rule longPositionEntryRule = createIchimokuLongEntryRule(series, chikouSpanDelay, ichimokuIndicators);
+
+        // create the exit rule (its just an easy example strategy. The internet is full
+        // of ideas how to use the ichimoku idnocators)
+        Rule longPositionExitRule = createIchimokuLongExitRule(ichimokuIndicators);
+
+        // create the example ichimoku strategy
+        return new BaseStrategy(longPositionEntryRule, longPositionExitRule);
+
+    }
+
+    private static Rule createIchimokuLongExitRule(IchimokuIndicators ichimokuIndicators) {
+        Rule conversionLineCrossesBackBaseline = new CrossedDownIndicatorRule(ichimokuIndicators.tenkanSenIndicator,
+                ichimokuIndicators.kijunSenIndicator);
+        return conversionLineCrossesBackBaseline; // This is a very basic example exit. Test your own exit criterias
+                                                  // here, dont forget stop loss if needed!
+    }
+
+    private static Rule createIchimokuLongEntryRule(BarSeries series, int chikouSpanDelay,
+            IchimokuIndicators ichimokuIndicators) {
+        // signal 1: cloud in future is green --> uptrend
+        OverIndicatorRule cloudGreenInFuture = new OverIndicatorRule(ichimokuIndicators.senkouSpanAFutureIndicator,
+                ichimokuIndicators.senkouSpanBFutureIndicator);
+
+        // signal 2: conversion line crosses the base line above the cloud
+        // --> bounce back to resistance of the cloud and breakout again up. Evertything
+        // in an uptrend as it was over the cloud --> Strong buy signal
+        Rule conversionLineCrossesBaseLine = new CrossedUpIndicatorRule(ichimokuIndicators.tenkanSenIndicator,
+                ichimokuIndicators.kijunSenIndicator);
+        Indicator<Num> cloudInPresentUpperLine = max(ichimokuIndicators.senkouSpanAPresentIndicator,
+                ichimokuIndicators.senkouSpanBPresentIndicator);
+        Rule conversionLineCrossIsOverCloud = new OverIndicatorRule(ichimokuIndicators.kijunSenIndicator,
+                cloudInPresentUpperLine).and(conversionLineCrossesBaseLine);
+
+        // signal 3: the lagging span is over the past price of the market. Sediment and
+        // also a sign for uptrent
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        Indicator<Num> delayedMarketPrice = new UnstableIndicator(
+                new PreviousValueIndicator(closePrice, chikouSpanDelay), chikouSpanDelay);
+        Rule laggingSpanAbovePastPrice = new OverIndicatorRule(ichimokuIndicators.chikouSpanIndicator,
+                delayedMarketPrice);
+
+        // signal 4: We are not down moving --> the current price must also be over the
+        // conversion line
+        Rule priceAboveTheCloud = new OverIndicatorRule(closePrice, cloudInPresentUpperLine);
+        Rule priceAboveConversionLine = new OverIndicatorRule(closePrice, ichimokuIndicators.tenkanSenIndicator);
+
+        // put everything together to a entry rule (Long position)
+        Rule entryRule = priceAboveTheCloud.and(cloudGreenInFuture)
+                .and(conversionLineCrossIsOverCloud)
+                .and(laggingSpanAbovePastPrice)
+                .and(priceAboveConversionLine);
+        return entryRule;
+    }
+
+    public static void main(String[] args) {
+
+        // Getting the bar series
+        BarSeries series = CsvTradesLoader.loadBitstampSeries();
+
+        // Building the trading strategy
+        Strategy strategy = buildStrategy(series);
+
+        // Running the strategy
+        BarSeriesManager seriesManager = new BarSeriesManager(series);
+        TradingRecord tradingRecord = seriesManager.run(strategy);
+        System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
+
+        // Analysis
+        System.out.println(
+                "Total return for the strategy: " + new GrossReturnCriterion().calculate(series, tradingRecord));
+    }
+
+    private static class IchimokuIndicators {
+        public final IchimokuKijunSenIndicator kijunSenIndicator;
+        public final IchimokuTenkanSenIndicator tenkanSenIndicator;
+        public final IchimokuChikouSpanIndicator chikouSpanIndicator;
+        public final IchimokuSenkouSpanAIndicator senkouSpanAFutureIndicator;
+        public final Indicator<Num> senkouSpanAPresentIndicator;
+        public final Indicator<Num> senkouSpanAPastIndicator;
+        public final IchimokuSenkouSpanBIndicator senkouSpanBFutureIndicator;
+        public final Indicator<Num> senkouSpanBPresentIndicator;
+        public final Indicator<Num> senkouSpanBPastIndicator;
+
+        public IchimokuIndicators(BarSeries series, int tenkanSenBarcount, int kijunSenBarCount, int senkunSpanBarCount,
+                int chikouSpanDelay) {
+            if (chikouSpanDelay != senkunSpanBarCount / 2) {
+                throw new IllegalArgumentException(
+                        "The senkunSpan delay should always be the double of the chikou span delay to allow correct calculations for the past");
+            }
+            tenkanSenIndicator = new IchimokuTenkanSenIndicator(series, tenkanSenBarcount);
+            kijunSenIndicator = new IchimokuKijunSenIndicator(series, kijunSenBarCount);
+            chikouSpanIndicator = new IchimokuChikouSpanIndicator(series);
+            senkouSpanAFutureIndicator = new IchimokuSenkouSpanAIndicator(tenkanSenIndicator, kijunSenIndicator);
+            senkouSpanBFutureIndicator = new IchimokuSenkouSpanBIndicator(series, senkunSpanBarCount);
+
+            senkouSpanAPresentIndicator = createDelayedIndicator(senkouSpanAFutureIndicator, senkunSpanBarCount / 2);
+            senkouSpanAPastIndicator = createDelayedIndicator(senkouSpanAFutureIndicator, senkunSpanBarCount);
+            senkouSpanBPresentIndicator = createDelayedIndicator(senkouSpanBFutureIndicator, senkunSpanBarCount / 2);
+            senkouSpanBPastIndicator = createDelayedIndicator(senkouSpanBFutureIndicator, senkunSpanBarCount);
+        }
+
+        private Indicator<Num> createDelayedIndicator(Indicator<Num> indicator, int delay) {
+            return new UnstableIndicator(new PreviousValueIndicator(indicator, delay), delay);
+        }
+    }
+}

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/IchimokuCloudStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/IchimokuCloudStrategyTest.java
@@ -1,0 +1,34 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package ta4jexamples.strategies;
+
+import org.junit.Test;
+
+public class IchimokuCloudStrategyTest {
+
+    @Test
+    public void test() {
+        IchimokuCloudStrategy.main(null);
+    }
+}


### PR DESCRIPTION
Fixes #705.

Changes proposed in this pull request:
- Cloud-Span indicators calculate their value according to the current index (only printing is in future)
- Lagging-Span is just a synonym for the current close price (only printing in graphs is in the past.)
- Added an example strategy which shows how to use those ichimoku indicators and how to get the current cloud, past cloud and how to use the lagging span correctly

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
