### PR TITLE
Implemented isNaN in DoubleNum and DecimalNum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Fixed** **`ChaikinOscillatorIndicatorTest`**
 - **DecimalNum#remainder()** adds NaN-check 
 - **Fixed** **ParabolicSarIndicatorTest** fixed openPrice always 0 and highPrice lower than lowPrice
+- **Fixed** **DecimalNum** added proper isNaN implementation
+- **Fixed** **DoubleNum** added proper isNaN implementation
 
 ### Changed
 - **KeltnerChannelMiddleIndicator** changed superclass to AbstractIndicator; add GetBarCount() and toString()

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -613,6 +613,19 @@ public final class DecimalNum implements Num {
     }
 
     /**
+     * Checks if this number is a NaN.
+     * 
+     * @return true if the value is a NaN, false otherwise.
+     */
+    @Override
+    public boolean isNaN() {
+        if (delegate != null) {
+            return Double.isNaN(delegate.doubleValue());
+        }
+        return false;
+    }
+
+    /**
      * Checks if this value is equal to another.
      *
      * @param other the other value, not null

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -172,6 +172,16 @@ public class DoubleNum implements Num {
         return new DoubleNum(-delegate);
     }
 
+    /**
+     * Checks if this number is a NaN. Uses Double.isNaN()
+     * 
+     * @return true if this number is a NaN, false otherwise.
+     */
+    @Override
+    public boolean isNaN() {
+        return Double.isNaN(delegate);
+    }
+
     @Override
     public boolean isZero() {
         return delegate == 0;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Implement isNaN() on DecimalNum by checking if the delegate is a NaN using Double.NaN().
- Implement isNaN() on DoubleNum by checking if the delegate is NaN using Double.NaN().


- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
