### PR TITLE
Prevent superfluous `Object[]` allocation for varargs `log.trace` and `log.debug` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - :tada: **Enhancement** added **`VarianceCriterion`**
 - :tada: **Enhancement** added **`AverageCriterion`**
 - :tada: **Enhancement** added javadoc for all rules to make clear which rule makes use of a TradingRecord
+- **Enhancement** prevent Object[] allocation for varargs log.trace and log.debug calls by wrapping them in `if` blocks
 
 ## 0.14 (released April 25, 2021)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
@@ -160,8 +160,10 @@ public class BarSeriesManager {
         int runBeginIndex = Math.max(startIndex, barSeries.getBeginIndex());
         int runEndIndex = Math.min(finishIndex, barSeries.getEndIndex());
 
-        log.trace("Running strategy (indexes: {} -> {}): {} (starting with {})", runBeginIndex, runEndIndex, strategy,
-                tradeType);
+        if (log.isTraceEnabled()) {
+            log.trace("Running strategy (indexes: {} -> {}): {} (starting with {})", runBeginIndex, runEndIndex,
+                    strategy, tradeType);
+        }
         TradingRecord tradingRecord = new BaseTradingRecord(tradeType, transactionCostModel, holdingCostModel);
         for (int i = runBeginIndex; i <= runEndIndex; i++) {
             // For each bar between both indexes...

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -322,8 +322,10 @@ public class BaseBarSeries implements BarSeries {
                 // Cannot return the i-th bar if i < 0
                 throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, i));
             }
-            log.trace("Bar series `{}` ({} bars): bar {} already removed, use {}-th instead", name, bars.size(), i,
-                    removedBarsCount);
+            if (log.isTraceEnabled()) {
+                log.trace("Bar series `{}` ({} bars): bar {} already removed, use {}-th instead", name, bars.size(), i,
+                        removedBarsCount);
+            }
             if (bars.isEmpty()) {
                 throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, removedBarsCount));
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -191,7 +191,9 @@ public class BaseStrategy implements Strategy {
      * @param enter true if the strategy should enter, false otherwise
      */
     protected void traceShouldEnter(int index, boolean enter) {
-        log.trace(">>> {}#shouldEnter({}): {}", className, index, enter);
+        if (log.isTraceEnabled()) {
+            log.trace(">>> {}#shouldEnter({}): {}", className, index, enter);
+        }
     }
 
     /**
@@ -201,6 +203,8 @@ public class BaseStrategy implements Strategy {
      * @param exit  true if the strategy should exit, false otherwise
      */
     protected void traceShouldExit(int index, boolean exit) {
-        log.trace(">>> {}#shouldExit({}): {}", className, index, exit);
+        if (log.isTraceEnabled()) {
+            log.trace(">>> {}#shouldExit({}): {}", className, index, exit);
+        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -83,7 +83,9 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
             // (e.g. simple computation of the value)
             // --> Calculating the value
             T result = calculate(index);
-            log.trace("{}({}): {}", this, index, result);
+            if (log.isTraceEnabled()) {
+                log.trace("{}({}): {}", this, index, result);
+            }
             return result;
         }
 
@@ -95,8 +97,10 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
         T result;
         if (index < removedBarsCount) {
             // Result already removed from cache
-            log.trace("{}: result from bar {} already removed from cache, use {}-th instead",
-                    getClass().getSimpleName(), index, removedBarsCount);
+            if (log.isTraceEnabled()) {
+                log.trace("{}: result from bar {} already removed from cache, use {}-th instead",
+                        getClass().getSimpleName(), index, removedBarsCount);
+            }
             increaseLengthTo(removedBarsCount, maximumResultCount);
             highestResultIndex = removedBarsCount;
             result = results.get(0);
@@ -130,7 +134,9 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
             }
 
         }
-        log.trace("{}({}): {}", this, index, result);
+        if (log.isTraceEnabled()) {
+            log.trace("{}({}): {}", this, index, result);
+        }
         return result;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -465,7 +465,9 @@ public final class DecimalNum implements Num {
                     : new BigDecimal(6);
             BigDecimal estimatedExponent = exponent.divide(new BigDecimal(2));
             String estimateString = String.format("%sE%s", estimatedMantissa, estimatedExponent);
-            log.trace("x[0] =~ sqrt({}...*10^{}) =~ {}", mantissa, exponent, estimateString);
+            if (log.isTraceEnabled()) {
+                log.trace("x[0] =~ sqrt({}...*10^{}) =~ {}", mantissa, exponent, estimateString);
+            }
             DecimalFormat format = new DecimalFormat();
             format.setParseBigDecimal(true);
             try {
@@ -635,8 +637,10 @@ public final class DecimalNum implements Num {
         if (thisNum.toString().equals(otherNum.toString())) {
             return true;
         }
-        log.debug("{} from {} does not match", thisNum, this);
-        log.debug("{} from {} to precision {}", otherNum, other, precision);
+        if (log.isDebugEnabled()) {
+            log.debug("{} from {} does not match", thisNum, this);
+            log.debug("{} from {} to precision {}", otherNum, other, precision);
+        }
         return false;
     }
 
@@ -653,8 +657,10 @@ public final class DecimalNum implements Num {
         if (!result.isGreaterThan(delta)) {
             return true;
         }
-        log.debug("{} does not match", this);
-        log.debug("{} within offset {}", other, delta);
+        if (log.isDebugEnabled()) {
+            log.debug("{} does not match", this);
+            log.debug("{} within offset {}", other, delta);
+        }
         return false;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
@@ -45,6 +45,8 @@ public abstract class AbstractRule implements Rule {
      * @param isSatisfied true if the rule is satisfied, false otherwise
      */
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
-        log.trace("{}#isSatisfied({}): {}", className, index, isSatisfied);
+        if (log.isTraceEnabled()) {
+            log.trace("{}#isSatisfied({}): {}", className, index, isSatisfied);
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Wraps all vararg (infinite argument) `log.trace` and `log.debug` SLF4j Logger calls in `if`-statement to prevent superfluous `Object[]` creation which decreases CPU performance and increases memory usage. 

The biggest performance hit in my case comes from the `CachedIndicator.getValue()` call which is called thousands of times per second when running my trading algo backtest. I used the Java VisualVM profiler to profile memory when running my backtests and it revealed the varargs `log.trace()` call is hurting memory/CPU performance quite a bit.
This first screenshot shows a memory profile of the top allocators of `java.lang.Object[]`. When the vararg call of any Logger method is used, a `java.lang.Object[]` is created before invoking the log method, as the SLF4j documentation states [here](http://www.slf4j.org/apidocs/org/slf4j/Logger.html#trace(java.lang.String,java.lang.Object...)):
> However, this variant incurs the hidden (and relatively small) cost of creating an Object[] before invoking the method, even if this logger is disabled for TRACE. The variants taking one and two arguments exist solely in order to avoid this hidden cost.

![old_profiler](https://user-images.githubusercontent.com/14127217/128586071-0479896a-3aaa-46be-891c-8a776a23e5e3.png)

As you can see, 94.8% of `Object[]` live bytes are allocated by `CachedIndicator.getValue()`.
Here is the profiler screenshot with my changes in this PR:

![new_profiler](https://user-images.githubusercontent.com/14127217/128586092-0ac965bf-5ca1-4942-ac08-cde19f9c4d5f.png)

`CachedIndicator.getValue()` doesn't even show up and the number of `Object[]` live bytes is cut by around 60%. I should note that these memory profiling reports were done under the exact same server environments both times. 
Additionally, I took a holistic memory sample during my backtests using the VisualVM profiler. The number of `Object[]` live objects was cut by around 95%. Note that these memory samples were taken a few moments after a garbage collection was invoked. 

`0.15-SNAPSHOT` develop branch:
![old_sampler](https://user-images.githubusercontent.com/14127217/128586224-aa2d5bea-367c-492d-9d02-86acbd7b4cb4.png)

With my changes in this PR:
![new_sampler](https://user-images.githubusercontent.com/14127217/128586225-8e6c5ace-a3d7-4871-9142-44bbdf539ddc.png)

🙂

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
