### PR TITLE
Add constructor for double input

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -63,6 +63,10 @@ public class DoubleNum implements Num {
         return new DoubleNum(Double.parseDouble(i));
     }
 
+    public static DoubleNum valueOf(Double i) {
+        return new DoubleNum(i);
+    }
+
     public static DoubleNum valueOf(Number i) {
         return new DoubleNum(Double.parseDouble(i.toString()));
     }


### PR DESCRIPTION
The Double.parseDouble(i.toString()) is a considerable performance hit.
This surfaced when doing profiling to our code, and I couldn't figure why there was no explicit constructor with a double argument.