### PR TITLE
DecimalNum: NaN-check for remainder()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 - **LosingPositionsRatioCriterion** correct betterThan
 - **VersusBuyAndHoldCriterionTest** NaN-Error.
-- :tada: **Fixed** **`ChaikinOscillatorIndicatorTest`**
+- **Fixed** **`ChaikinOscillatorIndicatorTest`**
+- **DecimalNum#remainder()** adds NaN-check 
 
 ### Changed
 - **KeltnerChannelMiddleIndicator** changed superclass to AbstractIndicator; add GetBarCount() and toString()

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -371,6 +371,9 @@ public final class DecimalNum implements Num {
      */
     @Override
     public Num remainder(Num divisor) {
+        if (divisor.isNaN()) {
+            return NaN;
+        }
         BigDecimal bigDecimal = ((DecimalNum) divisor).delegate;
         int precision = mathContext.getPrecision();
         BigDecimal result = delegate.remainder(bigDecimal, new MathContext(precision, RoundingMode.HALF_UP));


### PR DESCRIPTION
Adds NaN-check to remainder()


Fixes  https://github.com/ta4j/ta4j/issues/790

Changes proposed in this pull request:
- Adds NaN-check to remainder()

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
