### PR TITLE
Update WalkForward: javadoc

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -193,5 +193,4 @@ public class WalkForward {
             System.out.println("\t\t--> Best strategy: " + strategies.get(bestStrategy) + "\n");
         }
     }
-
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -96,7 +96,7 @@ public class WalkForward {
     }
 
     /**
-     * Returns a new bar series which is a view of a subset of the current series.
+     * Returns a new bar series which is a copy from a subset of the current series.
      *
      * The new series has begin and end indexes which correspond to the bounds of
      * the sub-set into the full series.<br>

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -50,9 +50,6 @@ import ta4jexamples.strategies.RSI2Strategy;
  *
  * @see <a href="http://en.wikipedia.org/wiki/Walk_forward_optimization">
  *      http://en.wikipedia.org/wiki/Walk_forward_optimization</a>
- * @see <a href=
- *      "http://www.futuresmag.com/2010/04/01/can-your-system-do-the-walk">
- *      http://www.futuresmag.com/2010/04/01/can-your-system-do-the-walk</a>
  */
 public class WalkForward {
 

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -97,7 +97,7 @@ public class WalkForward {
      *
      * The new series has begin and end indexes which correspond to the bounds of
      * the sub-set into the full series.<br>
-     * The bar of the series are shared between the original bar series and the
+     * The bars of the series are shared between the original bar series and the
      * returned one (i.e. no copy).
      *
      * @param series     the bar series to get a sub-series of


### PR DESCRIPTION
- Correct javadoc of `Walkforward#subseries`: `series.getSubSeries` does not return a "view" but a "copy". 
- remove broken url link from the header

