### PR TITLE
Num: rename multipliedBy() and dividedBy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Breaking
 - **DifferencePercentage** renamed to **`DifferencePercentageIndicator`**
 - **BuyAndHoldCriterion** renamed to **`EnterAndHoldCriterion`**
+- **Num#multipliedBy** renamed to **`Num#multiply`**
+- **Num#dividedBy** renamed to **`Num#divide`**
 - **DXIndicator** moved to adx-package
 - **PlusDMIndicator** moved to adx-package
 - **MinusDMIndicator** moved to adx-package

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -384,7 +384,7 @@ public class BaseBar implements Bar {
         addPrice(tradePrice);
 
         volume = volume.plus(tradeVolume);
-        amount = amount.plus(tradeVolume.multipliedBy(tradePrice));
+        amount = amount.plus(tradeVolume.multiply(tradePrice));
         trades++;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -312,10 +312,10 @@ public class Position implements Serializable {
      */
     public Num getGrossReturn(Num entryPrice, Num exitPrice) {
         if (getEntry().isBuy()) {
-            return exitPrice.dividedBy(entryPrice);
+            return exitPrice.divide(entryPrice);
         } else {
             Num one = entryPrice.numOf(1);
-            return ((exitPrice.dividedBy(entryPrice).minus(one)).negate()).plus(one);
+            return ((exitPrice.divide(entryPrice).minus(one)).negate()).plus(one);
         }
     }
 
@@ -342,7 +342,7 @@ public class Position implements Serializable {
     public Num getGrossProfit(Num finalPrice) {
         Num grossProfit;
         if (isOpened()) {
-            grossProfit = entry.getAmount().multipliedBy(finalPrice).minus(entry.getValue());
+            grossProfit = entry.getAmount().multiply(finalPrice).minus(entry.getValue());
         } else {
             grossProfit = exit.getValue().minus(entry.getValue());
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/Trade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Trade.java
@@ -259,7 +259,7 @@ public class Trade implements Serializable {
         this.pricePerAsset = pricePerAsset;
         this.cost = transactionCostModel.calculate(this.pricePerAsset, amount);
 
-        Num costPerAsset = cost.dividedBy(amount);
+        Num costPerAsset = cost.divide(amount);
         // add transaction costs to the pricePerAsset at the trade
         if (type.equals(TradeType.BUY)) {
             this.netPrice = this.pricePerAsset.plus(costPerAsset);
@@ -409,6 +409,6 @@ public class Trade implements Serializable {
      * @return the value of a trade (without transaction cost)
      */
     public Num getValue() {
-        return pricePerAsset.multipliedBy(amount);
+        return pricePerAsset.multiply(amount);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
@@ -155,14 +155,14 @@ public class CashFlow implements Indicator<Num> {
 
             int nPeriods = endIndex - entryIndex;
             Num holdingCost = position.getHoldingCost(endIndex);
-            Num avgCost = holdingCost.dividedBy(holdingCost.numOf(nPeriods));
+            Num avgCost = holdingCost.divide(holdingCost.numOf(nPeriods));
 
             // Add intermediate cash flows during position
             Num netEntryPrice = position.getEntry().getNetPrice();
             for (int i = startingIndex; i < endIndex; i++) {
                 Num intermediateNetPrice = addCost(barSeries.getBar(i).getClosePrice(), avgCost, isLongTrade);
                 Num ratio = getIntermediateRatio(isLongTrade, netEntryPrice, intermediateNetPrice);
-                values.add(values.get(entryIndex).multipliedBy(ratio));
+                values.add(values.get(entryIndex).multiply(ratio));
             }
 
             // add net cash flow at exit position
@@ -173,7 +173,7 @@ public class CashFlow implements Indicator<Num> {
                 exitPrice = barSeries.getBar(endIndex).getClosePrice();
             }
             Num ratio = getIntermediateRatio(isLongTrade, netEntryPrice, addCost(exitPrice, avgCost, isLongTrade));
-            values.add(values.get(entryIndex).multipliedBy(ratio));
+            values.add(values.get(entryIndex).multiply(ratio));
         }
     }
 
@@ -187,9 +187,9 @@ public class CashFlow implements Indicator<Num> {
     private static Num getIntermediateRatio(boolean isLongTrade, Num entryPrice, Num exitPrice) {
         Num ratio;
         if (isLongTrade) {
-            ratio = exitPrice.dividedBy(entryPrice);
+            ratio = exitPrice.divide(entryPrice);
         } else {
-            ratio = entryPrice.numOf(2).minus(exitPrice.dividedBy(entryPrice));
+            ratio = entryPrice.numOf(2).minus(exitPrice.divide(entryPrice));
         }
         return ratio;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -46,14 +46,14 @@ public class Returns implements Indicator<Num> {
             @Override
             public Num calculate(Num xNew, Num xOld) {
                 // r_i = ln(P_i/P_(i-1))
-                return (xNew.dividedBy(xOld)).log();
+                return (xNew.divide(xOld)).log();
             }
         },
         ARITHMETIC {
             @Override
             public Num calculate(Num xNew, Num xOld) {
                 // r_i = P_i/P_(i-1) - 1
-                return xNew.dividedBy(xOld).minus(one);
+                return xNew.divide(xOld).minus(one);
             }
         };
 
@@ -168,7 +168,7 @@ public class Returns implements Indicator<Num> {
         int startingIndex = Math.max(begin, 1);
         int nPeriods = endIndex - entryIndex;
         Num holdingCost = position.getHoldingCost(endIndex);
-        Num avgCost = holdingCost.dividedBy(holdingCost.numOf(nPeriods));
+        Num avgCost = holdingCost.divide(holdingCost.numOf(nPeriods));
 
         // returns are per period (iterative). Base price needs to be updated
         // accordingly
@@ -181,7 +181,7 @@ public class Returns implements Indicator<Num> {
             if (position.getEntry().isBuy()) {
                 strategyReturn = assetReturn;
             } else {
-                strategyReturn = assetReturn.multipliedBy(minusOne);
+                strategyReturn = assetReturn.multiply(minusOne);
             }
             values.add(strategyReturn);
             // update base price
@@ -201,7 +201,7 @@ public class Returns implements Indicator<Num> {
         if (position.getEntry().isBuy()) {
             strategyReturn = assetReturn;
         } else {
-            strategyReturn = assetReturn.multipliedBy(minusOne);
+            strategyReturn = assetReturn.multiply(minusOne);
         }
         values.add(strategyReturn);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -62,7 +62,7 @@ public class FixedTransactionCostModel implements CostModel {
         if (position.isClosed()) {
             multiplier = pricePerAsset.numOf(2);
         }
-        return pricePerAsset.numOf(feePerTrade).multipliedBy(multiplier);
+        return pricePerAsset.numOf(feePerTrade).multiply(multiplier);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
@@ -94,8 +94,7 @@ public class LinearBorrowingCostModel implements CostModel {
      * @return the absolute borrowing cost
      */
     private Num getHoldingCostForPeriods(int tradingPeriods, Num tradedValue) {
-        return tradedValue
-                .multipliedBy(tradedValue.numOf(tradingPeriods).multipliedBy(tradedValue.numOf(feePerPeriod)));
+        return tradedValue.multiply(tradedValue.numOf(tradingPeriods).multiply(tradedValue.numOf(feePerPeriod)));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
@@ -82,7 +82,7 @@ public class LinearTransactionCostModel implements CostModel {
      * @return the absolute trade transaction cost
      */
     public Num calculate(Num price, Num amount) {
-        return amount.numOf(feePerPosition).multipliedBy(price).multipliedBy(amount);
+        return amount.numOf(feePerPosition).multiply(price).multiply(amount);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -48,7 +48,7 @@ public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
             return series.numOf(1);
         }
 
-        return grossReturn.calculate(series, position).pow(series.numOf(1).dividedBy(bars));
+        return grossReturn.calculate(series, position).pow(series.numOf(1).divide(bars));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
             return series.numOf(1);
         }
 
-        return grossReturn.calculate(series, tradingRecord).pow(series.numOf(1).dividedBy(bars));
+        return grossReturn.calculate(series, tradingRecord).pow(series.numOf(1).divide(bars));
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
@@ -75,8 +75,8 @@ public class ExpectancyCriterion extends AbstractAnalysisCriterion {
             return series.numOf(0);
         }
         // Expectancy = (1 + AW/AL) * (ProbabilityToWinOnePosition - 1)
-        Num probabiltyToWinOnePosition = numberOfWinningPositions.dividedBy(numberOfAllPositions);
-        return (one.plus(profitLossRatio)).multipliedBy((probabiltyToWinOnePosition).minus(one));
+        Num probabiltyToWinOnePosition = numberOfWinningPositions.divide(numberOfAllPositions);
+        return (one.plus(profitLossRatio)).multiply((probabiltyToWinOnePosition).minus(one));
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -95,7 +95,7 @@ public class ExpectedShortfallCriterion extends AbstractAnalysisCriterion {
             for (int i = 0; i < nInTail; i++) {
                 sum = sum.plus(tailEvents.get(i));
             }
-            expectedShortfall = sum.dividedBy(returns.numOf(nInTail));
+            expectedShortfall = sum.divide(returns.numOf(nInTail));
 
             // ES is non-positive
             if (expectedShortfall.isGreaterThan(zero)) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
@@ -90,7 +90,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
             // - Multiply by the profit ratio
             // - Remove the cost of the *second* trade
             tradedAmount = tradedAmount.minus(getTradeCost(position.getEntry(), tradedAmount));
-            tradedAmount = tradedAmount.multipliedBy(grossReturn.calculate(series, position));
+            tradedAmount = tradedAmount.multiply(grossReturn.calculate(series, position));
             tradedAmount = tradedAmount.minus(getTradeCost(position.getExit(), tradedAmount));
         }
 
@@ -117,7 +117,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
     private Num getTradeCost(Trade trade, Num tradedAmount) {
         Num tradeCost = tradedAmount.numOf(0);
         if (trade != null) {
-            return tradedAmount.numOf(a).multipliedBy(tradedAmount).plus(tradedAmount.numOf(b));
+            return tradedAmount.numOf(a).multiply(tradedAmount).plus(tradedAmount.numOf(b));
         }
         return tradeCost;
     }
@@ -138,7 +138,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
                     // - Remove the cost of the first trade
                     // - Multiply by the profit ratio
                     Num newTradedAmount = initialAmount.minus(totalTradeCost)
-                            .multipliedBy(grossReturn.calculate(series, position));
+                            .multiply(grossReturn.calculate(series, position));
                     totalTradeCost = totalTradeCost.plus(getTradeCost(position.getExit(), newTradedAmount));
                 }
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/LosingPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/LosingPositionsRatioCriterion.java
@@ -46,7 +46,7 @@ public class LosingPositionsRatioCriterion extends AbstractAnalysisCriterion {
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         Num numberOfLosingPositions = numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
         numberOfLosingPositionsCriterion.calculate(series, tradingRecord);
-        return numberOfLosingPositions.dividedBy(series.numOf(tradingRecord.getPositionCount()));
+        return numberOfLosingPositions.divide(series.numOf(tradingRecord.getPositionCount()));
     }
 
     /** The lower the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
@@ -76,7 +76,7 @@ public class MaximumDrawdownCriterion extends AbstractAnalysisCriterion {
                     maxPeak = value;
                 }
 
-                Num drawdown = maxPeak.minus(value).dividedBy(maxPeak);
+                Num drawdown = maxPeak.minus(value).divide(maxPeak);
                 if (drawdown.isGreaterThan(maximumDrawdown)) {
                     maximumDrawdown = drawdown;
                 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -47,7 +47,7 @@ public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
             return NaN.NaN;
         } else {
             final Num totalProfit = grossReturnCriterion.calculate(series, position);
-            return totalProfit.dividedBy(maxDrawdown);
+            return totalProfit.divide(maxDrawdown);
         }
     }
 
@@ -58,7 +58,7 @@ public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
             return NaN.NaN;
         } else {
             final Num totalProfit = grossReturnCriterion.calculate(series, tradingRecord);
-            return totalProfit.dividedBy(maxDrawdown);
+            return totalProfit.divide(maxDrawdown);
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
@@ -88,13 +88,13 @@ public class SqnCriterion extends AbstractAnalysisCriterion {
     public Num calculate(BarSeries series, Position position) {
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
         Num pnl = criterion.calculate(series, position);
-        Num avgPnl = pnl.dividedBy(numberOfPositions);
+        Num avgPnl = pnl.divide(numberOfPositions);
         Num stdDevPnl = standardDeviationCriterion.calculate(series, position);
         if (stdDevPnl.isZero()) {
             return series.numOf(0);
         }
         // SQN = (Average (PnL) / StdDev(PnL)) * SquareRoot(NumberOfTrades)
-        return avgPnl.dividedBy(stdDevPnl).multipliedBy(numberOfPositions.sqrt());
+        return avgPnl.divide(stdDevPnl).multiply(numberOfPositions.sqrt());
     }
 
     @Override
@@ -103,7 +103,7 @@ public class SqnCriterion extends AbstractAnalysisCriterion {
             return series.numOf(0);
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
         Num pnl = criterion.calculate(series, tradingRecord);
-        Num avgPnl = pnl.dividedBy(numberOfPositions);
+        Num avgPnl = pnl.divide(numberOfPositions);
         Num stdDevPnl = standardDeviationCriterion.calculate(series, tradingRecord);
         if (stdDevPnl.isZero()) {
             return series.numOf(0);
@@ -112,7 +112,7 @@ public class SqnCriterion extends AbstractAnalysisCriterion {
             numberOfPositions = series.numOf(nPositions);
         }
         // SQN = (Average (PnL) / StdDev(PnL)) * SquareRoot(NumberOfTrades)
-        return avgPnl.dividedBy(stdDevPnl).multipliedBy(numberOfPositions.sqrt());
+        return avgPnl.divide(stdDevPnl).multiply(numberOfPositions.sqrt());
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusBuyAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusBuyAndHoldCriterion.java
@@ -52,13 +52,13 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Position position) {
         TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
-        return criterion.calculate(series, position).dividedBy(criterion.calculate(series, fakeRecord));
+        return criterion.calculate(series, position).divide(criterion.calculate(series, fakeRecord));
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
-        return criterion.calculate(series, tradingRecord).dividedBy(criterion.calculate(series, fakeRecord));
+        return criterion.calculate(series, tradingRecord).divide(criterion.calculate(series, fakeRecord));
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/WinningPositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/WinningPositionsRatioCriterion.java
@@ -45,7 +45,7 @@ public class WinningPositionsRatioCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         Num numberOfWinningPositions = numberOfWinningPositionsCriterion.calculate(series, tradingRecord);
-        return numberOfWinningPositions.dividedBy(series.numOf(tradingRecord.getPositionCount()));
+        return numberOfWinningPositions.divide(series.numOf(tradingRecord.getPositionCount()));
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
@@ -54,7 +54,7 @@ public class AverageCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Position position) {
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
-        return criterion.calculate(series, position).dividedBy(numberOfPositions);
+        return criterion.calculate(series, position).divide(numberOfPositions);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class AverageCriterion extends AbstractAnalysisCriterion {
             return series.numOf(0);
         }
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
-        return criterion.calculate(series, tradingRecord).dividedBy(numberOfPositions);
+        return criterion.calculate(series, tradingRecord).divide(numberOfPositions);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -59,7 +59,7 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
     @Override
     public Num calculate(BarSeries series, Position position) {
         Num average = averageCriterion.calculate(series, position);
-        return standardDeviationCriterion.calculate(series, position).dividedBy(average);
+        return standardDeviationCriterion.calculate(series, position).divide(average);
     }
 
     @Override
@@ -68,7 +68,7 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
             return series.numOf(0);
         }
         Num average = averageCriterion.calculate(series, tradingRecord);
-        return standardDeviationCriterion.calculate(series, tradingRecord).dividedBy(average);
+        return standardDeviationCriterion.calculate(series, tradingRecord).divide(average);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -55,7 +55,7 @@ public class StandardErrorCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Position position) {
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
-        return standardDeviationCriterion.calculate(series, position).dividedBy(numberOfPositions.sqrt());
+        return standardDeviationCriterion.calculate(series, position).divide(numberOfPositions.sqrt());
     }
 
     @Override
@@ -64,7 +64,7 @@ public class StandardErrorCriterion extends AbstractAnalysisCriterion {
             return series.numOf(0);
         }
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
-        return standardDeviationCriterion.calculate(series, tradingRecord).dividedBy(numberOfPositions.sqrt());
+        return standardDeviationCriterion.calculate(series, tradingRecord).divide(numberOfPositions.sqrt());
     }
 
     /** The lower the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -57,10 +57,10 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, position);
 
         Num variance = series.numOf(0);
-        Num average = criterionValue.dividedBy(numberOfPositions);
+        Num average = criterionValue.divide(numberOfPositions);
         Num pow = criterion.calculate(series, position).minus(average).pow(2);
         variance = variance.plus(pow);
-        variance = variance.dividedBy(numberOfPositions);
+        variance = variance.divide(numberOfPositions);
         return variance;
     }
 
@@ -73,13 +73,13 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
         Num numberOfPositions = numberOfPositionsCriterion.calculate(series, tradingRecord);
 
         Num variance = series.numOf(0);
-        Num average = criterionValue.dividedBy(numberOfPositions);
+        Num average = criterionValue.divide(numberOfPositions);
 
         for (Position position : tradingRecord.getPositions()) {
             Num pow = criterion.calculate(series, position).minus(average).pow(2);
             variance = variance.plus(pow);
         }
-        variance = variance.dividedBy(numberOfPositions);
+        variance = variance.divide(numberOfPositions);
         return variance;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -48,7 +48,7 @@ public class AverageLossCriterion extends AbstractAnalysisCriterion {
         if (grossLoss.isZero()) {
             return series.numOf(0);
         }
-        return grossLoss.dividedBy(numberOfLosingPositions);
+        return grossLoss.divide(numberOfLosingPositions);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class AverageLossCriterion extends AbstractAnalysisCriterion {
         if (grossLoss.isZero()) {
             return series.numOf(0);
         }
-        return grossLoss.dividedBy(numberOfLosingPositions);
+        return grossLoss.divide(numberOfLosingPositions);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -48,7 +48,7 @@ public class AverageProfitCriterion extends AbstractAnalysisCriterion {
         if (grossProfit.isZero()) {
             return series.numOf(0);
         }
-        return grossProfit.dividedBy(numberOfWinningPositions);
+        return grossProfit.divide(numberOfWinningPositions);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class AverageProfitCriterion extends AbstractAnalysisCriterion {
         if (grossProfit.isZero()) {
             return series.numOf(0);
         }
-        return grossProfit.dividedBy(numberOfWinningPositions);
+        return grossProfit.divide(numberOfWinningPositions);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/GrossReturnCriterion.java
@@ -48,7 +48,7 @@ public class GrossReturnCriterion extends AbstractAnalysisCriterion {
         return tradingRecord.getPositions()
                 .stream()
                 .map(position -> calculateProfit(series, position))
-                .reduce(series.numOf(1), Num::multipliedBy);
+                .reduce(series.numOf(1), Num::multiply);
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -43,7 +43,7 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
             Num entryPrice = position.getEntry().getValue();
-            Num pnl = position.getProfit().dividedBy(entryPrice).multipliedBy(series.numOf(100));
+            Num pnl = position.getProfit().divide(entryPrice).multiply(series.numOf(100));
             return pnl;
         }
         return series.numOf(0);

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -50,7 +50,7 @@ public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {
             // only winning positions means a ratio of 1
             return series.numOf(1);
         }
-        return averageProfit.dividedBy(averageLoss).abs();
+        return averageProfit.divide(averageLoss).abs();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {
             // only winning positions means a ratio of 1
             return series.numOf(1);
         }
-        return averageProfit.dividedBy(averageLoss).abs();
+        return averageProfit.divide(averageLoss).abs();
     }
 
     /** The higher the criterion value, the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
@@ -48,7 +48,7 @@ public abstract class AbstractEMAIndicator extends RecursiveCachedIndicator<Num>
             return indicator.getValue(0);
         }
         Num prevValue = getValue(index - 1);
-        return indicator.getValue(index).minus(prevValue).multipliedBy(multiplier).plus(prevValue);
+        return indicator.getValue(index).minus(prevValue).multiply(multiplier).plus(prevValue);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AroonDownIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AroonDownIndicator.java
@@ -85,7 +85,7 @@ public class AroonDownIndicator extends CachedIndicator<Num> {
             nbBars++;
         }
 
-        return numOf(barCount - nbBars).dividedBy(numOf(barCount)).multipliedBy(hundred);
+        return numOf(barCount - nbBars).divide(numOf(barCount)).multiply(hundred);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AroonUpIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AroonUpIndicator.java
@@ -85,7 +85,7 @@ public class AroonUpIndicator extends CachedIndicator<Num> {
             nbBars++;
         }
 
-        return numOf(barCount - nbBars).dividedBy(numOf(barCount)).multipliedBy(hundred);
+        return numOf(barCount - nbBars).divide(numOf(barCount)).multiply(hundred);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
@@ -66,7 +66,7 @@ public class CCIIndicator extends CachedIndicator<Num> {
         if (meanDeviation.isZero()) {
             return meanDeviation.zero();
         }
-        return (typicalPrice.minus(typicalPriceAvg)).dividedBy(meanDeviation.multipliedBy(factor));
+        return (typicalPrice.minus(typicalPriceAvg)).divide(meanDeviation.multiply(factor));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
@@ -67,6 +67,6 @@ public class CMOIndicator extends CachedIndicator<Num> {
         for (int i = Math.max(1, index - barCount + 1); i <= index; i++) {
             sumOfLosses = sumOfLosses.plus(lossIndicator.getValue(i));
         }
-        return sumOfGains.minus(sumOfLosses).dividedBy(sumOfGains.plus(sumOfLosses)).multipliedBy(numOf(100));
+        return sumOfGains.minus(sumOfLosses).divide(sumOfGains.plus(sumOfLosses)).multiply(numOf(100));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
@@ -66,6 +66,6 @@ public class ChandelierExitLongIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return high.getValue(index).minus(atr.getValue(index).multipliedBy(k));
+        return high.getValue(index).minus(atr.getValue(index).multiply(k));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -66,6 +66,6 @@ public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return low.getValue(index).plus(atr.getValue(index).multipliedBy(k));
+        return low.getValue(index).plus(atr.getValue(index).multiply(k));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -78,8 +78,8 @@ public class ChopIndicator extends CachedIndicator<Num> {
         for (int i = 1; i < timeFrame; ++i) {
             summ = summ.plus(atrIndicator.getValue(index - i));
         }
-        Num a = summ.dividedBy((hvi.getValue(index).minus(lvi.getValue(index))));
+        Num a = summ.divide((hvi.getValue(index).minus(lvi.getValue(index))));
         // TODO: implement Num.log10(Num)
-        return scaleUpTo.multipliedBy(numOf(Math.log10(a.doubleValue()))).dividedBy(log10n);
+        return scaleUpTo.multiply(numOf(Math.log10(a.doubleValue()))).divide(log10n);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
@@ -67,6 +67,6 @@ public class DistanceFromMAIndicator extends CachedIndicator<Num> {
         Bar currentBar = getBarSeries().getBar(index);
         Num closePrice = currentBar.getClosePrice();
         Num maValue = (Num) movingAverage.getValue(index);
-        return (closePrice.minus(maValue)).dividedBy(maValue);
+        return (closePrice.minus(maValue)).divide(maValue);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
@@ -55,7 +55,7 @@ public class DoubleEMAIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return ema.getValue(index).multipliedBy(numOf(2)).minus(emaEma.getValue(index));
+        return ema.getValue(index).multiply(numOf(2)).minus(emaEma.getValue(index));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
@@ -164,10 +164,10 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
                 Num currentRef = FisherIndicator.this.ref.getValue(index);
                 Num minL = periodLow.getValue(index);
                 Num maxH = periodHigh.getValue(index);
-                Num term1 = currentRef.minus(minL).dividedBy(maxH.minus(minL)).minus(numOf(ZERO_DOT_FIVE));
-                Num term2 = alpha.multipliedBy(numOf(2)).multipliedBy(term1);
-                Num term3 = term2.plus(beta.multipliedBy(getValue(index - 1)));
-                return term3.dividedBy(FisherIndicator.this.densityFactor);
+                Num term1 = currentRef.minus(minL).divide(maxH.minus(minL)).minus(numOf(ZERO_DOT_FIVE));
+                Num term2 = alpha.multiply(numOf(2)).multiply(term1);
+                Num term3 = term2.plus(beta.multiply(getValue(index - 1)));
+                return term3.divide(FisherIndicator.this.densityFactor);
             }
         };
     }
@@ -187,9 +187,9 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         // Fisher = gamma * Log((1 + Value) / (1 - Value)) + delta * priorFisher
-        Num term1 = numOf((Math.log(numOf(1).plus(value).dividedBy(numOf(1).minus(value)).doubleValue())));
+        Num term1 = numOf((Math.log(numOf(1).plus(value).divide(numOf(1).minus(value)).doubleValue())));
         Num term2 = getValue(index - 1);
-        return gamma.multipliedBy(term1).plus(delta.multipliedBy(term2));
+        return gamma.multiply(term1).plus(delta.multiply(term2));
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
@@ -56,8 +56,8 @@ public class KAMAIndicator extends RecursiveCachedIndicator<Num> {
         super(price);
         this.price = price;
         this.barCountEffectiveRatio = barCountEffectiveRatio;
-        fastest = numOf(2).dividedBy(numOf(barCountFast + 1));
-        slowest = numOf(2).dividedBy(numOf(barCountSlow + 1));
+        fastest = numOf(2).divide(numOf(barCountFast + 1));
+        slowest = numOf(2).divide(numOf(barCountSlow + 1));
     }
 
     /**
@@ -90,17 +90,17 @@ public class KAMAIndicator extends RecursiveCachedIndicator<Num> {
         for (int i = startChangeIndex; i < index; i++) {
             volatility = volatility.plus(price.getValue(i + 1).minus(price.getValue(i)).abs());
         }
-        Num er = change.dividedBy(volatility);
+        Num er = change.divide(volatility);
         /*
          * Smoothing Constant (SC) SC = [ER x (fastest SC - slowest SC) + slowest SC]2
          * SC = [ER x (2/(2+1) - 2/(30+1)) + 2/(30+1)]2
          */
-        Num sc = er.multipliedBy(fastest.minus(slowest)).plus(slowest).pow(2);
+        Num sc = er.multiply(fastest.minus(slowest)).plus(slowest).pow(2);
         /*
          * KAMA Current KAMA = Prior KAMA + SC x (Price - Prior KAMA)
          */
         Num priorKAMA = getValue(index - 1);
-        return priorKAMA.plus(sc.multipliedBy(currentPrice.minus(priorKAMA)));
+        return priorKAMA.plus(sc.multiply(currentPrice.minus(priorKAMA)));
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
@@ -88,9 +88,8 @@ public class KSTIndicator extends CachedIndicator<Num> {
         Num RCMA3Multiplier = numOf(3);
         Num RCMA4Multiplier = numOf(4);
 
-        return ((RCMA1.getValue(index).multipliedBy(RCMA1Multiplier))
-                .plus(RCMA2.getValue(index).multipliedBy(RCMA2Multiplier))
-                .plus(RCMA3.getValue(index).multipliedBy(RCMA3Multiplier))
-                .plus(RCMA4.getValue(index).multipliedBy(RCMA4Multiplier)));
+        return ((RCMA1.getValue(index).multiply(RCMA1Multiplier)).plus(RCMA2.getValue(index).multiply(RCMA2Multiplier))
+                .plus(RCMA3.getValue(index).multiply(RCMA3Multiplier))
+                .plus(RCMA4.getValue(index).multiply(RCMA4Multiplier)));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
@@ -59,9 +59,9 @@ public class LWMAIndicator extends CachedIndicator<Num> {
         for (int i = startIndex; i <= index; i++) {
             count++;
             denominator = denominator.plus(numOf(count));
-            sum = sum.plus(indicator.getValue(i).multipliedBy(numOf(count)));
+            sum = sum.plus(indicator.getValue(i).multiply(numOf(count)));
         }
-        return sum.dividedBy(denominator);
+        return sum.divide(denominator);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
@@ -64,7 +64,7 @@ public class MassIndexIndicator extends CachedIndicator<Num> {
         final int startIndex = Math.max(0, index - barCount + 1);
         Num massIndex = numOf(0);
         for (int i = startIndex; i <= index; i++) {
-            Num emaRatio = singleEma.getValue(i).dividedBy(doubleEma.getValue(i));
+            Num emaRatio = singleEma.getValue(i).divide(doubleEma.getValue(i));
             massIndex = massIndex.plus(emaRatio);
         }
         return massIndex;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
@@ -67,6 +67,6 @@ public class PPOIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         Num shortEmaValue = shortTermEma.getValue(index);
         Num longEmaValue = longTermEma.getValue(index);
-        return shortEmaValue.minus(longEmaValue).dividedBy(longEmaValue).multipliedBy(numOf(100));
+        return shortEmaValue.minus(longEmaValue).divide(longEmaValue).multiply(numOf(100));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -119,7 +119,7 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
 
         Num priorSar = getValue(index - 1);
         if (currentTrend) { // if up trend
-            sar = priorSar.plus(accelerationFactor.multipliedBy((currentExtremePoint.minus(priorSar))));
+            sar = priorSar.plus(accelerationFactor.multiply((currentExtremePoint.minus(priorSar))));
             currentTrend = lowPriceIndicator.getValue(index).isGreaterThan(sar);
             if (!currentTrend) { // check if sar touches the low price
                 if (minMaxExtremePoint.isGreaterThan(highPriceIndicator.getValue(index)))
@@ -145,7 +145,7 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
 
             }
         } else { // downtrend
-            sar = priorSar.minus(accelerationFactor.multipliedBy(((priorSar.minus(currentExtremePoint)))));
+            sar = priorSar.minus(accelerationFactor.multiply(((priorSar.minus(currentExtremePoint)))));
             currentTrend = highPriceIndicator.getValue(index).isGreaterThanOrEqual(sar);
             if (currentTrend) { // check if switch to up trend
                 if (minMaxExtremePoint.isLessThan(lowPriceIndicator.getValue(index)))

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
@@ -53,6 +53,6 @@ public class RAVIIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         Num shortMA = shortSma.getValue(index);
         Num longMA = longSma.getValue(index);
-        return shortMA.minus(longMA).dividedBy(longMA).multipliedBy(numOf(100));
+        return shortMA.minus(longMA).divide(longMA).multiply(numOf(100));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
@@ -57,7 +57,7 @@ public class ROCIndicator extends CachedIndicator<Num> {
         int nIndex = Math.max(index - barCount, 0);
         Num nPeriodsAgoValue = indicator.getValue(nIndex);
         Num currentValue = indicator.getValue(index);
-        return currentValue.minus(nPeriodsAgoValue).dividedBy(nPeriodsAgoValue).multipliedBy(numOf(100));
+        return currentValue.minus(nPeriodsAgoValue).divide(nPeriodsAgoValue).multiply(numOf(100));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
@@ -56,8 +56,8 @@ public class RSIIndicator extends CachedIndicator<Num> {
                 return numOf(100);
             }
         }
-        Num relativeStrength = averageGain.dividedBy(averageLoss);
+        Num relativeStrength = averageGain.divide(averageLoss);
         // compute relative strength index
-        return numOf(100).minus(numOf(100).dividedBy(numOf(1).plus(relativeStrength)));
+        return numOf(100).minus(numOf(100).divide(numOf(1).plus(relativeStrength)));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
@@ -70,7 +70,7 @@ public class RWIHighIndicator extends CachedIndicator<Num> {
         Num atrN = new ATRIndicator(series, n).getValue(index);
         Num sqrtN = numOf(n).sqrt();
 
-        return high.minus(lowN).dividedBy(atrN.multipliedBy(sqrtN));
+        return high.minus(lowN).divide(atrN.multiply(sqrtN));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
@@ -70,7 +70,7 @@ public class RWILowIndicator extends CachedIndicator<Num> {
         Num atrN = new ATRIndicator(series, n).getValue(index);
         Num sqrtN = numOf(n).sqrt();
 
-        return highN.minus(low).dividedBy(atrN.multipliedBy(sqrtN));
+        return highN.minus(low).divide(atrN.multiply(sqrtN));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -52,7 +52,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
         }
 
         final int realBarCount = Math.min(barCount, index + 1);
-        return sum.dividedBy(numOf(realBarCount));
+        return sum.divide(numOf(realBarCount));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -73,8 +73,8 @@ public class StochasticOscillatorKIndicator extends CachedIndicator<Num> {
 
         return indicator.getValue(index)
                 .minus(lowestLowPrice)
-                .dividedBy(highestHighPrice.minus(lowestLowPrice))
-                .multipliedBy(numOf(100));
+                .divide(highestHighPrice.minus(lowestLowPrice))
+                .multiply(numOf(100));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
@@ -78,7 +78,7 @@ public class StochasticRSIIndicator extends CachedIndicator<Num> {
     @Override
     protected Num calculate(int index) {
         Num minRsiValue = minRsi.getValue(index);
-        return rsi.getValue(index).minus(minRsiValue).dividedBy(maxRsi.getValue(index).minus(minRsiValue));
+        return rsi.getValue(index).minus(minRsiValue).divide(maxRsi.getValue(index).minus(minRsiValue));
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
@@ -63,7 +63,7 @@ public class TripleEMAIndicator extends CachedIndicator<Num> {
     @Override
     protected Num calculate(int index) {
         // trix = 3 * ( ema - emaEma ) + emaEmaEma
-        return numOf(3).multipliedBy(ema.getValue(index).minus(emaEma.getValue(index))).plus(emaEmaEma.getValue(index));
+        return numOf(3).multiply(ema.getValue(index).minus(emaEma.getValue(index))).plus(emaEmaEma.getValue(index));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -65,10 +65,10 @@ public class UlcerIndexIndicator extends CachedIndicator<Num> {
         for (int i = startIndex; i <= index; i++) {
             Num currentValue = indicator.getValue(i);
             Num highestValue = highestValueInd.getValue(i);
-            Num percentageDrawdown = currentValue.minus(highestValue).dividedBy(highestValue).multipliedBy(numOf(100));
+            Num percentageDrawdown = currentValue.minus(highestValue).divide(highestValue).multiply(numOf(100));
             squaredAverage = squaredAverage.plus(percentageDrawdown.pow(2));
         }
-        squaredAverage = squaredAverage.dividedBy(numOf(numberOfObservations));
+        squaredAverage = squaredAverage.divide(numOf(numberOfObservations));
         return squaredAverage.sqrt();
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
@@ -50,11 +50,11 @@ public class WMAIndicator extends CachedIndicator<Num> {
         int loopLength = (index - barCount < 0) ? index + 1 : barCount;
         int actualIndex = index;
         for (int i = loopLength; i > 0; i--) {
-            value = value.plus(numOf(i).multipliedBy(indicator.getValue(actualIndex)));
+            value = value.plus(numOf(i).multiply(indicator.getValue(actualIndex)));
             actualIndex--;
         }
 
-        return value.dividedBy(numOf((loopLength * (loopLength + 1)) / 2));
+        return value.divide(numOf((loopLength * (loopLength + 1)) / 2));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
@@ -71,7 +71,7 @@ public class WilliamsRIndicator extends CachedIndicator<Num> {
         Num lowestLowPrice = lowestMin.getValue(index);
 
         return ((highestHighPrice.minus(closePriceIndicator.getValue(index)))
-                .dividedBy(highestHighPrice.minus(lowestLowPrice))).multipliedBy(multiplier);
+                .divide(highestHighPrice.minus(lowestLowPrice))).multiply(multiplier);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
@@ -44,7 +44,7 @@ public class ZLEMAIndicator extends RecursiveCachedIndicator<Num> {
         super(indicator);
         this.indicator = indicator;
         this.barCount = barCount;
-        k = numOf(2).dividedBy(numOf(barCount + 1));
+        k = numOf(2).divide(numOf(barCount + 1));
         lag = (barCount - 1) / 2;
     }
 
@@ -59,8 +59,8 @@ public class ZLEMAIndicator extends RecursiveCachedIndicator<Num> {
             return indicator.getValue(0);
         }
         Num zlemaPrev = getValue(index - 1);
-        return k.multipliedBy(numOf(2).multipliedBy(indicator.getValue(index)).minus(indicator.getValue(index - lag)))
-                .plus(numOf(1).minus(k).multipliedBy(zlemaPrev));
+        return k.multiply(numOf(2).multiply(indicator.getValue(index)).minus(indicator.getValue(index - lag)))
+                .plus(numOf(1).minus(k).multiply(zlemaPrev));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -50,7 +50,7 @@ public class DXIndicator extends CachedIndicator<Num> {
         if (pdiValue.plus(mdiValue).equals(numOf(0))) {
             return numOf(0);
         }
-        return pdiValue.minus(mdiValue).abs().dividedBy(pdiValue.plus(mdiValue)).multipliedBy(numOf(100));
+        return pdiValue.minus(mdiValue).abs().divide(pdiValue.plus(mdiValue)).multiply(numOf(100));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -53,7 +53,7 @@ public class MinusDIIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return avgMinusDMIndicator.getValue(index).dividedBy(atrIndicator.getValue(index)).multipliedBy(numOf(100));
+        return avgMinusDMIndicator.getValue(index).divide(atrIndicator.getValue(index)).multiply(numOf(100));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -53,7 +53,7 @@ public class PlusDIIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return avgPlusDMIndicator.getValue(index).dividedBy(atrIndicator.getValue(index)).multipliedBy(numOf(100));
+        return avgPlusDMIndicator.getValue(index).divide(atrIndicator.getValue(index)).multiply(numOf(100));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
@@ -58,6 +58,6 @@ public class BollingerBandWidthIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return bbu.getValue(index).minus(bbl.getValue(index)).dividedBy(bbm.getValue(index)).multipliedBy(hundred);
+        return bbu.getValue(index).minus(bbl.getValue(index)).divide(bbm.getValue(index)).multiply(hundred);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
@@ -70,7 +70,7 @@ public class BollingerBandsLowerIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return bbm.getValue(index).minus(indicator.getValue(index).multipliedBy(k));
+        return bbm.getValue(index).minus(indicator.getValue(index).multiply(k));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
@@ -72,7 +72,7 @@ public class BollingerBandsUpperIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return bbm.getValue(index).plus(deviation.getValue(index).multipliedBy(k));
+        return bbm.getValue(index).plus(deviation.getValue(index).multiply(k));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
@@ -65,6 +65,6 @@ public class PercentBIndicator extends CachedIndicator<Num> {
         Num value = indicator.getValue(index);
         Num upValue = bbu.getValue(index);
         Num lowValue = bbl.getValue(index);
-        return value.minus(lowValue).dividedBy(upValue.minus(lowValue));
+        return value.minus(lowValue).divide(upValue.minus(lowValue));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
@@ -77,6 +77,6 @@ public class DojiIndicator extends CachedIndicator<Boolean> {
         Num averageBodyHeight = averageBodyHeightInd.getValue(index - 1);
         Num currentBodyHeight = bodyHeightInd.getValue(index);
 
-        return currentBodyHeight.isLessThan(averageBodyHeight.multipliedBy(factor));
+        return currentBodyHeight.isLessThan(averageBodyHeight.multiply(factor));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
@@ -87,7 +87,7 @@ public class ThreeBlackCrowsIndicator extends CachedIndicator<Boolean> {
         // We use the white candle index to remove to bias of the previous crows
         Num averageLowerShadow = averageLowerShadowInd.getValue(whiteCandleIndex);
 
-        return currentLowerShadow.isLessThan(averageLowerShadow.multipliedBy(factor));
+        return currentLowerShadow.isLessThan(averageLowerShadow.multiply(factor));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
@@ -87,7 +87,7 @@ public class ThreeWhiteSoldiersIndicator extends CachedIndicator<Boolean> {
         // We use the black candle index to remove to bias of the previous soldiers
         Num averageUpperShadow = averageUpperShadowInd.getValue(blackCandleIndex);
 
-        return currentUpperShadow.isLessThan(averageUpperShadow.multipliedBy(factor));
+        return currentUpperShadow.isLessThan(averageUpperShadow.multiply(factor));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -51,6 +51,6 @@ public class CloseLocationValueIndicator extends CachedIndicator<Num> {
 
         final Num diffHighLow = high.minus(low);
 
-        return diffHighLow.isNaN() ? zero : ((close.minus(low)).minus(high.minus(close))).dividedBy(diffHighLow);
+        return diffHighLow.isNaN() ? zero : ((close.minus(low)).minus(high.minus(close))).divide(diffHighLow);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
@@ -83,7 +83,7 @@ public class CombineIndicator extends CachedIndicator<Num> {
      * Combines the two input indicators by indicatorLeft.dividedBy(indicatorRight).
      */
     public static CombineIndicator divide(Indicator<Num> indicatorLeft, Indicator<Num> indicatorRight) {
-        return new CombineIndicator(indicatorLeft, indicatorRight, Num::dividedBy);
+        return new CombineIndicator(indicatorLeft, indicatorRight, Num::divide);
     }
 
     /**
@@ -91,7 +91,7 @@ public class CombineIndicator extends CachedIndicator<Num> {
      * indicatorLeft.multipliedBy(indicatorRight).
      */
     public static CombineIndicator multiply(Indicator<Num> indicatorLeft, Indicator<Num> indicatorRight) {
-        return new CombineIndicator(indicatorLeft, indicatorRight, Num::multipliedBy);
+        return new CombineIndicator(indicatorLeft, indicatorRight, Num::multiply);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -326,7 +326,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
         boolean isConvergent = cc.getValue(index).isGreaterThanOrEqual(minStrength);
 
         Num slope = calculateSlopeRel(index);
-        boolean isNegative = slope.isLessThanOrEqual(minSlope.abs().multipliedBy(numOf(-1)));
+        boolean isNegative = slope.isLessThanOrEqual(minSlope.abs().multiply(numOf(-1)));
 
         return isConvergent && isNegative;
     }
@@ -338,7 +338,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
     private Boolean calculatePositiveDivergence(int index) {
 
         CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
+        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multiply(numOf(-1)));
 
         if (isDivergent) {
             // If "isDivergent" and "ref" is positive, then "other" must be negative.
@@ -356,12 +356,12 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
     private Boolean calculateNegativeDivergence(int index) {
 
         CorrelationCoefficientIndicator cc = new CorrelationCoefficientIndicator(ref, other, barCount);
-        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multipliedBy(numOf(-1)));
+        boolean isDivergent = cc.getValue(index).isLessThanOrEqual(minStrength.multiply(numOf(-1)));
 
         if (isDivergent) {
             // If "isDivergent" and "ref" is positive, then "other" must be negative.
             Num slope = calculateSlopeRel(index);
-            return slope.isLessThanOrEqual(minSlope.abs().multipliedBy(numOf(-1)));
+            return slope.isLessThanOrEqual(minSlope.abs().multiply(numOf(-1)));
         }
 
         return false;
@@ -374,7 +374,7 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
     private Num calculateSlopeRel(int index) {
         SimpleLinearRegressionIndicator slrRef = new SimpleLinearRegressionIndicator(ref, barCount);
         int firstIndex = Math.max(0, index - barCount + 1);
-        return (slrRef.getValue(index).minus(slrRef.getValue(firstIndex))).dividedBy(slrRef.getValue(index));
+        return (slrRef.getValue(index).minus(slrRef.getValue(firstIndex))).divide(slrRef.getValue(index));
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
@@ -68,7 +68,7 @@ public class DifferencePercentageIndicator extends CachedIndicator<Num> {
             return NaN.NaN;
         }
 
-        Num changeFraction = value.dividedBy(lastNotification);
+        Num changeFraction = value.divide(lastNotification);
         Num changePercentage = fractionToPercentage(changeFraction);
 
         if (changePercentage.abs().isGreaterThanOrEqual(percentageThreshold)) {
@@ -79,6 +79,6 @@ public class DifferencePercentageIndicator extends CachedIndicator<Num> {
     }
 
     private Num fractionToPercentage(Num changeFraction) {
-        return changeFraction.multipliedBy(hundred).minus(hundred);
+        return changeFraction.multiply(hundred).minus(hundred);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
@@ -40,6 +40,6 @@ public class MedianPriceIndicator extends CachedIndicator<Num> {
     @Override
     protected Num calculate(int index) {
         final Bar bar = getBarSeries().getBar(index);
-        return bar.getHighPrice().plus(bar.getLowPrice()).dividedBy(numOf(2));
+        return bar.getHighPrice().plus(bar.getLowPrice()).divide(numOf(2));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PriceVariationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PriceVariationIndicator.java
@@ -40,6 +40,6 @@ public class PriceVariationIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         Num previousBarClosePrice = getBarSeries().getBar(Math.max(0, index - 1)).getClosePrice();
         Num currentBarClosePrice = getBarSeries().getBar(index).getClosePrice();
-        return currentBarClosePrice.dividedBy(previousBarClosePrice);
+        return currentBarClosePrice.divide(previousBarClosePrice);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -82,7 +82,7 @@ public class TransformIndicator extends CachedIndicator<Num> {
      */
     public static TransformIndicator divide(Indicator<Num> indicator, Number coefficient) {
         Num numCoefficient = indicator.numOf(coefficient);
-        return new TransformIndicator(indicator, val -> val.dividedBy(numCoefficient));
+        return new TransformIndicator(indicator, val -> val.divide(numCoefficient));
     }
 
     /**
@@ -90,7 +90,7 @@ public class TransformIndicator extends CachedIndicator<Num> {
      */
     public static TransformIndicator multiply(Indicator<Num> indicator, Number coefficient) {
         Num numCoefficient = indicator.numOf(coefficient);
-        return new TransformIndicator(indicator, val -> val.multipliedBy(numCoefficient));
+        return new TransformIndicator(indicator, val -> val.multiply(numCoefficient));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
@@ -43,6 +43,6 @@ public class TypicalPriceIndicator extends CachedIndicator<Num> {
         final Num highPrice = bar.getHighPrice();
         final Num lowPrice = bar.getLowPrice();
         final Num closePrice = bar.getClosePrice();
-        return highPrice.plus(lowPrice).plus(closePrice).dividedBy(numOf(3));
+        return highPrice.plus(lowPrice).plus(closePrice).divide(numOf(3));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
@@ -61,6 +61,6 @@ public class IchimokuLineIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return periodHigh.getValue(index).plus(periodLow.getValue(index)).dividedBy(numOf(2));
+        return periodHigh.getValue(index).plus(periodLow.getValue(index)).divide(numOf(2));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
@@ -91,7 +91,7 @@ public class IchimokuSenkouSpanAIndicator extends CachedIndicator<Num> {
         // at index=7 we need index=3 when offset=5
         int spanIndex = index - offset + 1;
         if (spanIndex >= getBarSeries().getBeginIndex()) {
-            return conversionLine.getValue(spanIndex).plus(baseLine.getValue(spanIndex)).dividedBy(numOf(2));
+            return conversionLine.getValue(spanIndex).plus(baseLine.getValue(spanIndex)).divide(numOf(2));
         } else {
             return NaN.NaN;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -55,8 +55,7 @@ public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return keltnerMiddleIndicator.getValue(index)
-                .minus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
+        return keltnerMiddleIndicator.getValue(index).minus(ratio.multiply(averageTrueRangeIndicator.getValue(index)));
     }
 
     public int getBarCount() {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -55,8 +55,7 @@ public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        return keltnerMiddleIndicator.getValue(index)
-                .plus(ratio.multipliedBy(averageTrueRangeIndicator.getValue(index)));
+        return keltnerMiddleIndicator.getValue(index).plus(ratio.multiply(averageTrueRangeIndicator.getValue(index)));
     }
 
     public int getBarCount() {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
@@ -104,14 +104,14 @@ public class DeMarkPivotPointIndicator extends RecursiveCachedIndicator<Num> {
 
         Num x;
         if (close.isLessThan(open)) {
-            x = high.plus(two.multipliedBy(low)).plus(close);
+            x = high.plus(two.multiply(low)).plus(close);
         } else if (close.isGreaterThan(open)) {
-            x = two.multipliedBy(high).plus(low).plus(close);
+            x = two.multiply(high).plus(low).plus(close);
         } else {
-            x = high.plus(low).plus(two.multipliedBy(close));
+            x = high.plus(low).plus(two.multiply(close));
         }
 
-        return x.dividedBy(numOf(4));
+        return x.divide(numOf(4));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
@@ -67,7 +67,7 @@ public class DeMarkReversalIndicator extends RecursiveCachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        Num x = pivotPointIndicator.getValue(index).multipliedBy(numOf(4));
+        Num x = pivotPointIndicator.getValue(index).multiply(numOf(4));
         Num result;
 
         if (level == DeMarkPivotLevel.SUPPORT) {
@@ -91,7 +91,7 @@ public class DeMarkReversalIndicator extends RecursiveCachedIndicator<Num> {
             low = getBarSeries().getBar(i).getLowPrice().min(low);
         }
 
-        return x.dividedBy(two).minus(low);
+        return x.divide(two).minus(low);
     }
 
     private Num calculateSupport(Num x, int index) {
@@ -105,6 +105,6 @@ public class DeMarkReversalIndicator extends RecursiveCachedIndicator<Num> {
             high = getBarSeries().getBar(i).getHighPrice().max(high);
         }
 
-        return x.dividedBy(two).minus(high);
+        return x.divide(two).minus(high);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
@@ -114,8 +114,8 @@ public class FibonacciReversalIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         if (fibReversalTyp == FibReversalTyp.RESISTANCE) {
-            return pivotPointIndicator.getValue(index).plus(fibonacciFactor.multipliedBy(high.minus(low)));
+            return pivotPointIndicator.getValue(index).plus(fibonacciFactor.multiply(high.minus(low)));
         }
-        return pivotPointIndicator.getValue(index).minus(fibonacciFactor.multipliedBy(high.minus(low)));
+        return pivotPointIndicator.getValue(index).minus(fibonacciFactor.multiply(high.minus(low)));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
@@ -94,7 +94,7 @@ public class PivotPointIndicator extends RecursiveCachedIndicator<Num> {
             high = (getBarSeries().getBar(i).getHighPrice()).max(high);
             low = (getBarSeries().getBar(i).getLowPrice()).min(low);
         }
-        return (high.plus(low).plus(close)).dividedBy(numOf(3));
+        return (high.plus(low).plus(close)).divide(numOf(3));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
@@ -90,7 +90,7 @@ public class StandardReversalIndicator extends RecursiveCachedIndicator<Num> {
             low = (getBarSeries().getBar(i).getLowPrice()).min(low);
             high = (getBarSeries().getBar(i).getHighPrice()).max(high);
         }
-        return high.plus(numOf(2).multipliedBy((pivotPointIndicator.getValue(index).minus(low))));
+        return high.plus(numOf(2).multiply((pivotPointIndicator.getValue(index).minus(low))));
     }
 
     private Num calculateR2(List<Integer> barsOfPreviousPeriod, int index) {
@@ -109,7 +109,7 @@ public class StandardReversalIndicator extends RecursiveCachedIndicator<Num> {
         for (int i : barsOfPreviousPeriod) {
             low = (getBarSeries().getBar(i).getLowPrice()).min(low);
         }
-        return numOf(2).multipliedBy(pivotPointIndicator.getValue(index)).minus(low);
+        return numOf(2).multiply(pivotPointIndicator.getValue(index)).minus(low);
     }
 
     private Num calculateS1(List<Integer> barsOfPreviousPeriod, int index) {
@@ -117,7 +117,7 @@ public class StandardReversalIndicator extends RecursiveCachedIndicator<Num> {
         for (int i : barsOfPreviousPeriod) {
             high = (getBarSeries().getBar(i).getHighPrice()).max(high);
         }
-        return numOf(2).multipliedBy(pivotPointIndicator.getValue(index)).minus(high);
+        return numOf(2).multiply(pivotPointIndicator.getValue(index)).minus(high);
     }
 
     private Num calculateS2(List<Integer> barsOfPreviousPeriod, int index) {
@@ -139,6 +139,6 @@ public class StandardReversalIndicator extends RecursiveCachedIndicator<Num> {
             high = (getBarSeries().getBar(i).getHighPrice()).max(high);
             low = (getBarSeries().getBar(i).getLowPrice()).min(low);
         }
-        return low.minus(numOf(2).multipliedBy((high.minus(pivotPointIndicator.getValue(index)))));
+        return low.minus(numOf(2).multiply((high.minus(pivotPointIndicator.getValue(index)))));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
@@ -59,8 +59,8 @@ public class CorrelationCoefficientIndicator extends CachedIndicator<Num> {
         Num cov = covariance.getValue(index);
         Num var1 = variance1.getValue(index);
         Num var2 = variance2.getValue(index);
-        Num multipliedSqrt = var1.multipliedBy(var2).sqrt();
-        return cov.dividedBy(multipliedSqrt);
+        Num multipliedSqrt = var1.multiply(var2).sqrt();
+        return cov.divide(multipliedSqrt);
 
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
@@ -63,10 +63,10 @@ public class CovarianceIndicator extends CachedIndicator<Num> {
         Num average1 = sma1.getValue(index);
         Num average2 = sma2.getValue(index);
         for (int i = startIndex; i <= index; i++) {
-            Num mul = indicator1.getValue(i).minus(average1).multipliedBy(indicator2.getValue(i).minus(average2));
+            Num mul = indicator1.getValue(i).minus(average1).multiply(indicator2.getValue(i).minus(average2));
             covariance = covariance.plus(mul);
         }
-        covariance = covariance.dividedBy(numOf(numberOfObservations));
+        covariance = covariance.divide(numOf(numberOfObservations));
         return covariance;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
@@ -66,7 +66,7 @@ public class MeanDeviationIndicator extends CachedIndicator<Num> {
             // For each period...
             absoluteDeviations = absoluteDeviations.plus(indicator.getValue(i).minus(average).abs());
         }
-        return absoluteDeviations.dividedBy(numOf(nbValues));
+        return absoluteDeviations.divide(numOf(nbValues));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -74,19 +74,18 @@ public class PearsonCorrelationIndicator extends RecursiveCachedIndicator<Num> {
 
             Sx = Sx.plus(x);
             Sy = Sy.plus(y);
-            Sxy = Sxy.plus(x.multipliedBy(y));
-            Sxx = Sxx.plus(x.multipliedBy(x));
-            Syy = Syy.plus(y.multipliedBy(y));
+            Sxy = Sxy.plus(x.multiply(y));
+            Sxx = Sxx.plus(x.multiply(x));
+            Syy = Syy.plus(y.multiply(y));
         }
 
         // (n * Sxx - Sx * Sx) * (n * Syy - Sy * Sy)
-        Num toSqrt = (n.multipliedBy(Sxx).minus(Sx.multipliedBy(Sx)))
-                .multipliedBy(n.multipliedBy(Syy).minus(Sy.multipliedBy(Sy)));
+        Num toSqrt = (n.multiply(Sxx).minus(Sx.multiply(Sx))).multiply(n.multiply(Syy).minus(Sy.multiply(Sy)));
 
         if (toSqrt.isGreaterThan(numOf(0))) {
             // pearson = (n * Sxy - Sx * Sy) / sqrt((n * Sxx - Sx * Sx) * (n * Syy - Sy *
             // Sy))
-            return (n.multipliedBy(Sxy).minus(Sx.multipliedBy(Sy))).dividedBy(toSqrt.sqrt());
+            return (n.multiply(Sxy).minus(Sx.multiply(Sy))).divide(toSqrt.sqrt());
         }
 
         return NaN;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
@@ -97,11 +97,11 @@ public class PeriodicalGrowthRateIndicator extends CachedIndicator<Num> {
             // Skip NaN at the end of a series
             if (currentReturn != NaN) {
                 currentReturn = currentReturn.plus(one);
-                totalProduct = totalProduct.multipliedBy(currentReturn);
+                totalProduct = totalProduct.multiply(currentReturn);
             }
         }
 
-        return totalProduct.pow(one.dividedBy(numOf(completeTimeFrames)));
+        return totalProduct.pow(one.divide(numOf(completeTimeFrames)));
     }
 
     @Override
@@ -112,10 +112,10 @@ public class PeriodicalGrowthRateIndicator extends CachedIndicator<Num> {
         int helpPartialTimeframe = index % barCount;
         // TODO: implement Num.floor()
         Num helpFullTimeframes = numOf(
-                Math.floor(numOf(indicator.getBarSeries().getBarCount()).dividedBy(numOf(barCount)).doubleValue()));
-        Num helpIndexTimeframes = numOf(index).dividedBy(numOf(barCount));
+                Math.floor(numOf(indicator.getBarSeries().getBarCount()).divide(numOf(barCount)).doubleValue()));
+        Num helpIndexTimeframes = numOf(index).divide(numOf(barCount));
 
-        Num helpPartialTimeframeHeld = numOf(helpPartialTimeframe).dividedBy(numOf(barCount));
+        Num helpPartialTimeframeHeld = numOf(helpPartialTimeframe).divide(numOf(barCount));
         Num partialTimeframeHeld = (helpPartialTimeframeHeld.isZero()) ? one : helpPartialTimeframeHeld;
 
         // Avoid calculations of returns:
@@ -125,9 +125,9 @@ public class PeriodicalGrowthRateIndicator extends CachedIndicator<Num> {
         Num timeframedReturn = NaN;
         if ((index >= barCount) /* (a) */ && (helpIndexTimeframes.isLessThan(helpFullTimeframes)) /* (b) */) {
             Num movingValue = indicator.getValue(index - barCount);
-            Num movingSimpleReturn = (currentValue.minus(movingValue)).dividedBy(movingValue);
+            Num movingSimpleReturn = (currentValue.minus(movingValue)).divide(movingValue);
 
-            timeframedReturn = one.plus(movingSimpleReturn).pow(one.dividedBy(partialTimeframeHeld)).minus(one);
+            timeframedReturn = one.plus(movingSimpleReturn).pow(one.divide(partialTimeframeHeld)).minus(one);
         }
 
         return timeframedReturn;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
@@ -58,7 +58,7 @@ public class SigmaIndicator extends CachedIndicator<Num> {
     @Override
     protected Num calculate(int index) {
         // z-score = (ref - mean) / sd
-        return (ref.getValue(index).minus(mean.getValue(index))).dividedBy(sd.getValue(index));
+        return (ref.getValue(index).minus(mean.getValue(index))).divide(sd.getValue(index));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
@@ -92,7 +92,7 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Num> {
             return intercept;
         }
 
-        return slope.multipliedBy(numOf(index)).plus(intercept);
+        return slope.multiply(numOf(index)).plus(intercept);
     }
 
     /**
@@ -110,8 +110,8 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Num> {
             sumY = sumY.plus(indicator.getValue(i));
         }
         Num nbObservations = numOf(endIndex - startIndex + 1);
-        Num xBar = sumX.dividedBy(nbObservations);
-        Num yBar = sumY.dividedBy(nbObservations);
+        Num xBar = sumX.divide(nbObservations);
+        Num yBar = sumY.divide(nbObservations);
 
         // Second pass: compute slope and intercept
         Num xxBar = numOf(0);
@@ -119,11 +119,11 @@ public class SimpleLinearRegressionIndicator extends CachedIndicator<Num> {
         for (int i = startIndex; i <= endIndex; i++) {
             Num dX = numOf(i).minus(xBar);
             Num dY = indicator.getValue(i).minus(yBar);
-            xxBar = xxBar.plus(dX.multipliedBy(dX));
-            xyBar = xyBar.plus(dX.multipliedBy(dY));
+            xxBar = xxBar.plus(dX.multiply(dX));
+            xyBar = xyBar.plus(dX.multiply(dY));
         }
 
-        slope = xyBar.dividedBy(xxBar);
-        intercept = yBar.minus(slope.multipliedBy(xBar));
+        slope = xyBar.divide(xxBar);
+        intercept = yBar.minus(slope.multiply(xBar));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
@@ -52,6 +52,6 @@ public class StandardErrorIndicator extends CachedIndicator<Num> {
     protected Num calculate(int index) {
         final int startIndex = Math.max(0, index - barCount + 1);
         final int numberOfObservations = index - startIndex + 1;
-        return sdev.getValue(index).dividedBy(numOf(numberOfObservations).sqrt());
+        return sdev.getValue(index).divide(numOf(numberOfObservations).sqrt());
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
@@ -60,7 +60,7 @@ public class VarianceIndicator extends CachedIndicator<Num> {
             Num pow = indicator.getValue(i).minus(average).pow(2);
             variance = variance.plus(pow);
         }
-        variance = variance.dividedBy(numOf(numberOfObservations));
+        variance = variance.divide(numOf(numberOfObservations));
         return variance;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
@@ -50,7 +50,7 @@ public class AccumulationDistributionIndicator extends RecursiveCachedIndicator<
         Num moneyFlowMultiplier = clvIndicator.getValue(index);
 
         // Calculating the money flow volume
-        Num moneyFlowVolume = moneyFlowMultiplier.multipliedBy(getBarSeries().getBar(index).getVolume());
+        Num moneyFlowVolume = moneyFlowMultiplier.multiply(getBarSeries().getBar(index).getVolume());
 
         return moneyFlowVolume.plus(getValue(index - 1));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
@@ -61,7 +61,7 @@ public class ChaikinMoneyFlowIndicator extends CachedIndicator<Num> {
         }
         Num sumOfVolume = volumeIndicator.getValue(index);
 
-        return sumOfMoneyFlowVolume.dividedBy(sumOfVolume);
+        return sumOfMoneyFlowVolume.divide(sumOfVolume);
     }
 
     /**
@@ -69,7 +69,7 @@ public class ChaikinMoneyFlowIndicator extends CachedIndicator<Num> {
      * @return the money flow volume for the i-th period/bar
      */
     private Num getMoneyFlowVolume(int index) {
-        return clvIndicator.getValue(index).multipliedBy(getBarSeries().getBar(index).getVolume());
+        return clvIndicator.getValue(index).multiply(getBarSeries().getBar(index).getVolume());
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -59,13 +59,12 @@ public class IIIIndicator extends CachedIndicator<Num> {
         if (index == getBarSeries().getBeginIndex()) {
             return numOf(0);
         }
-        final Num doubledClosePrice = two.multipliedBy(closePriceIndicator.getValue(index));
+        final Num doubledClosePrice = two.multiply(closePriceIndicator.getValue(index));
         final Num high = highPriceIndicator.getValue(index);
         final Num low = lowPriceIndicator.getValue(index);
         final Num highMinusLow = high.minus(low);
         final Num highPlusLow = high.plus(low);
 
-        return doubledClosePrice.minus(highPlusLow)
-                .dividedBy(highMinusLow.multipliedBy(volumeIndicator.getValue(index)));
+        return doubledClosePrice.minus(highPlusLow).divide(highMinusLow.multiply(volumeIndicator.getValue(index)));
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
@@ -59,8 +59,8 @@ public class NVIIndicator extends RecursiveCachedIndicator<Num> {
         if (currentBar.getVolume().isLessThan(previousBar.getVolume())) {
             Num currentPrice = currentBar.getClosePrice();
             Num previousPrice = previousBar.getClosePrice();
-            Num priceChangeRatio = currentPrice.minus(previousPrice).dividedBy(previousPrice);
-            return previousValue.plus(priceChangeRatio.multipliedBy(previousValue));
+            Num priceChangeRatio = currentPrice.minus(previousPrice).divide(previousPrice);
+            return previousValue.plus(priceChangeRatio.multiply(previousValue));
         }
         return previousValue;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
@@ -56,8 +56,8 @@ public class PVIIndicator extends RecursiveCachedIndicator<Num> {
         if (currentBar.getVolume().isGreaterThan(previousBar.getVolume())) {
             Num currentPrice = currentBar.getClosePrice();
             Num previousPrice = previousBar.getClosePrice();
-            Num priceChangeRatio = currentPrice.minus(previousPrice).dividedBy(previousPrice);
-            return previousValue.plus(priceChangeRatio.multipliedBy(previousValue));
+            Num priceChangeRatio = currentPrice.minus(previousPrice).divide(previousPrice);
+            return previousValue.plus(priceChangeRatio.multiply(previousValue));
         }
         return previousValue;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
@@ -55,7 +55,7 @@ public class ROCVIndicator extends CachedIndicator<Num> {
         int nIndex = Math.max(index - barCount, 0);
         Num nPeriodsAgoValue = getBarSeries().getBar(nIndex).getVolume();
         Num currentValue = getBarSeries().getBar(index).getVolume();
-        return currentValue.minus(nPeriodsAgoValue).dividedBy(nPeriodsAgoValue).multipliedBy(hundred);
+        return currentValue.minus(nPeriodsAgoValue).divide(nPeriodsAgoValue).multiply(hundred);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
@@ -73,10 +73,10 @@ public class VWAPIndicator extends CachedIndicator<Num> {
         Num cumulativeVolume = zero;
         for (int i = startIndex; i <= index; i++) {
             Num currentVolume = volume.getValue(i);
-            cumulativeTPV = cumulativeTPV.plus(typicalPrice.getValue(i).multipliedBy(currentVolume));
+            cumulativeTPV = cumulativeTPV.plus(typicalPrice.getValue(i).multiply(currentVolume));
             cumulativeVolume = cumulativeVolume.plus(currentVolume);
         }
-        return cumulativeTPV.dividedBy(cumulativeVolume);
+        return cumulativeTPV.divide(cumulativeVolume);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -332,7 +332,7 @@ public final class DecimalNum implements Num {
      * @see BigDecimal#multiply(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
-    public Num multipliedBy(Num multiplicand) {
+    public Num multiply(Num multiplicand) {
         if (multiplicand.isNaN()) {
             return NaN;
         }
@@ -351,7 +351,7 @@ public final class DecimalNum implements Num {
      * @see BigDecimal#divide(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
-    public Num dividedBy(Num divisor) {
+    public Num divide(Num divisor) {
         if (divisor.isNaN() || divisor.isZero()) {
             return NaN;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -111,12 +111,12 @@ public class DoubleNum implements Num {
     }
 
     @Override
-    public Num multipliedBy(Num multiplicand) {
+    public Num multiply(Num multiplicand) {
         return multiplicand.isNaN() ? NaN : new DoubleNum(delegate * ((DoubleNum) multiplicand).delegate);
     }
 
     @Override
-    public Num dividedBy(Num divisor) {
+    public Num divide(Num divisor) {
         if (divisor.isNaN() || divisor.isZero()) {
             return NaN;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -111,12 +111,12 @@ public class NaN implements Num {
     }
 
     @Override
-    public Num multipliedBy(Num multiplicand) {
+    public Num multiply(Num multiplicand) {
         return this;
     }
 
     @Override
-    public Num dividedBy(Num divisor) {
+    public Num divide(Num divisor) {
         return this;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -95,7 +95,7 @@ public interface Num extends Comparable<Num> {
      * @param multiplicand value to be multiplied by this {@code num}.
      * @return {@code this * multiplicand}, rounded as necessary
      */
-    Num multipliedBy(Num multiplicand);
+    Num multiply(Num multiplicand);
 
     /**
      * Returns a {@code num} whose value is {@code (this / divisor)},
@@ -103,7 +103,7 @@ public interface Num extends Comparable<Num> {
      * @param divisor value by which this {@code num} is to be divided.
      * @return {@code this / divisor}, rounded as necessary
      */
-    Num dividedBy(Num divisor);
+    Num divide(Num divisor);
 
     /**
      * Returns a {@code num} whose value is {@code (this % divisor)},

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -96,14 +96,14 @@ public class StopGainRule extends AbstractRule {
     }
 
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.plus(gainPercentage).divide(HUNDRED);
+        Num threshold = entryPrice.multiply(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 
     private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).divide(HUNDRED);
+        Num threshold = entryPrice.multiply(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -96,14 +96,14 @@ public class StopLossRule extends AbstractRule {
     }
 
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).divide(HUNDRED);
+        Num threshold = entryPrice.multiply(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).divide(HUNDRED);
+        Num threshold = entryPrice.multiply(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -102,8 +102,8 @@ public class TrailingStopLossRule extends AbstractRule {
         HighestValueIndicator highest = new HighestValueIndicator(priceIndicator,
                 getValueIndicatorBarCount(index, positionIndex));
         Num highestCloseNum = highest.getValue(index);
-        Num lossRatioThreshold = highestCloseNum.numOf(100).minus(lossPercentage).dividedBy(highestCloseNum.numOf(100));
-        currentStopLossLimitActivation = highestCloseNum.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = highestCloseNum.numOf(100).minus(lossPercentage).divide(highestCloseNum.numOf(100));
+        currentStopLossLimitActivation = highestCloseNum.multiply(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(currentStopLossLimitActivation);
     }
 
@@ -115,8 +115,8 @@ public class TrailingStopLossRule extends AbstractRule {
         LowestValueIndicator lowest = new LowestValueIndicator(priceIndicator,
                 getValueIndicatorBarCount(index, positionIndex));
         Num lowestCloseNum = lowest.getValue(index);
-        Num lossRatioThreshold = lowestCloseNum.numOf(100).plus(lossPercentage).dividedBy(lowestCloseNum.numOf(100));
-        currentStopLossLimitActivation = lowestCloseNum.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = lowestCloseNum.numOf(100).plus(lossPercentage).divide(lowestCloseNum.numOf(100));
+        currentStopLossLimitActivation = lowestCloseNum.multiply(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(currentStopLossLimitActivation);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
@@ -144,7 +144,7 @@ public class ReturnsTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
         assertNumEquals(arithDouble, DoubleNum.valueOf(-0.08333333333333326));
         assertNumEquals(arithPrecision,
-                DecimalNum.valueOf(1.1).dividedBy(DecimalNum.valueOf(1.2)).minus(DecimalNum.valueOf(1)));
+                DecimalNum.valueOf(1.1).divide(DecimalNum.valueOf(1.2)).minus(DecimalNum.valueOf(1)));
 
         assertNumEquals(logDouble, DoubleNum.valueOf(-0.08701137698962969));
         assertNumEquals(logPrecision, DecimalNum.valueOf("-0.087011376989629766167765901873746"));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
@@ -156,13 +156,13 @@ public class LinearTransactionCostModelTest {
         Num amount = series.numOf(25);
         TradingStatement strategyResult = executor.execute(strategies, amount).get(0);
 
-        Num firstPositionBuy = one.plus(one.multipliedBy(orderFee));
-        Num firstPositionSell = two.minus(two.multipliedBy(orderFee));
-        Num firstPositionProfit = firstPositionSell.minus(firstPositionBuy).multipliedBy(amount);
+        Num firstPositionBuy = one.plus(one.multiply(orderFee));
+        Num firstPositionSell = two.minus(two.multiply(orderFee));
+        Num firstPositionProfit = firstPositionSell.minus(firstPositionBuy).multiply(amount);
 
-        Num secondPositionBuy = three.plus(three.multipliedBy(orderFee));
-        Num secondPositionSell = four.minus(four.multipliedBy(orderFee));
-        Num secondPositionProfit = secondPositionSell.minus(secondPositionBuy).multipliedBy(amount);
+        Num secondPositionBuy = three.plus(three.multiply(orderFee));
+        Num secondPositionSell = four.minus(four.multiply(orderFee));
+        Num secondPositionProfit = secondPositionSell.minus(secondPositionBuy).multiply(amount);
 
         Num overallProfit = firstPositionProfit.plus(secondPositionProfit);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -137,7 +137,7 @@ public class RSIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         Indicator<Num> avgLoss = new SMAIndicator(loss, 14);
 
         // first online calculation is simple division
-        double onlineRs = avgGain.getValue(14).dividedBy(avgLoss.getValue(14)).doubleValue();
+        double onlineRs = avgGain.getValue(14).divide(avgLoss.getValue(14)).doubleValue();
         assertEquals(0.5848, avgGain.getValue(14).doubleValue(), TestUtils.GENERAL_OFFSET);
         assertEquals(0.5446, avgLoss.getValue(14).doubleValue(), TestUtils.GENERAL_OFFSET);
         assertEquals(1.0738, onlineRs, TestUtils.GENERAL_OFFSET);
@@ -155,15 +155,15 @@ public class RSIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         // second online calculation uses MMAs
         // MMA of average gain
         double dividend = avgGain.getValue(14)
-                .multipliedBy(series.numOf(13))
+                .multiply(series.numOf(13))
                 .plus(gain.getValue(15))
-                .dividedBy(series.numOf(14))
+                .divide(series.numOf(14))
                 .doubleValue();
         // MMA of average loss
         double divisor = avgLoss.getValue(14)
-                .multipliedBy(series.numOf(13))
+                .multiply(series.numOf(13))
                 .plus(loss.getValue(15))
-                .dividedBy(series.numOf(14))
+                .divide(series.numOf(14))
                 .doubleValue();
         onlineRs = dividend / divisor;
         assertEquals(0.9409, onlineRs, TestUtils.GENERAL_OFFSET);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -74,7 +74,7 @@ public class MedianPriceIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
             result = barSeries.getBar(i)
                     .getHighPrice()
                     .plus(barSeries.getBar(i).getLowPrice())
-                    .dividedBy(barSeries.numOf(2));
+                    .divide(barSeries.numOf(2));
             assertEquals(average.getValue(i), result);
         }
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PriceVariationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PriceVariationIndicatorTest.java
@@ -58,7 +58,7 @@ public class PriceVariationIndicatorTest extends AbstractIndicatorTest<Indicator
         for (int i = 1; i < 10; i++) {
             Num previousBarClosePrice = barSeries.getBar(i - 1).getClosePrice();
             Num currentBarClosePrice = barSeries.getBar(i).getClosePrice();
-            assertEquals(variationIndicator.getValue(i), currentBarClosePrice.dividedBy(previousBarClosePrice));
+            assertEquals(variationIndicator.getValue(i), currentBarClosePrice.divide(previousBarClosePrice));
         }
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
@@ -59,7 +59,7 @@ public class TypicalPriceIndicatorTest extends AbstractIndicatorTest<Indicator<N
             Num typicalPrice = bar.getHighPrice()
                     .plus(bar.getLowPrice())
                     .plus(bar.getClosePrice())
-                    .dividedBy(barSeries.numOf(3));
+                    .divide(barSeries.numOf(3));
             assertEquals(typicalPrice, typicalPriceIndicator.getValue(i));
         }
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1390,30 +1390,26 @@ public class PivotPointIndicatorTest {
         assertEquals(fibS2.getValue(series1Hours.getBeginIndex()), NaN);
         assertEquals(fibS3.getValue(6), NaN);
 
-        assertEquals(fibR3.getValue(series1Hours.getEndIndex()),
-                pp.getValue(series1Hours.getEndIndex())
-                        .plus(series1Hours.numOf(1)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibR3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex())
+                .plus(series1Hours.numOf(1).multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
         assertEquals(fibR2.getValue(series1Hours.getEndIndex()),
                 pp.getValue(series1Hours.getEndIndex())
                         .plus(series1Hours.numOf(0.618)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+                                .multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
         assertEquals(fibR1.getValue(series1Hours.getEndIndex()),
                 pp.getValue(series1Hours.getEndIndex())
                         .plus(series1Hours.numOf(0.382)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+                                .multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
         assertEquals(fibS1.getValue(series1Hours.getEndIndex()),
                 pp.getValue(series1Hours.getEndIndex())
                         .minus(series1Hours.numOf(0.382)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+                                .multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
         assertEquals(fibS2.getValue(series1Hours.getEndIndex()),
                 pp.getValue(series1Hours.getEndIndex())
                         .minus(series1Hours.numOf(0.618)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
-        assertEquals(fibS3.getValue(series1Hours.getEndIndex()),
-                pp.getValue(series1Hours.getEndIndex())
-                        .minus(series1Hours.numOf(1)
-                                .multipliedBy(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+                                .multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
+        assertEquals(fibS3.getValue(series1Hours.getEndIndex()), pp.getValue(series1Hours.getEndIndex())
+                .minus(series1Hours.numOf(1).multiply(series1Hours.numOf(171.66).minus(series1Hours.numOf(161.56)))));
 
         DeMarkPivotPointIndicator deMarkpp = new DeMarkPivotPointIndicator(series1Hours, WEEK);
         DeMarkReversalIndicator deMarkR1 = new DeMarkReversalIndicator(deMarkpp,

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -153,13 +153,12 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
     public void testMultiplicationSymmetrically() {
         Num decimalFromString = numOf(new BigDecimal("0.33"));
         Num decimalFromDouble = numOf(45.33);
-        assertEquals(decimalFromString.multipliedBy(decimalFromDouble),
-                decimalFromDouble.multipliedBy(decimalFromString));
+        assertEquals(decimalFromString.multiply(decimalFromDouble), decimalFromDouble.multiply(decimalFromString));
 
         Num doubleNumFromString = numOf(new BigDecimal("0.33"));
         Num doubleNumFromDouble = numOf(10.33);
-        assertNumEquals(doubleNumFromString.multipliedBy(doubleNumFromDouble),
-                doubleNumFromDouble.multipliedBy(doubleNumFromString));
+        assertNumEquals(doubleNumFromString.multiply(doubleNumFromDouble),
+                doubleNumFromDouble.multiply(doubleNumFromString));
     }
 
     @Test(expected = java.lang.ClassCastException.class)
@@ -197,10 +196,10 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         mustBeNaN = a.minus(eleven);
         assertNumEquals(mustBeNaN, NaN);
 
-        mustBeNaN = a.dividedBy(a);
+        mustBeNaN = a.divide(a);
         assertNumEquals(mustBeNaN, NaN);
 
-        mustBeNaN = a.multipliedBy(NaN);
+        mustBeNaN = a.multiply(NaN);
         assertNumEquals(mustBeNaN, NaN);
 
         mustBeNaN = a.max(eleven);
@@ -235,13 +234,13 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
         Num zero = ten.minus(ten);
         assertNumEquals(0, zero);
 
-        Num hundred = ten.multipliedBy(ten);
+        Num hundred = ten.multiply(ten);
         assertNumEquals(100, hundred);
 
-        Num hundredMillion = hundred.multipliedBy(million);
+        Num hundredMillion = hundred.multiply(million);
         assertNumEquals(100000000, hundredMillion);
 
-        assertNumEquals(hundredMillion.dividedBy(hundred), million);
+        assertNumEquals(hundredMillion.divide(hundred), million);
         assertNumEquals(0, hundredMillion.remainder(hundred));
 
         Num five = ten.numOf(5); // generate new value with NumFunction
@@ -332,7 +331,7 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
                 BigDecimal sqrtBD = new BigDecimal(sqrt.toString());
                 assertNumEquals(numOf(numBD),
                         numOf(sqrtBD.multiply(sqrtBD, new MathContext(99999, RoundingMode.HALF_UP))));
-                assertNumNotEquals(numOf(numBD), sqrt.multipliedBy(sqrt));
+                assertNumNotEquals(numOf(numBD), sqrt.multiply(sqrt));
             } catch (IOException ioe) {
                 ioe.printStackTrace();
             }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -84,22 +84,22 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
         // Enter at 114
         tradingRecord.enter(2, numOf(114), numOf(1));
         assertFalse(rule.isSatisfied(2, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(120).multiply(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
 
         assertFalse(rule.isSatisfied(3, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(130).multiply(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
 
         assertTrue(rule.isSatisfied(4, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(130).multiply(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
         // Exit
         tradingRecord.exit(5);
 
         // Enter at 128
         tradingRecord.enter(5, numOf(128), numOf(1));
         assertFalse(rule.isSatisfied(5, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(130).multiply(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
         assertTrue(rule.isSatisfied(6, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(130).multiply(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
     }
 
     @Test
@@ -148,22 +148,22 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
         // Enter at 84
         tradingRecord.enter(2, numOf(84), numOf(1));
         assertFalse(rule.isSatisfied(2, tradingRecord));
-        assertEquals(numOf(80).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(80).multiply(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
 
         assertFalse(rule.isSatisfied(3, tradingRecord));
-        assertEquals(numOf(70).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(70).multiply(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
 
         assertTrue(rule.isSatisfied(4, tradingRecord));
-        assertEquals(numOf(70).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(70).multiply(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
         // Exit
         tradingRecord.exit(5);
 
         // Enter at 128
         tradingRecord.enter(5, numOf(128), numOf(1));
         assertFalse(rule.isSatisfied(5, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(120).multiply(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
         assertTrue(rule.isSatisfied(6, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+        assertEquals(numOf(120).multiply(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
     }
 
     @Test

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
@@ -101,7 +101,7 @@ public class TradingBotOnMovingBarSeries {
         Num randomDecimal = null;
         if (min != null && max != null && min.isLessThan(max)) {
             Num range = max.minus(min);
-            Num position = range.multipliedBy(DecimalNum.valueOf(Math.random()));
+            Num position = range.multiply(DecimalNum.valueOf(Math.random()));
             randomDecimal = min.plus(position);
         }
         return randomDecimal;
@@ -115,8 +115,8 @@ public class TradingBotOnMovingBarSeries {
     private static Bar generateRandomBar() {
         final Num maxRange = DecimalNum.valueOf("0.03"); // 3.0%
         Num openPrice = LAST_BAR_CLOSE_PRICE;
-        Num lowPrice = openPrice.minus(maxRange.multipliedBy(DecimalNum.valueOf(Math.random())));
-        Num highPrice = openPrice.plus(maxRange.multipliedBy(DecimalNum.valueOf(Math.random())));
+        Num lowPrice = openPrice.minus(maxRange.multiply(DecimalNum.valueOf(Math.random())));
+        Num highPrice = openPrice.plus(maxRange.multiply(DecimalNum.valueOf(Math.random())));
         Num closePrice = randDecimal(lowPrice, highPrice);
         LAST_BAR_CLOSE_PRICE = closePrice;
         return new BaseBar(Duration.ofDays(1), ZonedDateTime.now(), openPrice, highPrice, lowPrice, closePrice,

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -73,10 +73,10 @@ public class CompareNumTypes {
         Num D = DecimalNum.valueOf(test(seriesD).toString(), 256);
         Num P = DecimalNum.valueOf(test(seriesP).toString(), 256);
         Num standard = DecimalNum.valueOf(test(seriesPH).toString(), 256);
-        System.out.println(seriesD.getName() + " error: "
-                + D.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
-        System.out.println(seriesP.getName() + " error: "
-                + P.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
+        System.out.println(
+                seriesD.getName() + " error: " + D.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
+        System.out.println(
+                seriesP.getName() + " error: " + P.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
     }
 
     public static Num test(BarSeries series) {

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -74,9 +74,9 @@ public class CompareNumTypes {
         Num P = DecimalNum.valueOf(test(seriesP).toString(), 256);
         Num standard = DecimalNum.valueOf(test(seriesPH).toString(), 256);
         System.out.println(seriesD.getName() + " error: "
-                + D.minus(standard).dividedBy(standard).multipliedBy(DecimalNum.valueOf(100)));
+                + D.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
         System.out.println(seriesP.getName() + " error: "
-                + P.minus(standard).dividedBy(standard).multipliedBy(DecimalNum.valueOf(100)));
+                + P.minus(standard).divide(standard).multiply(DecimalNum.valueOf(100)));
     }
 
     public static Num test(BarSeries series) {


### PR DESCRIPTION
Changes proposed in this pull request:
- **Num#multipliedBy** renamed to **`Num#multiply`**
- **Num#dividedBy** renamed to **`Num#divide`**

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

It's common to say `multiply` and `divide` instead of the puffy words `multipliedBy` and `dividedBy`. Btw, BigDecimal also calls it `divide` and `multipy`. It's better and it also eliminates a lot of characters in the ta4j-source-code.