### PR TITLE
CashFlow: use correct finalIndex

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
@@ -47,7 +47,7 @@ public class CashFlow implements Indicator<Num> {
     private final BarSeries barSeries;
 
     /**
-     * The cash flow values
+     * The (accrued) cash flow sequence (without trading costs).
      */
     private List<Num> values;
 
@@ -72,11 +72,7 @@ public class CashFlow implements Indicator<Num> {
      * @param tradingRecord the trading record
      */
     public CashFlow(BarSeries barSeries, TradingRecord tradingRecord) {
-        this.barSeries = barSeries;
-        values = new ArrayList<>(Collections.singletonList(numOf(1)));
-
-        calculate(tradingRecord);
-        fillToTheEnd(barSeries.getEndIndex());
+        this(barSeries, tradingRecord, tradingRecord.getEndIndex(barSeries));
     }
 
     /**
@@ -92,7 +88,7 @@ public class CashFlow implements Indicator<Num> {
         values = new ArrayList<>(Collections.singletonList(numOf(1)));
 
         calculate(tradingRecord, finalIndex);
-        fillToTheEnd(tradingRecord.getEndIndex(barSeries));
+        fillToTheEnd(finalIndex);
     }
 
     /**
@@ -192,6 +188,7 @@ public class CashFlow implements Indicator<Num> {
         } else {
             ratio = entryPrice.numOf(2).minus(exitPrice.dividedBy(entryPrice));
         }
+
         return ratio;
     }
 
@@ -250,7 +247,7 @@ public class CashFlow implements Indicator<Num> {
     }
 
     /**
-     * Determines the the valid final index to be considered.
+     * Determines the valid final index to be considered.
      *
      * @param position   the position
      * @param finalIndex index up until cash flows of open positions are considered

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
@@ -30,7 +30,12 @@ import org.ta4j.core.analysis.CashFlow;
 import org.ta4j.core.num.Num;
 
 /**
- * Maximum drawdown criterion.
+ * Maximum drawdown criterion (in percentage).
+ * 
+ * <p>
+ * The maximum drawdown measures the largest loss. Its value can be within the
+ * range of [0,1], e.g. a maximum drawdown of <code>+1</code> (= +100%) means a
+ * total loss, a maximum drawdown of <code>0</code> (= 0%) means no loss at all.
  *
  * @see <a href=
  *      "http://en.wikipedia.org/wiki/Drawdown_%28economics%29">https://en.wikipedia.org/wiki/Drawdown_(economics)</a>
@@ -39,11 +44,11 @@ public class MaximumDrawdownCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        if (position != null && position.getEntry() != null && position.getExit() != null) {
-            CashFlow cashFlow = new CashFlow(series, position);
-            return calculateMaximumDrawdown(series, null, cashFlow);
+        if (position == null || position.getEntry() == null || position.getExit() == null) {
+            return series.numOf(0);
         }
-        return series.numOf(0);
+        CashFlow cashFlow = new CashFlow(series, position);
+        return calculateMaximumDrawdown(series, null, cashFlow);
     }
 
     @Override
@@ -60,20 +65,29 @@ public class MaximumDrawdownCriterion extends AbstractAnalysisCriterion {
 
     /**
      * Calculates the maximum drawdown from a cash flow over a series.
+     * 
+     * The formula is as follows:
+     * 
+     * <pre>
+     * MDD = (LP - PV) / PV
+     * with MDD: Maximum drawdown, in percent.
+     * with LP: Lowest point (lowest value after peak value).
+     * with PV: Peak value (highest value within the observation).
+     * </pre>
      *
      * @param series        the bar series
-     * @param tradingRecord the trading record (optional)
+     * @param tradingRecord the trading record
      * @param cashFlow      the cash flow
      * @return the maximum drawdown from a cash flow over a series
      */
     private Num calculateMaximumDrawdown(BarSeries series, TradingRecord tradingRecord, CashFlow cashFlow) {
         Num maximumDrawdown = series.numOf(0);
         Num maxPeak = series.numOf(0);
-        int beginIndex = tradingRecord == null ? series.getBeginIndex() : tradingRecord.getStartIndex(series);
-        int endIndex = tradingRecord == null ? series.getEndIndex() : tradingRecord.getEndIndex(series);
+        int beginIndex = tradingRecord.getStartIndex(series);
+        int endIndex = tradingRecord.getEndIndex(series);
         if (!series.isEmpty()) {
-            // The series is not empty
             for (int i = beginIndex; i <= endIndex; i++) {
+
                 Num value = cashFlow.getValue(i);
                 if (value.isGreaterThan(maxPeak)) {
                     maxPeak = value;

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
@@ -69,7 +69,6 @@ public class MaximumDrawdownCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(3, series), Trade.sellAt(4, series), Trade.buyAt(5, series), Trade.sellAt(6, series));
 
         assertNumEquals(.875d, mdd.calculate(series, tradingRecord));
-
     }
 
     @Test


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- use correct `finalIndex` in constructor
- improve javadoc

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
