### PR TITLE
Update BarSeriesManager.java: consider finishIndex

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
@@ -172,10 +172,9 @@ public class BarSeriesManager {
             }
         }
 
-        if (!tradingRecord.isClosed()) {
+        if (!tradingRecord.isClosed() && finishIndex == barSeries.getEndIndex()) {
             // If the last position is still opened, we search out of the run end index.
-            // May works if the end index for this run was inferior to the actual number of
-            // bars
+            // It may work if the end index for this run was inferior to the actual number of bars.
             int seriesMaxSize = Math.max(barSeries.getEndIndex() + 1, barSeries.getBarData().size());
             for (int i = runEndIndex + 1; i < seriesMaxSize; i++) {
                 // For each bar after the end index of this run...


### PR DESCRIPTION
Changes proposed in this pull request:
- If `finishIndex` is set, then closing the last position should **NOT** be possible, if it happens after finishIndex.

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
