### PR TITLE
added javadoc for all rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`StandardErrorCriterion`**
 - :tada: **Enhancement** added **`VarianceCriterion`**
 - :tada: **Enhancement** added **`AverageCriterion`**
+- :tada: **Enhancement** added javadoc for all rules to make clear which rule makes use of a TradingRecord
 
 ## 0.14 (released April 25, 2021)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
@@ -44,6 +44,7 @@ public class BooleanIndicatorRule extends AbstractRule {
         this.indicator = indicator;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = indicator.getValue(index);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
@@ -54,6 +54,7 @@ public class BooleanRule extends AbstractRule {
         this.satisfied = satisfied;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         traceIsSatisfied(index, satisfied);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
@@ -51,6 +51,7 @@ public class ChainRule extends AbstractRule {
         rulesInChain.addAll(Arrays.asList(chainLinks));
     }
 
+    /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         int lastRuleWasSatisfiedAfterBars = 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
@@ -70,6 +70,7 @@ public class CrossedDownIndicatorRule extends AbstractRule {
         this.cross = new CrossIndicator(first, second);
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = cross.getValue(index);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
@@ -70,6 +70,7 @@ public class CrossedUpIndicatorRule extends AbstractRule {
         this.cross = new CrossIndicator(second, first);
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = cross.getValue(index);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -48,6 +48,7 @@ public class DayOfWeekRule extends AbstractRule {
         this.timeIndicator = timeIndicator;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         ZonedDateTime dateTime = this.timeIndicator.getValue(index);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
@@ -45,6 +45,7 @@ public class FixedRule extends AbstractRule {
         this.indexes = Arrays.copyOf(indexes, indexes.length);
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
@@ -79,6 +79,7 @@ public class InPipeRule extends AbstractRule {
         this.ref = ref;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = ref.getValue(index).isLessThanOrEqual(upper.getValue(index))

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
@@ -102,6 +102,7 @@ public class InSlopeRule extends AbstractRule {
         this.maxSlope = maxSlope;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         CombineIndicator diff = CombineIndicator.minus(ref, prev);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
@@ -76,6 +76,7 @@ public class IsEqualRule extends AbstractRule {
         this.second = second;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = first.getValue(index).isEqual(second.getValue(index));

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
@@ -66,6 +66,7 @@ public class IsFallingRule extends AbstractRule {
         this.minStrenght = minStrenght;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         if (minStrenght >= 1) {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
@@ -56,6 +56,7 @@ public class IsHighestRule extends AbstractRule {
         this.barCount = barCount;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         HighestValueIndicator highest = new HighestValueIndicator(ref, barCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
@@ -56,6 +56,7 @@ public class IsLowestRule extends AbstractRule {
         this.barCount = barCount;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         LowestValueIndicator lowest = new LowestValueIndicator(ref, barCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
@@ -66,6 +66,7 @@ public class IsRisingRule extends AbstractRule {
         this.minStrenght = minStrenght;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         if (minStrenght >= 1) {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
@@ -50,7 +50,7 @@ public class OpenedPositionMinimumBarCountRule extends AbstractRule {
      * {@link OpenedPositionMinimumBarCountRule#barCount}
      *
      * @param index         the bar index
-     * @param tradingRecord the potentially needed trading history
+     * @param tradingRecord the required trading history
      * @return true if opened trade reached minimum bar count specified in
      *         {@link OpenedPositionMinimumBarCountRule#barCount}, otherwise false
      */
@@ -64,6 +64,7 @@ public class OpenedPositionMinimumBarCountRule extends AbstractRule {
         return false;
     }
 
+    /** @return the {@link #barCount} */
     public int getBarCount() {
         return barCount;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
@@ -76,6 +76,7 @@ public class OverIndicatorRule extends AbstractRule {
         this.second = second;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = first.getValue(index).isGreaterThan(second.getValue(index));

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -72,6 +72,7 @@ public class StopGainRule extends AbstractRule {
         HUNDRED = closePrice.numOf(100);
     }
 
+    /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -95,15 +95,15 @@ public class StopGainRule extends AbstractRule {
         return satisfied;
     }
 
-    private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
-        return currentPrice.isLessThanOrEqual(threshold);
-    }
-
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
         Num lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
         Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
+    }
+
+    private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
+        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        return currentPrice.isLessThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -72,6 +72,7 @@ public class StopLossRule extends AbstractRule {
         this.HUNDRED = closePrice.numOf(100);
     }
 
+    /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -95,15 +95,15 @@ public class StopLossRule extends AbstractRule {
         return satisfied;
     }
 
-    private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
-        return currentPrice.isGreaterThanOrEqual(threshold);
-    }
-
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
         Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
         Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
+    }
+
+    private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
+        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        return currentPrice.isGreaterThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -46,6 +46,7 @@ public class TimeRangeRule extends AbstractRule {
         this.timeIndicator = beginTimeIndicator;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -76,6 +76,7 @@ public class TrailingStopLossRule extends AbstractRule {
         this(indicator, lossPercentage, Integer.MAX_VALUE);
     }
 
+    /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
@@ -76,6 +76,7 @@ public class UnderIndicatorRule extends AbstractRule {
         this.second = second;
     }
 
+    /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         final boolean satisfied = first.getValue(index).isLessThan(second.getValue(index));

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
@@ -57,6 +57,7 @@ public class WaitForRule extends AbstractRule {
         this.numberOfBars = numberOfBars;
     }
 
+    /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
         boolean satisfied = false;


### PR DESCRIPTION
Currently it's not clear which rule makes use of the `tradingRecord` and which not (without looking into the source).

Changes proposed in this pull request:
- added javadoc within all rules to make clear which rule uses the tradingRecord and which not

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
