### PR TITLE
SMAIndicator use the previously cached sma value to calculate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BarSeriesManager** removed empty args constructor
 - **Open|High|Low|Close** do not cache price values anymore
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)
+- **SMAIndicator** use the previously cached sma value to calculate
 
 ### Removed/Deprecated
 - **Num** removed Serializable

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -46,13 +46,18 @@ public class SMAIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        Num sum = numOf(0);
-        for (int i = Math.max(0, index - barCount + 1); i <= index; i++) {
-            sum = sum.plus(indicator.getValue(i));
+        if (index < barCount) {
+            Num sum = numOf(0);
+            for (int i = 0; i <= index; i++) {
+                sum = sum.plus(indicator.getValue(i));
+            }
+            return sum.dividedBy(numOf(index + 1));
         }
-
-        final int realBarCount = Math.min(barCount, index + 1);
-        return sum.dividedBy(numOf(realBarCount));
+        Num count = numOf(barCount);
+        Num currentValue = indicator.getValue(index).dividedBy(count);
+        Num nPeriodsAgoValue = indicator.getValue(index - barCount).dividedBy(count);
+        Num prevValue = getValue(index - 1);
+        return prevValue.minus(nPeriodsAgoValue).plus(currentValue);
     }
 
     @Override


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- The existing SMAIndicator is calculated by traversing the data. In fact, we can use the previous cached sma value to calculate and improve performance.

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
