### PR TITLE
add indices to TradingRecord to track start and end recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
 - **BuyAndHoldCriterion** renamed to **`EnterAndHoldCriterion`**
+- **VersusBuyAndHoldCriterion** renamed to **`VersusEnterAndHoldCriterion`**
 - **DXIndicator** moved to adx-package
 - **PlusDMIndicator** moved to adx-package
 - **MinusDMIndicator** moved to adx-package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **DifferenceIndicator(i1,i2)** replaced by the more flexible CombineIndicator.minus(i1,i2)
 - **DoubleNum** replace redundant `toString()` call in `DoubleNum.valueOf(Number i)` with `i.doubleValue()`
 - **ZeroCostModel** now extends from `FixedTransactionCostModel`
+- added `TradingRecord.getStartIndex()` and `TradingRecord.getEndIndex()` to track start and end of the recording
 
 ### Removed/Deprecated
 - **Num** removed Serializable

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
@@ -164,7 +164,8 @@ public class BarSeriesManager {
             log.trace("Running strategy (indexes: {} -> {}): {} (starting with {})", runBeginIndex, runEndIndex,
                     strategy, tradeType);
         }
-        TradingRecord tradingRecord = new BaseTradingRecord(tradeType, transactionCostModel, holdingCostModel);
+        TradingRecord tradingRecord = new BaseTradingRecord(tradeType, runBeginIndex, runEndIndex, transactionCostModel,
+                holdingCostModel);
         for (int i = runBeginIndex; i <= runEndIndex; i++) {
             // For each bar between both indexes...
             if (strategy.shouldOperate(i, tradingRecord)) {

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -45,6 +45,16 @@ public class BaseTradingRecord implements TradingRecord {
     private String name;
 
     /**
+     * The start of the recording (included)
+     */
+    private final int startIndex;
+
+    /**
+     * The start of the recording (included)
+     */
+    private final int endIndex;
+
+    /**
      * The recorded trades
      */
     private List<Trade> trades = new ArrayList<>();
@@ -138,10 +148,27 @@ public class BaseTradingRecord implements TradingRecord {
      * @param holdingCostModel     the cost model for holding asset (e.g. borrowing)
      */
     public BaseTradingRecord(TradeType entryTradeType, CostModel transactionCostModel, CostModel holdingCostModel) {
+        this(entryTradeType, 0, 0, transactionCostModel, holdingCostModel);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param entryTradeType       the {@link TradeType trade type} of entries in
+     *                             the trading session
+     * @param startIndex           the start of the recording (included)
+     * @param endIndex             the end of the recording (included)
+     * @param transactionCostModel the cost model for transactions of the asset
+     * @param holdingCostModel     the cost model for holding asset (e.g. borrowing)
+     */
+    public BaseTradingRecord(TradeType entryTradeType, int startIndex, int endIndex, CostModel transactionCostModel,
+            CostModel holdingCostModel) {
         if (entryTradeType == null) {
             throw new IllegalArgumentException("Starting type must not be null");
         }
         this.startingType = entryTradeType;
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
         this.transactionCostModel = transactionCostModel;
         this.holdingCostModel = holdingCostModel;
         currentPosition = new Position(entryTradeType, transactionCostModel, holdingCostModel);
@@ -307,5 +334,15 @@ public class BaseTradingRecord implements TradingRecord {
             sb.append(trade.toString()).append(System.lineSeparator());
         }
         return sb.toString();
+    }
+
+    @Override
+    public int getStartIndex() {
+        return startIndex;
+    }
+
+    @Override
+    public int getEndIndex() {
+        return endIndex;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -167,4 +167,14 @@ public interface TradingRecord extends Serializable {
      * @return the last exit trade recorded
      */
     Trade getLastExit();
+
+    /**
+     * @return the start of the recording (included)
+     */
+    int getStartIndex();
+
+    /**
+     * @return the end of the recording (included)
+     */
+    int getEndIndex();
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -32,7 +32,7 @@ import org.ta4j.core.num.Num;
 /**
  * Enter and hold criterion.
  *
- * Calculates the return if a enter-and-hold strategy was used:
+ * Calculates the return if an enter-and-hold strategy was used:
  * 
  * <ul>
  * <li>For {@link #tradeType} = {@link TradeType#BUY}: buying on the first bar
@@ -75,17 +75,19 @@ public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return createEnterAndHoldTrade(series).getGrossReturn(series);
+        int beginIndex = series.getBeginIndex();
+        int endIndex = series.getEndIndex();
+        if (tradingRecord.getEndIndex() != 0) {
+            beginIndex = tradingRecord.getStartIndex();
+            endIndex = tradingRecord.getEndIndex();
+        }
+        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
     }
 
     /** The higher the criterion value the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
-    }
-
-    private Position createEnterAndHoldTrade(BarSeries series) {
-        return createEnterAndHoldTrade(series, series.getBeginIndex(), series.getEndIndex());
     }
 
     private Position createEnterAndHoldTrade(BarSeries series, int beginIndex, int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -28,36 +28,56 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.num.Num;
 
 /**
- * Versus "buy and hold" criterion.
+ * Versus "enter and hold" criterion.
  *
  * Compares the value of a provided {@link AnalysisCriterion criterion} with the
- * value of a "buy and hold".
+ * value of an "enter and hold".
  */
-public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
+public class VersusEnterAndHoldCriterion extends AbstractAnalysisCriterion {
 
+    private final TradeType tradeType;
     private final AnalysisCriterion criterion;
+
+    /**
+     * Constructor for buy-and-hold strategy.
+     * 
+     * @param criterion an analysis criterion to be compared
+     */
+    public VersusEnterAndHoldCriterion(AnalysisCriterion criterion) {
+        this(TradeType.BUY, criterion);
+    }
 
     /**
      * Constructor.
      * 
-     * @param criterion an analysis criterion to be compared
+     * @param tradeType the {@link TradeType} used to open the position
+     * @param criterion the analysis criterion to be compared
      */
-    public VersusBuyAndHoldCriterion(AnalysisCriterion criterion) {
+    public VersusEnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion) {
+        this.tradeType = tradeType;
         this.criterion = criterion;
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
+        TradingRecord fakeRecord = createEnterAndHoldTradingRecord(series, series.getBeginIndex(),
+                series.getEndIndex());
         return criterion.calculate(series, position).dividedBy(criterion.calculate(series, fakeRecord));
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
+        int beginIndex = series.getBeginIndex();
+        int endIndex = series.getEndIndex();
+        if (tradingRecord.getEndIndex() != 0) {
+            beginIndex = tradingRecord.getStartIndex();
+            endIndex = tradingRecord.getEndIndex();
+        }
+        TradingRecord fakeRecord = createEnterAndHoldTradingRecord(series, beginIndex, endIndex);
         return criterion.calculate(series, tradingRecord).dividedBy(criterion.calculate(series, fakeRecord));
     }
 
@@ -67,12 +87,8 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
         return criterionValue1.isGreaterThan(criterionValue2);
     }
 
-    private TradingRecord createBuyAndHoldTradingRecord(BarSeries series) {
-        return createBuyAndHoldTradingRecord(series, series.getBeginIndex(), series.getEndIndex());
-    }
-
-    private TradingRecord createBuyAndHoldTradingRecord(BarSeries series, int beginIndex, int endIndex) {
-        TradingRecord fakeRecord = new BaseTradingRecord();
+    private TradingRecord createEnterAndHoldTradingRecord(BarSeries series, int beginIndex, int endIndex) {
+        TradingRecord fakeRecord = new BaseTradingRecord(tradeType);
         fakeRecord.enter(beginIndex, series.getBar(beginIndex).getClosePrice(), series.numOf(1));
         fakeRecord.exit(endIndex, series.getBar(endIndex).getClosePrice(), series.numOf(1));
         return fakeRecord;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -35,7 +35,7 @@ import org.ta4j.core.num.Num;
  * Standard error criterion.
  * 
  * <p>
- * Calculates the standard deviation for a Criterion.
+ * Calculates the standard error for a Criterion.
  */
 public class StandardErrorCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -35,7 +35,7 @@ import org.ta4j.core.num.Num;
  * Variance criterion.
  * 
  * <p>
- * Calculates the standard deviation for a Criterion.
+ * Calculates the variance for a Criterion.
  */
 public class VarianceCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
@@ -40,10 +40,10 @@ import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
+public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
 
-    public VersusBuyAndHoldCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new VersusBuyAndHoldCriterion((AnalysisCriterion) params[0]), numFunction);
+    public VersusEnterAndHoldCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new VersusEnterAndHoldCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -30,7 +30,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
-import org.ta4j.core.criteria.VersusBuyAndHoldCriterion;
+import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.WinningPositionsRatioCriterion;
 import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
@@ -105,7 +105,7 @@ public class Quickstart {
         System.out.println("Return over Max Drawdown: " + romad.calculate(series, tradingRecord));
 
         // Total return of our strategy vs total return of a buy-and-hold strategy
-        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new GrossReturnCriterion());
+        AnalysisCriterion vsBuyAndHold = new VersusEnterAndHoldCriterion(new GrossReturnCriterion());
         System.out.println("Our return vs buy-and-hold return: " + vsBuyAndHold.calculate(series, tradingRecord));
 
         // Your turn!

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -34,7 +34,7 @@ import org.ta4j.core.criteria.MaximumDrawdownCriterion;
 import org.ta4j.core.criteria.NumberOfBarsCriterion;
 import org.ta4j.core.criteria.NumberOfPositionsCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
-import org.ta4j.core.criteria.VersusBuyAndHoldCriterion;
+import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.WinningPositionsRatioCriterion;
 import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 
@@ -87,6 +87,6 @@ public class StrategyAnalysis {
                 .println("Buy-and-hold return: " + new EnterAndHoldReturnCriterion().calculate(series, tradingRecord));
         // Total profit vs buy-and-hold
         System.out.println("Custom strategy return vs buy-and-hold strategy return: "
-                + new VersusBuyAndHoldCriterion(totalReturn).calculate(series, tradingRecord));
+                + new VersusEnterAndHoldCriterion(totalReturn).calculate(series, tradingRecord));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- added `TradingRecord#getStartIndex()` to track the start of the recording 
- added `TradingRecord#getEndIndex()` to track the end of the recording 
- correct `EnterAndHoldReturnCriterion`
- rename `VersusBuyAndHoldCriterion` to `VersusEnterAndHoldCriterion`
- correct `VersusEnterAndHoldCriterion`
- ability to add `TradeType` to `VersusEnterAndHoldCriterion`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 




Using https://github.com/ta4j/ta4j/blob/9a3bb213364424f92ce0fd9501f47e45b2c33c21/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java#L158 

with:
- `startIndex` > series.getBeginIndex()
- `endIndex` < barSeries.getEndIndex()

returns a tradingRecord within `startIndex` and `endIndex`, however, all those Criteria which calculates stuff within the whole barSeries (from `series.getBeginIndex()` till `barSeries.getEndIndex()`) are not aware of the fact that the tradingRecord was only run within `startIndex` and  `endIndex` and should return its analyzes only within this segment. 

For example, the following Criteria:

- VersusBuyAndHoldCriterion
- EnterAndHoldReturnCriterion
- ..

returns misleading values because it assumes the **full** barSeries instead of only restricting its calculation only from `startIndex` till  `endIndex`. Of course, I can use `series.subSeries(startIndex, endIndex)`, but then the indices are changed which is not always appropriate. 

The tradingRecord must be analyzed correctly by any criterion if I use custom `startIndex` and  `endIndex`.

We can provide two properties within the TradingRecord-interface
- endIndex with `TradingRecord#getEndIndex()`
- startIndex with `TradingRecord#getStartIndex()`

those properties will be set within the run-method.

With this, we can access the real startIndex and endIndex of the TradingRecord within any Criteria. What do you think?
