### PR TITLE
Additional context object to org.ta4j.core.Position

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/CustomPositionData.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/CustomPositionData.java
@@ -1,0 +1,69 @@
+package org.ta4j.core;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * Extension point that enable a {@link Position} to carry additional context data.
+ *
+ * This class be used as is or extended by developers and enables the development of dynamic
+ * rules.
+ *
+ * See usage example of this class in {@link org.ta4j.core.rules.FixedPriceStopLossRule}
+ * or {@link org.ta4j.core.rules.FixedPriceStopGainRule}.
+ */
+public class CustomPositionData {
+
+    /** position's current stop loss price. */
+    private Num stopLossPrice;
+
+    /** position's take profit price. */
+    private Num takeProfitPrice;
+
+    /**
+     * Default constructor.
+     */
+    public CustomPositionData() {
+    }
+
+    /**
+     * Constructor accpeting the initial stop loss and take profit prices.
+     * @param stopLossPrice position's current stop loss price.
+     * @param takeProfitPrice position's take profit price.
+     */
+    public CustomPositionData(Num stopLossPrice, Num takeProfitPrice) {
+        this.stopLossPrice = stopLossPrice;
+        this.takeProfitPrice = takeProfitPrice;
+    }
+
+    /**
+     * Returns position's  current stop loss price.
+     * @return current stop loss price if present, null otherwise.
+     */
+    public Num getStopLossPrice() {
+        return stopLossPrice;
+    }
+
+    /**
+     * Updates position's current stop loss price.
+     * @param stopLossPrice the new stop loss price.
+     */
+    public void setStopLossPrice(Num stopLossPrice) {
+        this.stopLossPrice = stopLossPrice;
+    }
+
+    /**
+     * Returns position's initial take profit price.
+     * @return the initial take prifit price if present, null otherwise.
+     */
+    public Num getTakeProfitPrice() {
+        return takeProfitPrice;
+    }
+
+    /**
+     * Updates position's current take profit price.
+     * @param takeProfitPrice the new take profit price.
+     */
+    public void setTakeProfitPrice(Num takeProfitPrice) {
+        this.takeProfitPrice = takeProfitPrice;
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -58,6 +58,9 @@ public class Position implements Serializable {
     /** The cost model for holding the asset */
     private final CostModel holdingCostModel;
 
+    /** Additional position data */
+    private CustomPositionData customPositionData;
+
     /**
      * Constructor.
      */
@@ -403,6 +406,24 @@ public class Position implements Serializable {
      */
     public TradeType getStartingType() {
         return startingType;
+    }
+
+    /**
+     * Returns the custom position data object.
+     *
+     * @return the custom position data object.
+     */
+    public CustomPositionData getCustomPositionData() {
+        return customPositionData;
+    }
+
+    /**
+     * Sets the custom position data object.
+     *
+     * @param customPositionData the custom position data object to set.
+     */
+    public void setCustomPositionData(CustomPositionData customPositionData) {
+        this.customPositionData = customPositionData;
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/FixedPriceStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/FixedPriceStopGainRule.java
@@ -1,0 +1,65 @@
+package org.ta4j.core.rules;
+
+import org.ta4j.core.CustomPositionData;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.indicators.AbstractIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Stop gain rule.
+ *
+ * Satisfied when the underlying indicator price reaches the take profit price carried by
+ * position's custom data object.
+ *
+ * See {@link CustomPositionData}.
+ */
+public class FixedPriceStopGainRule extends AbstractRule {
+
+    /** the indicator whose value will be compared position's take profit price. */
+    private final AbstractIndicator<Num> indicator;
+
+    /**
+     * Constructor.
+     *
+     * @param indicator the price indicator whose value will be used to be compared with position's take profit price.
+     */
+    public FixedPriceStopGainRule(AbstractIndicator<Num> indicator) {
+        this.indicator = indicator;
+    }
+
+    /** This rule uses the {@code tradingRecord}. */
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        boolean satisfied = false;
+        // No trading history or no position opened, no loss
+        if (tradingRecord != null) {
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            CustomPositionData customPositionData = currentPosition.getCustomPositionData();
+
+            if (currentPosition.isOpened()
+                    && customPositionData != null
+                    && customPositionData.getTakeProfitPrice() != null) {
+
+                Num takeProfitPrice = customPositionData.getTakeProfitPrice();
+                Num currentPrice = indicator.getValue(index);
+
+                if (currentPosition.getEntry().isBuy()) {
+                    satisfied = isBuyGainSatisfied(takeProfitPrice, currentPrice);
+                } else {
+                    satisfied = isSellGainSatisfied(takeProfitPrice, currentPrice);
+                }
+            }
+        }
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+    }
+
+    private boolean isSellGainSatisfied(Num takeProfitPrice, Num currentPrice) {
+        return currentPrice.isLessThanOrEqual(takeProfitPrice);
+    }
+
+    private boolean isBuyGainSatisfied(Num takeProfitPrice,  Num currentPrice) {
+        return currentPrice.isGreaterThanOrEqual(takeProfitPrice);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/FixedPriceStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/FixedPriceStopLossRule.java
@@ -1,0 +1,68 @@
+package org.ta4j.core.rules;
+
+import org.ta4j.core.CustomPositionData;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.indicators.AbstractIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Stop loss rule.
+ *
+ * Satisfied when the underlying indicator price reaches the stop loss price carried by
+ * position's custom data object.
+ *
+ * See {@link CustomPositionData}.
+ */
+public class FixedPriceStopLossRule extends AbstractRule {
+
+    /** the indicator whose value will be compared position's stop loss price. */
+    private final AbstractIndicator<Num> indicator;
+
+    /**
+     * Constructor.
+     *
+     * @param indicator the price indicator whose value will be used to be compared with position's stop loss price.
+     */
+    public FixedPriceStopLossRule(AbstractIndicator<Num> indicator) {
+        this.indicator = indicator;
+    }
+
+    /** This rule uses the {@code tradingRecord}. */
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        boolean satisfied = false;
+        // No trading history or no position opened, no loss
+        if (tradingRecord != null) {
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            CustomPositionData customPositionData = currentPosition.getCustomPositionData();
+
+            if (currentPosition.isOpened()
+                    && customPositionData != null
+                    && customPositionData.getStopLossPrice() != null) {
+
+                Num stopLossValue =
+                        currentPosition.getCustomPositionData().getStopLossPrice();
+
+                Num currentPrice = indicator.getValue(index);
+
+                if (currentPosition.getEntry().isBuy()) {
+                    satisfied = isBuyStopSatisfied(stopLossValue, currentPrice);
+                } else {
+                    satisfied = isSellStopSatisfied(stopLossValue, currentPrice);
+                }
+            }
+        }
+
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+    }
+
+    private boolean isSellStopSatisfied(Num stopLossValue, Num currentPrice) {
+        return currentPrice.isGreaterThanOrEqual(stopLossValue);
+    }
+
+    private boolean isBuyStopSatisfied(Num stopLossValue, Num currentPrice) {
+        return currentPrice.isLessThanOrEqual(stopLossValue);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
@@ -23,15 +23,13 @@
  */
 package org.ta4j.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 import static org.ta4j.core.num.NaN.NaN;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.theories.DataPoint;
 import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.analysis.cost.CostModel;
 import org.ta4j.core.analysis.cost.LinearBorrowingCostModel;
@@ -268,6 +266,43 @@ public class PositionTest {
     @Test(expected = IllegalArgumentException.class)
     public void testCostModelExitInconsistent() {
         new Position(enter, exitDifferentType, transactionModel, holdingModel);
+    }
+
+    @Test
+    public void testNullCustomPositionDataOnInitialization(){
+        Position p = new Position(enter, exitSameType);
+        assertNull(p.getCustomPositionData());
+
+        p = new Position();
+        assertNull(p.getCustomPositionData());
+    }
+
+    @Test
+    public void testUpdateCustomPositionData(){
+        Position p = new Position();
+        assertNull(p.getCustomPositionData());
+
+        p.setCustomPositionData(new CustomPositionData());
+        assertNotNull(p.getCustomPositionData());
+    }
+
+    @Test
+    public void testInitCustomPositionData(){
+        CustomPositionData customPositionData = new CustomPositionData();
+        assertNull(customPositionData.getStopLossPrice());
+        assertNull(customPositionData.getTakeProfitPrice());
+
+        customPositionData = new CustomPositionData(DoubleNum.valueOf("102.34"), DoubleNum.valueOf("110.75"));
+        assertNumEquals(102.34, customPositionData.getStopLossPrice());
+        assertNumEquals(110.75, customPositionData.getTakeProfitPrice());
+
+        customPositionData.setStopLossPrice(DoubleNum.valueOf("103.15"));
+        assertNumEquals(103.15, customPositionData.getStopLossPrice());
+        assertNumEquals(110.75, customPositionData.getTakeProfitPrice());
+
+        customPositionData.setTakeProfitPrice(DoubleNum.valueOf("117.99"));
+        assertNumEquals(103.15, customPositionData.getStopLossPrice());
+        assertNumEquals(117.99, customPositionData.getTakeProfitPrice());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/FixedPriceStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/FixedPriceStopGainRuleTest.java
@@ -1,0 +1,89 @@
+package org.ta4j.core.rules;
+
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FixedPriceStopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
+
+    public FixedPriceStopGainRuleTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Test
+    public void testWithNullTradingRecord(){
+        ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(null);
+
+        FixedPriceStopGainRule rule = new FixedPriceStopGainRule(closePriceIndicator);
+
+        assertFalse(rule.isSatisfied(1));
+        assertFalse(rule.isSatisfied(1, null));
+    }
+
+    @Test
+    public void testIsSatisfiedNoPositionOpened(){
+        ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(null);
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        FixedPriceStopGainRule rule = new FixedPriceStopGainRule(closePriceIndicator);
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+    }
+
+
+    @Test
+    public void isSatisfiedWorksForBuy() {
+        ClosePriceIndicator closePriceIndicator =
+                new ClosePriceIndicator(
+                        new MockBarSeries(numFunction,
+                                48873.0, 48872.5, 48799.0, 48765.5, 48709.5, 49006.0, 49587.5, 48674.5, 48782.0, 48750.0));
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        FixedPriceStopGainRule rule = new FixedPriceStopGainRule(closePriceIndicator);
+        final Num tradedAmount = numOf(0.01);
+
+        assertFalse(rule.isSatisfied(0, null));
+
+        tradingRecord.enter(1, numOf(48872.0), tradedAmount);
+        tradingRecord.getCurrentPosition().setCustomPositionData(new CustomPositionData(null, numOf(49550.0)));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(4, tradingRecord));
+        assertFalse(rule.isSatisfied(5, tradingRecord));
+        assertTrue(rule.isSatisfied(6, tradingRecord));
+    }
+
+    @Test
+    public void isSatisfiedWorksForSell() {
+        ClosePriceIndicator closePriceIndicator =
+                new ClosePriceIndicator(
+                        new MockBarSeries(numFunction,
+                                48873.0, 48872.5, 48799.0, 48765.5, 48709.5, 49006.0, 49587.5, 48674.5, 48782.0, 48750.0));
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        FixedPriceStopGainRule rule = new FixedPriceStopGainRule(closePriceIndicator);
+        final Num tradedAmount = numOf(0.01);
+
+        assertFalse(rule.isSatisfied(0, null));
+
+        tradingRecord.enter(1, numOf(48872.0), tradedAmount);
+        tradingRecord.getCurrentPosition().setCustomPositionData(new CustomPositionData(null, numOf(48705.0)));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(4, tradingRecord));
+        assertFalse(rule.isSatisfied(5, tradingRecord));
+        assertFalse(rule.isSatisfied(6, tradingRecord));
+        assertTrue(rule.isSatisfied(7, tradingRecord));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/FixedPriceStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/FixedPriceStopLossRuleTest.java
@@ -1,0 +1,87 @@
+package org.ta4j.core.rules;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FixedPriceStopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
+
+    public FixedPriceStopLossRuleTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Test
+    public void testWithNullTradingRecord(){
+        ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(null);
+
+        FixedPriceStopLossRule rule = new FixedPriceStopLossRule(closePriceIndicator);
+
+        assertFalse(rule.isSatisfied(1));
+        assertFalse(rule.isSatisfied(1, null));
+    }
+
+    @Test
+    public void testIsSatisfiedNoPositionOpened(){
+        ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(null);
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        FixedPriceStopLossRule rule = new FixedPriceStopLossRule(closePriceIndicator);
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+    }
+
+
+    @Test
+    public void isSatisfiedWorksForBuy() {
+        ClosePriceIndicator closePriceIndicator =
+                new ClosePriceIndicator(
+                        new MockBarSeries(numFunction,
+                                48873.0, 48872.5, 48799.0, 48765.5, 48709.5, 49006.0, 49587.5, 48674.5, 48782.0, 48750.0));
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        FixedPriceStopLossRule rule = new FixedPriceStopLossRule(closePriceIndicator);
+        final Num tradedAmount = numOf(0.01);
+
+        assertFalse(rule.isSatisfied(0, null));
+
+        tradingRecord.enter(1, numOf(48872.0), tradedAmount);
+        tradingRecord.getCurrentPosition().setCustomPositionData(new CustomPositionData(numOf(48750.0), null));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertTrue(rule.isSatisfied(4, tradingRecord));
+        assertFalse(rule.isSatisfied(5, tradingRecord));
+    }
+
+    @Test
+    public void isSatisfiedWorksForSell() {
+        ClosePriceIndicator closePriceIndicator =
+                new ClosePriceIndicator(
+                        new MockBarSeries(numFunction,
+                                48873.0, 48872.5, 48799.0, 48765.5, 48709.5, 49006.0, 49587.5, 48674.5, 48782.0, 48750.0));
+
+        final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        FixedPriceStopLossRule rule = new FixedPriceStopLossRule(closePriceIndicator);
+        final Num tradedAmount = numOf(0.01);
+
+        assertFalse(rule.isSatisfied(0, null));
+
+        tradingRecord.enter(1, numOf(48872.0), tradedAmount);
+        tradingRecord.getCurrentPosition().setCustomPositionData(new CustomPositionData(numOf(48905.2), null));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(4, tradingRecord));
+        assertTrue(rule.isSatisfied(5, tradingRecord));
+    }
+}


### PR DESCRIPTION
Added an additional context object to `org.ta4j.core.Position` that can be used or extended by developers to create dynamic rules.

Two additional rules that make use of the new `Position`´s object have been added:
- `org.ta4j.core.rules.FixedPriceStopLossRule`
- `org.ta4j.core.rules.FixedPriceStopGainRule`

Additional test classes for the two new rules have been added as well as new tests in `org.ta4j.core.PositionTest`.
