### PR TITLE
Replace redundant `toString()` call in `DoubleNum.valueOf(Number i)` with `i.doubleValue()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BarSeriesManager** removed empty args constructor
 - **Open|High|Low|Close** do not cache price values anymore
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)
+- **DoubleNum** replace redundant `toString()` call in `DoubleNum.valueOf(Number i)` with `i.doubleValue()`
 
 ### Removed/Deprecated
 - **Num** removed Serializable

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -67,7 +67,7 @@ public class DoubleNum implements Num {
     }
 
     public static DoubleNum valueOf(Number i) {
-        return new DoubleNum(Double.parseDouble(i.toString()));
+        return new DoubleNum(i.doubleValue());
     }
 
     @Override


### PR DESCRIPTION
Changes proposed in this pull request:
- Replaces redundant `i.toString()` call in `DoubleNum.valueOf(Number i)` with `i.doubleValue()`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
