### PR TITLE
Fix UlcerIndexIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Fixed** **`ChaikinOscillatorIndicatorTest`**
 - **DecimalNum#remainder()** adds NaN-check 
 - **Fixed** **ParabolicSarIndicatorTest** fixed openPrice always 0 and highPrice lower than lowPrice
+- **UlcerIndexIndicator** using the max price of current period instead of the highest value of last n bars
 
 ### Changed
 - **KeltnerChannelMiddleIndicator** changed superclass to AbstractIndicator; add GetBarCount() and toString()

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * Copyright (c) 2017-2022 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -38,10 +38,10 @@ import org.ta4j.core.num.Num;
  */
 public class UlcerIndexIndicator extends CachedIndicator<Num> {
 
+    private final Num hundred;
+    private final Num zero;
+
     private Indicator<Num> indicator;
-
-    private HighestValueIndicator highestValueInd;
-
     private int barCount;
 
     /**
@@ -54,18 +54,22 @@ public class UlcerIndexIndicator extends CachedIndicator<Num> {
         super(indicator);
         this.indicator = indicator;
         this.barCount = barCount;
-        highestValueInd = new HighestValueIndicator(indicator, barCount);
+        this.zero = numOf(0);
+        this.hundred = numOf(100);
     }
 
     @Override
     protected Num calculate(int index) {
         final int startIndex = Math.max(0, index - barCount + 1);
         final int numberOfObservations = index - startIndex + 1;
-        Num squaredAverage = numOf(0);
+        Num squaredAverage = zero;
+        Num highestValue = indicator.getValue(startIndex);
         for (int i = startIndex; i <= index; i++) {
             Num currentValue = indicator.getValue(i);
-            Num highestValue = highestValueInd.getValue(i);
-            Num percentageDrawdown = currentValue.minus(highestValue).dividedBy(highestValue).multipliedBy(numOf(100));
+            if (currentValue.isGreaterThan(highestValue)) {
+                highestValue = currentValue;
+            }
+            Num percentageDrawdown = currentValue.minus(highestValue).dividedBy(highestValue).multipliedBy(hundred);
             squaredAverage = squaredAverage.plus(percentageDrawdown.pow(2));
         }
         squaredAverage = squaredAverage.dividedBy(numOf(numberOfObservations));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
+ * Copyright (c) 2017-2022 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
@@ -57,24 +57,22 @@ public class UlcerIndexIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
         assertNumEquals(0, ulcer.getValue(0));
 
-        // From:
-        // http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:ulcer_index
-        assertNumEquals(1.3047, ulcer.getValue(26));
-        assertNumEquals(1.3022, ulcer.getValue(27));
-        assertNumEquals(1.2156, ulcer.getValue(28));
-        assertNumEquals(0.9967, ulcer.getValue(29));
-        assertNumEquals(0.7257, ulcer.getValue(30));
-        assertNumEquals(0.453, ulcer.getValue(31));
-        assertNumEquals(0.4284, ulcer.getValue(32));
-        assertNumEquals(0.4284, ulcer.getValue(33));
-        assertNumEquals(0.4284, ulcer.getValue(34));
-        assertNumEquals(0.4287, ulcer.getValue(35));
-        assertNumEquals(0.5089, ulcer.getValue(36));
-        assertNumEquals(0.6673, ulcer.getValue(37));
-        assertNumEquals(0.9914, ulcer.getValue(38));
-        assertNumEquals(1.0921, ulcer.getValue(39));
-        assertNumEquals(1.3161, ulcer.getValue(40));
-        assertNumEquals(1.5632, ulcer.getValue(41));
-        assertNumEquals(1.7609, ulcer.getValue(42));
+        assertNumEquals(0, ulcer.getValue(0));
+        assertNumEquals(1.2340096463740846, ulcer.getValue(26));
+        assertNumEquals(0.560553282860879, ulcer.getValue(27));
+        assertNumEquals(0.39324888828140886, ulcer.getValue(28));
+        assertNumEquals(0.38716275079310825, ulcer.getValue(29));
+        assertNumEquals(0.3889794194862251, ulcer.getValue(30));
+        assertNumEquals(0.4114481689096125, ulcer.getValue(31));
+        assertNumEquals(0.42841008722557894, ulcer.getValue(32));
+        assertNumEquals(0.42841008722557894, ulcer.getValue(33));
+        assertNumEquals(0.3121617589229034, ulcer.getValue(34));
+        assertNumEquals(0.2464924497436544, ulcer.getValue(35));
+        assertNumEquals(0.4089008481549337, ulcer.getValue(36));
+        assertNumEquals(0.667264629592715, ulcer.getValue(37));
+        assertNumEquals(0.9913518177402276, ulcer.getValue(38));
+        assertNumEquals(1.0921325741850083, ulcer.getValue(39));
+        assertNumEquals(1.3156949266800984, ulcer.getValue(40));
+        assertNumEquals(1.5606676136361992, ulcer.getValue(41));
     }
 }


### PR DESCRIPTION
Fixes #622.

Changes proposed in this pull request:
- Fixed UlcerIndexIndicator by using the max value of `[startIndex, i]` in calculation instead of HighestValueIndicator

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
