### PR TITLE
Rename VersusBuyAndHoldCriterion.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangelog.com/en/1.0.0/) from version 0.9 onwards.
 
 ## 0.16 (unreleased)
+### Breaking
+- **VersusBuyAndHoldCriterion** renamed to **`VersusEnterAndHoldCriterion`**
 
 ## 0.15 (released September 11, 2022)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -31,12 +31,12 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Versus "buy and hold" criterion.
+ * Versus "enter and hold" criterion.
  *
  * Compares the value of a provided {@link AnalysisCriterion criterion} with the
- * value of a "buy and hold".
+ * value of an "enter and hold".
  */
-public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
+public class VersusEnterAndHoldCriterion extends AbstractAnalysisCriterion {
 
     private final AnalysisCriterion criterion;
 
@@ -45,7 +45,7 @@ public class VersusBuyAndHoldCriterion extends AbstractAnalysisCriterion {
      * 
      * @param criterion an analysis criterion to be compared
      */
-    public VersusBuyAndHoldCriterion(AnalysisCriterion criterion) {
+    public VersusEnterAndHoldCriterion(AnalysisCriterion criterion) {
         this.criterion = criterion;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -27,6 +27,7 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
+import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
@@ -38,26 +39,42 @@ import org.ta4j.core.num.Num;
  */
 public class VersusEnterAndHoldCriterion extends AbstractAnalysisCriterion {
 
+    private final TradeType tradeType;
     private final AnalysisCriterion criterion;
 
     /**
-     * Constructor.
+     * Constructor for buy-and-hold strategy.
      * 
      * @param criterion an analysis criterion to be compared
      */
     public VersusEnterAndHoldCriterion(AnalysisCriterion criterion) {
+        this(TradeType.BUY, criterion);
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param tradeType the {@link TradeType} used to open the position
+     * @param criterion the analysis criterion to be compared
+     */
+    public VersusEnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion) {
+        this.tradeType = tradeType;
         this.criterion = criterion;
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
+        int beginIndex = series.getBeginIndex();
+        int endIndex = series.getEndIndex();
+        TradingRecord fakeRecord = createEnterAndHoldTradingRecord(series, beginIndex, endIndex);
         return criterion.calculate(series, position).dividedBy(criterion.calculate(series, fakeRecord));
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        TradingRecord fakeRecord = createBuyAndHoldTradingRecord(series);
+        int beginIndex = series.getBeginIndex();
+        int endIndex = series.getEndIndex();
+        TradingRecord fakeRecord = createEnterAndHoldTradingRecord(series, beginIndex, endIndex);
         return criterion.calculate(series, tradingRecord).dividedBy(criterion.calculate(series, fakeRecord));
     }
 
@@ -67,14 +84,11 @@ public class VersusEnterAndHoldCriterion extends AbstractAnalysisCriterion {
         return criterionValue1.isGreaterThan(criterionValue2);
     }
 
-    private TradingRecord createBuyAndHoldTradingRecord(BarSeries series) {
-        return createBuyAndHoldTradingRecord(series, series.getBeginIndex(), series.getEndIndex());
-    }
-
-    private TradingRecord createBuyAndHoldTradingRecord(BarSeries series, int beginIndex, int endIndex) {
-        TradingRecord fakeRecord = new BaseTradingRecord();
+    private TradingRecord createEnterAndHoldTradingRecord(BarSeries series, int beginIndex, int endIndex) {
+        TradingRecord fakeRecord = new BaseTradingRecord(tradeType);
         fakeRecord.enter(beginIndex, series.getBar(beginIndex).getClosePrice(), series.numOf(1));
         fakeRecord.exit(endIndex, series.getBar(endIndex).getClosePrice(), series.numOf(1));
         return fakeRecord;
     }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
@@ -40,10 +40,10 @@ import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class VersusBuyAndHoldCriterionTest extends AbstractCriterionTest {
+public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
 
-    public VersusBuyAndHoldCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new VersusBuyAndHoldCriterion((AnalysisCriterion) params[0]), numFunction);
+    public VersusEnterAndHoldCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new VersusEnterAndHoldCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -30,7 +30,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
-import org.ta4j.core.criteria.VersusBuyAndHoldCriterion;
+import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.WinningPositionsRatioCriterion;
 import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
@@ -105,7 +105,7 @@ public class Quickstart {
         System.out.println("Return over Max Drawdown: " + romad.calculate(series, tradingRecord));
 
         // Total return of our strategy vs total return of a buy-and-hold strategy
-        AnalysisCriterion vsBuyAndHold = new VersusBuyAndHoldCriterion(new GrossReturnCriterion());
+        AnalysisCriterion vsBuyAndHold = new VersusEnterAndHoldCriterion(new GrossReturnCriterion());
         System.out.println("Our return vs buy-and-hold return: " + vsBuyAndHold.calculate(series, tradingRecord));
 
         // Your turn!

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -34,7 +34,7 @@ import org.ta4j.core.criteria.MaximumDrawdownCriterion;
 import org.ta4j.core.criteria.NumberOfBarsCriterion;
 import org.ta4j.core.criteria.NumberOfPositionsCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
-import org.ta4j.core.criteria.VersusBuyAndHoldCriterion;
+import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.WinningPositionsRatioCriterion;
 import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
 
@@ -87,6 +87,6 @@ public class StrategyAnalysis {
                 .println("Buy-and-hold return: " + new EnterAndHoldReturnCriterion().calculate(series, tradingRecord));
         // Total profit vs buy-and-hold
         System.out.println("Custom strategy return vs buy-and-hold strategy return: "
-                + new VersusBuyAndHoldCriterion(totalReturn).calculate(series, tradingRecord));
+                + new VersusEnterAndHoldCriterion(totalReturn).calculate(series, tradingRecord));
     }
 }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Renamed `VersusBuyAndHoldCriterion` to `VersusEnterAndHoldCriterion` (to align with https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java)

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
