### PR TITLE
Examine DoubleNum performance + Misc performance intellij inspections

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -475,8 +475,8 @@ public class BaseBarSeries implements BarSeries {
         if (barCount > maximumBarCount) {
             // Removing old bars
             int nbBarsToRemove = barCount - maximumBarCount;
-            for (int i = 0; i < nbBarsToRemove; i++) {
-                bars.remove(0);
+            if (nbBarsToRemove > 0) {
+                bars.subList(0, nbBarsToRemove).clear();
             }
             // Updating removed bars count
             removedBarsCount += nbBarsToRemove;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -78,7 +78,7 @@ public class Returns implements Indicator<Num> {
     /**
      * Unit element for efficient arithmetic return computation
      */
-    private static Num one;
+    static Num one;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -168,8 +168,8 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
         if (resultCount > maximumResultCount) {
             // Removing old results
             final int nbResultsToRemove = resultCount - maximumResultCount;
-            for (int i = 0; i < nbResultsToRemove; i++) {
-                results.remove(0);
+            if (nbResultsToRemove > 0) {
+                results.subList(0, nbResultsToRemove).clear();
             }
         }
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
@@ -50,9 +50,9 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
     private static final double VALUE_MAX = 0.999;
     private static final double VALUE_MIN = -0.999;
 
-    private final Indicator<Num> ref;
+    final Indicator<Num> ref;
     private final Indicator<Num> intermediateValue;
-    private final Num densityFactor;
+    final Num densityFactor;
     private final Num gamma;
     private final Num delta;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -40,19 +40,23 @@ public class DoubleNum implements Num {
     public static final DoubleNum DNZERO = new DoubleNum(-0.0d);
     public static final DoubleNum D1_0 = new DoubleNum(1d);
     public static Map<Double, DoubleNum> cache = new WeakHashMap<>();
-    public static boolean useCache=false;
+    public static boolean useCache = false;
+
     public static DoubleNum bind(double delegate) {
         if (0d == delegate) return DZERO;
         if (1d == delegate) return D1_0;
         if (-0.0d == delegate) return DNZERO;
+        if (!useCache) return new DoubleNum(delegate); //this should be a basic case for the C2 var profiler inlining
 
         DoubleNum ref = cache.get(delegate);
-        if (null != ref) return ref;
+        if (null == ref) {
+            ref = new DoubleNum(delegate);
+            cache.put(delegate, ref);
+        }
+        return ref;
 
-        DoubleNum doubleNum = new DoubleNum(delegate);
-        if(useCache)cache.put(delegate, doubleNum);
-        return doubleNum;
     }
+
     private static final long serialVersionUID = -2611177221813615070L;
     private final static double EPS = 0.00001; // precision
     public static final long negativeZeroDoubleBits = Double.doubleToRawLongBits(-0.0d);
@@ -107,7 +111,7 @@ public class DoubleNum implements Num {
 
         if (0d == delegate || -0d == delegate) return augend;
         double v = augend.doubleValue();
-        if (0d== v || -0d== v) return this;
+        if (0d == v || -0d == v) return this;
         return bind(delegate + v);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -86,8 +86,11 @@ public class DoubleNum implements Num {
         return bind(Double.parseDouble(i));
     }
 
+
     public static DoubleNum valueOf(Number i) {
-        return bind(Double.parseDouble(i.toString()));
+        /*@see https://github.com/ta4j/ta4j/issues/731#issuecomment-1172802423*/
+        /*double delegate1 = Double.parseDouble(i.toString());*/
+        return bind(i.doubleValue());
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- *
+ * <p>
  * Copyright (c) 2014-2017 Marc de Verdelhan, 2017-2021 Ta4j Organization & respective
  * authors (see AUTHORS)
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -23,20 +23,38 @@
  */
 package org.ta4j.core.num;
 
-import static org.ta4j.core.num.NaN.NaN;
-
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.function.Function;
+
+import static org.ta4j.core.num.NaN.NaN;
 
 /**
  * Representation of Double. High performance, lower precision.
  *
  * @apiNote the delegate should never become a NaN value. No self NaN checks
- *          provided
+ * provided
  */
 public class DoubleNum implements Num {
+    public static final DoubleNum DZERO = new DoubleNum(0d);
+    public static final DoubleNum DNZERO = new DoubleNum(-0.0d);
+    public static final DoubleNum D1_0 = new DoubleNum(1d);
+    public static Map<Double, DoubleNum> cache = new WeakHashMap<>();
+    public static DoubleNum bind(double delegate) {
+        if (0d == delegate) return DZERO;
+        if (1d == delegate) return D1_0;
+        if (-0.0d == delegate) return DNZERO;
 
+        DoubleNum ref = cache.get(delegate);
+        if (null != ref) return ref;
+
+        DoubleNum doubleNum = new DoubleNum(delegate);
+        cache.put(delegate, doubleNum);
+        return doubleNum;
+    }
     private static final long serialVersionUID = -2611177221813615070L;
     private final static double EPS = 0.00001; // precision
+    public static final long negativeZeroDoubleBits = Double.doubleToRawLongBits(-0.0d);
     private final double delegate;
 
     private DoubleNum(double val) {
@@ -44,27 +62,27 @@ public class DoubleNum implements Num {
     }
 
     public static DoubleNum valueOf(int i) {
-        return new DoubleNum((double) i);
+        return bind(i);
     }
 
     public static DoubleNum valueOf(long i) {
-        return new DoubleNum((double) i);
+        return bind((double) i);
     }
 
     public static DoubleNum valueOf(short i) {
-        return new DoubleNum((double) i);
+        return bind(i);
     }
 
     public static DoubleNum valueOf(float i) {
-        return new DoubleNum((double) i);
+        return bind(i);
     }
 
     public static DoubleNum valueOf(String i) {
-        return new DoubleNum(Double.parseDouble(i));
+        return bind(Double.parseDouble(i));
     }
 
     public static DoubleNum valueOf(Number i) {
-        return new DoubleNum(Double.parseDouble(i.toString()));
+        return bind(Double.parseDouble(i.toString()));
     }
 
     @Override
@@ -84,51 +102,66 @@ public class DoubleNum implements Num {
 
     @Override
     public Num plus(Num augend) {
-        return augend.isNaN() ? NaN : new DoubleNum(delegate + ((DoubleNum) augend).delegate);
+        if (augend.isNaN()) return NaN;
+
+        if (0d == delegate || -0d == delegate) return augend;
+        double v = augend.doubleValue();
+        if (0d== v || -0d== v) return this;
+        return bind(delegate + v);
     }
 
     @Override
     public Num minus(Num subtrahend) {
-        return subtrahend.isNaN() ? NaN : new DoubleNum(delegate - ((DoubleNum) subtrahend).delegate);
+        if (subtrahend.isNaN()) return NaN;
+        double v = subtrahend.doubleValue();
+        if (0d == v || -0d == v) return this;
+        if (v == delegate) return DZERO;
+        return bind(delegate - v);
     }
 
     @Override
     public Num multipliedBy(Num multiplicand) {
-        return multiplicand.isNaN() ? NaN : new DoubleNum(delegate * ((DoubleNum) multiplicand).delegate);
+        if (multiplicand.isNaN()) return NaN;
+        double v = multiplicand.doubleValue();
+        return 0d == v || 1d == delegate ? multiplicand : 1d == v || 0d == delegate ? this : bind(delegate * v);
     }
 
     @Override
     public Num dividedBy(Num divisor) {
-        if (divisor.isNaN() || divisor.isZero()) {
-            return NaN;
-        }
-        DoubleNum divisorD = (DoubleNum) divisor;
-        return new DoubleNum(delegate / divisorD.delegate);
+        if (divisor.isNaN() || divisor.isZero()) return NaN;
+        double v = divisor.doubleValue();
+        if (1d == v || 0d == delegate)
+            return this;
+
+        return bind(delegate / v);
     }
 
     @Override
     public Num remainder(Num divisor) {
-        return divisor.isNaN() ? NaN : new DoubleNum(delegate % ((DoubleNum) divisor).delegate);
+        if (divisor.isNaN()) return NaN;
+        double v = divisor.doubleValue();
+        return 1d == v ? this : bind(delegate % v);
     }
 
     @Override
     public Num floor() {
-        return new DoubleNum(Math.floor(delegate));
+        return bind(Math.floor(delegate));
     }
 
     @Override
     public Num ceil() {
-        return new DoubleNum(Math.ceil(delegate));
+        return bind(Math.ceil(delegate));
     }
 
     @Override
     public Num pow(int n) {
-        return new DoubleNum(Math.pow(delegate, n));
+        return bind(Math.pow(delegate, n));
     }
 
     @Override
     public Num pow(Num n) {
-        return new DoubleNum(Math.pow(delegate, n.doubleValue()));
+        double b = n.doubleValue();
+        return 1d == b ? this : bind(Math.pow(delegate, b));
     }
 
     @Override
@@ -136,7 +169,7 @@ public class DoubleNum implements Num {
         if (delegate < 0) {
             return NaN;
         }
-        return new DoubleNum(Math.sqrt(delegate));
+        return bind(Math.sqrt(delegate));
     }
 
     @Override
@@ -146,12 +179,12 @@ public class DoubleNum implements Num {
 
     @Override
     public Num abs() {
-        return new DoubleNum(Math.abs(delegate));
+        return bind(Math.abs(delegate));
     }
 
     @Override
     public Num negate() {
-        return new DoubleNum(-delegate);
+        return bind(-delegate);
     }
 
     @Override
@@ -188,7 +221,7 @@ public class DoubleNum implements Num {
         if (delegate <= 0) {
             return NaN;
         }
-        return new DoubleNum(Math.log(delegate));
+        return bind(Math.log(delegate));
     }
 
     /**
@@ -206,7 +239,7 @@ public class DoubleNum implements Num {
      *
      * @param other the other value, not null
      * @return true is this is greater than or equal to the specified value, false
-     *         otherwise
+     * otherwise
      */
     public boolean isGreaterThanOrEqual(Num other) {
         return !other.isNaN() && compareTo(other) > -1;
@@ -229,12 +262,34 @@ public class DoubleNum implements Num {
 
     @Override
     public Num min(Num other) {
-        return other.isNaN() ? NaN : new DoubleNum(Math.min(delegate, ((DoubleNum) other).delegate));
+        double a = delegate;
+        //noinspection ConstantConditions
+        if (a != a)
+            return NaN;   // a is NaN
+        double b = other.getDelegate().doubleValue();
+        if ((a == 0d) &&
+                (b == 0d) &&
+                (Double.doubleToRawLongBits(b) == negativeZeroDoubleBits)) {
+            // Raw conversion ok since NaN can't map to -0d.
+            return other;
+        }
+        return (a <= b) ? this : other;
+
     }
 
     @Override
     public Num max(Num other) {
-        return other.isNaN() ? NaN : new DoubleNum(Math.max(delegate, ((DoubleNum) other).delegate));
+        double a = delegate;
+        //noinspection ConstantConditions
+        if (a != a) return NaN;
+        double b = (double) other.getDelegate();
+        if ((a == 0d) &&
+                (b == 0d) &&
+                (Double.doubleToRawLongBits(a) == negativeZeroDoubleBits)) {
+            // Raw conversion ok since NaN can't map to -0d.
+            return other;
+        }
+        return (a >= b) ? this : other;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -40,6 +40,7 @@ public class DoubleNum implements Num {
     public static final DoubleNum DNZERO = new DoubleNum(-0.0d);
     public static final DoubleNum D1_0 = new DoubleNum(1d);
     public static Map<Double, DoubleNum> cache = new WeakHashMap<>();
+    public static boolean useCache=false;
     public static DoubleNum bind(double delegate) {
         if (0d == delegate) return DZERO;
         if (1d == delegate) return D1_0;
@@ -49,7 +50,7 @@ public class DoubleNum implements Num {
         if (null != ref) return ref;
 
         DoubleNum doubleNum = new DoubleNum(delegate);
-        cache.put(delegate, doubleNum);
+        if(useCache)cache.put(delegate, doubleNum);
         return doubleNum;
     }
     private static final long serialVersionUID = -2611177221813615070L;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -26,6 +26,7 @@ package org.ta4j.core.rules;
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -46,6 +47,11 @@ public class DayOfWeekRule extends AbstractRule {
     public DayOfWeekRule(DateTimeIndicator timeIndicator, DayOfWeek... daysOfWeek) {
         this.daysOfWeekSet = new HashSet<>(Arrays.asList(daysOfWeek));
         this.timeIndicator = timeIndicator;
+    }
+
+    public  DayOfWeekRule(DateTimeIndicator timeIndicator, EnumSet<DayOfWeek> dowSet) {
+          this.daysOfWeekSet =dowSet;
+          this.timeIndicator = timeIndicator;
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
@@ -98,6 +98,9 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
      * last bar.
      */
     private static class BarAggregatorForTest implements BarAggregator {
+        BarAggregatorForTest() {
+        }
+
         @Override
         public List<Bar> aggregate(List<Bar> bars) {
             final List<Bar> aggregated = new ArrayList<>();

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DateTimeIndicatorTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -50,7 +51,7 @@ public class DateTimeIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
     @Test
     public void test() {
         ZonedDateTime expectedZonedDateTime = ZonedDateTime.parse("2019-09-17T00:04:00-00:00", DATE_TIME_FORMATTER);
-        List<Bar> bars = Arrays.asList(new MockBar(expectedZonedDateTime, 1, numFunction));
+        List<Bar> bars = Collections.singletonList(new MockBar(expectedZonedDateTime, 1, numFunction));
         BarSeries series = new MockBarSeries(bars);
         DateTimeIndicator dateTimeIndicator = new DateTimeIndicator(series, Bar::getEndTime);
         assertEquals(expectedZonedDateTime, dateTimeIndicator.getValue(0));

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 import java.util.function.Function;
 
 import org.junit.Test;
@@ -57,8 +58,8 @@ public class DayOfWeekRuleTest extends AbstractIndicatorTest<Object, Object> {
                                 ZonedDateTime.parse("2019-09-21T12:00:00-00:00", dtf), // 5, Sat
                                 ZonedDateTime.parse("2019-09-22T12:00:00-00:00", dtf) // 6, Sun
                         }), Bar::getEndTime);
-        DayOfWeekRule rule = new DayOfWeekRule(dateTime, DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
-                DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
+        DayOfWeekRule rule = new DayOfWeekRule(dateTime, EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY, DayOfWeek.FRIDAY));
 
         assertTrue(rule.isSatisfied(0, null));
         assertTrue(rule.isSatisfied(1, null));


### PR DESCRIPTION
I am working with tens of billions of candles.  I wanted to peek into the internals and see if there was anything that might make a difference for performance.  

intellij catches the following: deletion of bars/results by subList range, an enum list that pushes the varargs into EnumSet without removing the original ctor, and I took an interest in DoubleNum math performance, and am testing a few things ~~not submitted here yet~~.

DoubleNum references are created with a sort of Key->Value relationship to the Double values.  that said, there is no Map or prior re-use of these refs at large.  while this may or may not make a difference with other Num variants, the DoubleNum is the express tradeoff of precision for performance and some attention has been given to scavenging existing references wherever the logic arithmetic presents an opportunity. 

Additionally a WeakHashMap cache has been introduced to potentially make hot recursive inner loops even hotter.  My initial testing on jdk 18 bears this to be the case (I see 10-20% faster loops) with `DoubleNum.useCache=true` but the garbage collection costs are significantly greater cost in the one Par-GC test given.  This cache is disabled by default for this reason but if you want to test maximum thruput with weak refs and giant heaps it could potentially decrease latency in the short term calculations.

Prior issues mentioning `CachedInstrument` efficacy also bring to light the inconsistent or unecessary caching occurring; with this DoubleNum cache enabled (and similar for larger Num delagates) it is likely that the Instrument inheritance hierarchy could be flatter in certain cases.

the gc expense comes when the DoubleNum's leave scope but the DoubleNum.cache items are still present.  this is a sort of transactional rigor, calling `DoubleNum.cache.clear()` after a series is finished but before it is GC'd is advised to avoid large GC trace slowdowns.

