### PR TITLE
moved DateTimeIndicator to package `indicators/helpers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LosingPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **WinningPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars*`**
+- **DateTimeIndicator* moved to package **`indicators/helpers`**
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LosingPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **WinningPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars*`**
-- **DateTimeIndicator* moved to package **`indicators/helpers`**
+- **DateTimeIndicator** moved to package **`indicators/helpers`**
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -21,13 +21,14 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators;
+package org.ta4j.core.indicators.helpers;
 
 import java.time.ZonedDateTime;
 import java.util.function.Function;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.indicators.CachedIndicator;
 
 /**
  * DateTime indicator.

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.DateTimeIndicator;
+import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 
 /**
  * Day of the week rule.

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -28,7 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.DateTimeIndicator;
+import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 
 /**
  * Time range rule.

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
@@ -21,7 +21,7 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.indicators;
+package org.ta4j.core.indicators.helpers;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.indicators.DateTimeIndicator;
+import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.indicators.DateTimeIndicator;
+import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 


### PR DESCRIPTION
Changes proposed in this pull request:
- `DateTimeIndicator` moved to package **`indicators/helpers`**

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
