### PR TITLE
Rename pnl files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
 - **BuyAndHoldCriterion** renamed to **`EnterAndHoldCriterion`**
+- **ProfitLossCriterion** renamed to **`NetProfitLossCriterion`**
+- **ProfitLossPercentageCriterion** renamed to **`NetProfitLossPercentageCriterion`**
+- **ProfitLossRatioCriterion** renamed to **`GrossProfitLossRatioCriterion`**
 - **DXIndicator** moved to adx-package
 - **PlusDMIndicator** moved to adx-package
 - **MinusDMIndicator** moved to adx-package

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -226,7 +226,7 @@ public class Position implements Serializable {
     }
 
     /**
-     * Calculate the profit of the position if it is closed
+     * Calculate the net profit of the position if it is closed.
      *
      * @return the profit or loss of the position
      */
@@ -239,8 +239,8 @@ public class Position implements Serializable {
     }
 
     /**
-     * Calculate the profit of the position. If it is open, calculates the profit
-     * until the final bar.
+     * Calculate the net profit of the position. If it is open, calculates the
+     * profit until the final bar.
      *
      * @param finalIndex the index of the final bar to be considered (if position is
      *                   open)
@@ -255,7 +255,42 @@ public class Position implements Serializable {
     }
 
     /**
-     * Calculate the gross return of the position if it is closed
+     * Calculate the gross profit of the position if it is closed.
+     *
+     * @return the gross profit of the position
+     */
+    public Num getGrossProfit() {
+        if (isOpened()) {
+            return numOf(0);
+        } else {
+            return getGrossProfit(exit.getPricePerAsset());
+        }
+    }
+
+    /**
+     * Calculates the gross profit of the position.
+     * 
+     * @param finalPrice the price of the final bar to be considered (if position is
+     *                   open)
+     * @return the profit or loss of the position
+     */
+    public Num getGrossProfit(Num finalPrice) {
+        Num grossProfit;
+        if (isOpened()) {
+            grossProfit = entry.getAmount().multipliedBy(finalPrice).minus(entry.getValue());
+        } else {
+            grossProfit = exit.getValue().minus(entry.getValue());
+        }
+
+        // Profits of long position are losses of short
+        if (entry.isSell()) {
+            grossProfit = grossProfit.negate();
+        }
+        return grossProfit;
+    }
+
+    /**
+     * Calculates the gross return of the position if it is closed.
      *
      * @return the gross return of the position in percent
      */
@@ -268,7 +303,7 @@ public class Position implements Serializable {
     }
 
     /**
-     * Calculate the gross return of the position, if it exited at the provided
+     * Calculates the gross return of the position, if it exited at the provided
      * price.
      *
      * @param finalPrice the price of the final bar to be considered (if position is
@@ -320,38 +355,14 @@ public class Position implements Serializable {
     }
 
     /**
-     * Calculate the gross profit of the position if it is closed
-     *
-     * @return the gross profit of the position
-     */
-    public Num getGrossProfit() {
-        if (isOpened()) {
-            return numOf(0);
-        } else {
-            return getGrossProfit(exit.getPricePerAsset());
-        }
-    }
-
-    /**
-     * Calculate the gross (w/o trading costs) profit of the position.
+     * Calculates the total cost of the closed position
      * 
-     * @param finalPrice the price of the final bar to be considered (if position is
-     *                   open)
-     * @return the profit or loss of the position
+     * @return the cost of the position
      */
-    public Num getGrossProfit(Num finalPrice) {
-        Num grossProfit;
-        if (isOpened()) {
-            grossProfit = entry.getAmount().multipliedBy(finalPrice).minus(entry.getValue());
-        } else {
-            grossProfit = exit.getValue().minus(entry.getValue());
-        }
-
-        // Profits of long position are losses of short
-        if (entry.isSell()) {
-            grossProfit = grossProfit.negate();
-        }
-        return grossProfit;
+    public Num getPositionCost() {
+        Num transactionCost = transactionCostModel.calculate(this);
+        Num borrowingCost = getHoldingCost();
+        return transactionCost.plus(borrowingCost);
     }
 
     /**
@@ -364,17 +375,6 @@ public class Position implements Serializable {
     public Num getPositionCost(int finalIndex) {
         Num transactionCost = transactionCostModel.calculate(this, finalIndex);
         Num borrowingCost = getHoldingCost(finalIndex);
-        return transactionCost.plus(borrowingCost);
-    }
-
-    /**
-     * Calculates the total cost of the closed position
-     * 
-     * @return the cost of the position
-     */
-    public Num getPositionCost() {
-        Num transactionCost = transactionCostModel.calculate(this);
-        Num borrowingCost = getHoldingCost();
         return transactionCost.plus(borrowingCost);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
@@ -26,7 +26,7 @@ package org.ta4j.core.criteria;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ProfitLossRatioCriterion;
+import org.ta4j.core.criteria.pnl.GrossProfitLossRatioCriterion;
 import org.ta4j.core.num.Num;
 
 /**
@@ -42,7 +42,7 @@ import org.ta4j.core.num.Num;
  */
 public class ExpectancyCriterion extends AbstractAnalysisCriterion {
 
-    private final ProfitLossRatioCriterion profitLossRatioCriterion = new ProfitLossRatioCriterion();
+    private final GrossProfitLossRatioCriterion profitLossRatioCriterion = new GrossProfitLossRatioCriterion();
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
     private final NumberOfWinningPositionsCriterion numberOfWinningPositionsCriterion = new NumberOfWinningPositionsCriterion();
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
@@ -28,7 +28,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.helpers.StandardDeviationCriterion;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.num.Num;
 
 /**
@@ -58,7 +58,7 @@ public class SqnCriterion extends AbstractAnalysisCriterion {
      * Uses ProfitLossCriterion for {@link #criterion}.
      */
     public SqnCriterion() {
-        this(new ProfitLossCriterion());
+        this(new NetProfitLossCriterion());
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.criteria.NumberOfLosingPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross loss criterion (with added trading costs).
+ * Average gross loss criterion (includes trading costs).
  */
 public class AverageLossCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.criteria.NumberOfLosingPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross loss (with commissions).
+ * Average gross loss criterion (with added trading costs).
  */
 public class AverageLossCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.criteria.NumberOfWinningPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross profit (with added trading costs).
+ * Average gross profit (includes trading costs).
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.criteria.NumberOfWinningPositionsCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Average gross profit (with commissions).
+ * Average gross profit (with added trading costs).
  */
 public class AverageProfitCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossLossCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross loss criterion (with added trading costs).
+ * Gross loss criterion (includes trading costs).
  *
  * <p>
  * The gross loss of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossLossCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross loss criterion (with commissions).
+ * Gross loss criterion (with added trading costs).
  *
  * <p>
  * The gross loss of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross profit criterion (with added trading costs).
+ * Gross profit criterion (includes trading costs).
  *
  * <p>
  * The gross profit of the provided {@link Position position(s)} over the

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross profit criterion (with commissions).
+ * Gross profit criterion (with added trading costs).
  *
  * <p>
  * The gross profit of the provided {@link Position position(s)} over the

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossProfitLossRatioCriterion.java
@@ -30,8 +30,8 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Ratio gross profit and loss criterion = Average gross profit (with added
- * trading costs) / Average gross loss (with added trading costs).
+ * Ratio gross profit and loss criterion = Average gross profit (includes
+ * trading costs) / Average gross loss (includes trading costs).
  */
 public class GrossProfitLossRatioCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross return criterion (with commissions).
+ * Gross return (in percentage) criterion (with added trading costs).
  *
  * <p>
  * The gross return of the provided {@link Position position(s)} over the

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Gross return (in percentage) criterion (with added trading costs).
+ * Gross return (in percentage) criterion (includes trading costs).
  *
  * <p>
  * The gross return of the provided {@link Position position(s)} over the

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetLossCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net loss criterion (without commissions).
+ * Net loss criterion (with substracted trading costs).
  *
  * <p>
  * The net loss of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetLossCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net loss criterion (with substracted trading costs).
+ * Net loss criterion (excludes trading costs).
  *
  * <p>
  * The net loss of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net profit criterion (without commissions).
+ * Net profit criterion (with substracted trading costs).
  *
  * <p>
  * The net profit of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net profit criterion (with substracted trading costs).
+ * Net profit criterion (excludes trading costs).
  *
  * <p>
  * The net profit of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net Profit and loss criterion (absolute PnL with substracted trading costs).
+ * Net Profit and loss criterion (absolute PnL, excludes trading costs).
  *
  * <p>
  * The profit or loss over the provided {@link BarSeries series}.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterion.java
@@ -30,12 +30,12 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Profit and loss criterion (absolute PnL) (without commissions).
+ * Net Profit and loss criterion (absolute PnL with substracted trading costs).
  *
  * <p>
  * The profit or loss over the provided {@link BarSeries series}.
  */
-public class ProfitLossCriterion extends AbstractAnalysisCriterion {
+public class NetProfitLossCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetProfitLossPercentageCriterion.java
@@ -30,8 +30,8 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Net profit and loss in percentage criterion (relative PnL with substracted
- * trading costs).
+ * Net profit and loss in percentage criterion (relative PnL, excludes trading
+ * costs).
  * 
  * <p>
  * Defined as the position profit over the purchase price. The profit or loss in

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
@@ -28,8 +28,8 @@ import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.pnl.NetLossCriterion;
 import org.ta4j.core.criteria.pnl.NetProfitCriterion;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
-import org.ta4j.core.criteria.pnl.ProfitLossPercentageCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossPercentageCriterion;
 import org.ta4j.core.num.Num;
 
 /**
@@ -42,10 +42,10 @@ public class PerformanceReportGenerator implements ReportGenerator<PerformanceRe
 
     @Override
     public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
-        final Num pnl = new ProfitLossCriterion().calculate(series, tradingRecord);
-        final Num pnlPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
+        final Num netPnl = new NetProfitLossCriterion().calculate(series, tradingRecord);
+        final Num netPnlPercentage = new NetProfitLossPercentageCriterion().calculate(series, tradingRecord);
         final Num netProfit = new NetProfitCriterion().calculate(series, tradingRecord);
         final Num netLoss = new NetLossCriterion().calculate(series, tradingRecord);
-        return new PerformanceReport(pnl, pnlPercentage, netProfit, netLoss);
+        return new PerformanceReport(netPnl, netPnlPercentage, netProfit, netLoss);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractCriterionTest;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,13 +52,13 @@ public class AverageCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series, series.numOf(1)), Trade.buyAt(3, series, series.numOf(1)),
                 Trade.sellAt(5, series, series.numOf(1)));
 
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertNumEquals(7.5, criterion.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
     }
@@ -66,7 +66,7 @@ public class AverageCriterionTest extends AbstractCriterionTest {
     @Test
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction,
-                getCriterion(new ProfitLossCriterion()), 0);
+                getCriterion(new NetProfitLossCriterion()), 0);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractCriterionTest;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,13 +52,13 @@ public class RelativeStandardDeviationCriterionTest extends AbstractCriterionTes
                 Trade.sellAt(2, series, series.numOf(1)), Trade.buyAt(3, series, series.numOf(1)),
                 Trade.sellAt(5, series, series.numOf(1)));
 
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertNumEquals(0.3333333333333333, criterion.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
     }
@@ -66,7 +66,7 @@ public class RelativeStandardDeviationCriterionTest extends AbstractCriterionTes
     @Test
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction,
-                getCriterion(new ProfitLossCriterion()), 0);
+                getCriterion(new NetProfitLossCriterion()), 0);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractCriterionTest;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,13 +52,13 @@ public class StandardDeviationCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series, series.numOf(1)), Trade.buyAt(3, series, series.numOf(1)),
                 Trade.sellAt(5, series, series.numOf(1)));
 
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertNumEquals(2.5, criterion.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
     }
@@ -66,7 +66,7 @@ public class StandardDeviationCriterionTest extends AbstractCriterionTest {
     @Test
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction,
-                getCriterion(new ProfitLossCriterion()), 0);
+                getCriterion(new NetProfitLossCriterion()), 0);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractCriterionTest;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,13 +52,13 @@ public class StandardErrorCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series, series.numOf(1)), Trade.buyAt(3, series, series.numOf(1)),
                 Trade.sellAt(5, series, series.numOf(1)));
 
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertNumEquals(1.7677669529663687, criterion.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
         assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
     }
@@ -66,7 +66,7 @@ public class StandardErrorCriterionTest extends AbstractCriterionTest {
     @Test
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction,
-                getCriterion(new ProfitLossCriterion()), 0);
+                getCriterion(new NetProfitLossCriterion()), 0);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractCriterionTest;
-import org.ta4j.core.criteria.pnl.ProfitLossCriterion;
+import org.ta4j.core.criteria.pnl.NetProfitLossCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,13 +52,13 @@ public class VarianceCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series, series.numOf(1)), Trade.buyAt(3, series, series.numOf(1)),
                 Trade.sellAt(5, series, series.numOf(1)));
 
-        AnalysisCriterion variance = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion variance = getCriterion(new NetProfitLossCriterion());
         assertNumEquals(6.25, variance.calculate(series, tradingRecord));
     }
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
+        AnalysisCriterion criterion = getCriterion(new NetProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
     }
@@ -66,7 +66,7 @@ public class VarianceCriterionTest extends AbstractCriterionTest {
     @Test
     public void testCalculateOneOpenPositionShouldReturnZero() {
         openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction,
-                getCriterion(new ProfitLossCriterion()), 0);
+                getCriterion(new NetProfitLossCriterion()), 0);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitLossRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/GrossProfitLossRatioCriterionTest.java
@@ -38,10 +38,10 @@ import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class ProfitLossRatioCriterionTest extends AbstractCriterionTest {
+public class GrossProfitLossRatioCriterionTest extends AbstractCriterionTest {
 
-    public ProfitLossRatioCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new ProfitLossRatioCriterion(), numFunction);
+    public GrossProfitLossRatioCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new GrossProfitLossRatioCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossCriterionTest.java
@@ -38,10 +38,10 @@ import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class ProfitLossCriterionTest extends AbstractCriterionTest {
+public class NetProfitLossCriterionTest extends AbstractCriterionTest {
 
-    public ProfitLossCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new ProfitLossCriterion(), numFunction);
+    public NetProfitLossCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NetProfitLossCriterion(), numFunction);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/NetProfitLossPercentageCriterionTest.java
@@ -38,10 +38,10 @@ import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
+public class NetProfitLossPercentageCriterionTest extends AbstractCriterionTest {
 
-    public ProfitLossPercentageCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new ProfitLossPercentageCriterion(), numFunction);
+    public NetProfitLossPercentageCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new NetProfitLossPercentageCriterion(), numFunction);
     }
 
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:

- **ProfitLossCriterion** renamed to **`NetProfitLossCriterion`**
- **ProfitLossPercentageCriterion** renamed to **`NetProfitLossPercentageCriterion`**
- **ProfitLossRatioCriterion** renamed to **`GrossProfitLossRatioCriterion`**
-  small javadoc corrections

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
