### PR TITLE
Improve javadoc for percentage criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added **SuperTrendLowerBandIndicator**
 - added **Donchian Channel indicators (Upper, Lower, and Middle)**
 - added `Indicator.getUnstableBars()`
+- added javadoc improvements for percentage criteria
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.pnl.ReturnCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Calculates the average return per bar criterion.
+ * Calculates the average return per bar criterion, presented in decimal format.
  *
  * <p>
  * The {@link ReturnCriterion gross return} raised to the power of 1 divided by

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.pnl.ReturnCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Calculates the average return per bar criterion, presented in decimal format.
+ * Calculates the average return per bar criterion, returned in decimal format.
  *
  * <p>
  * The {@link ReturnCriterion gross return} raised to the power of 1 divided by

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Enter and hold criterion.
+ * Enter and hold criterion, presented in decimal format.
  *
  * Calculates the gross return (in percent) of an enter-and-hold strategy:
  * 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Enter and hold criterion, presented in decimal format.
+ * Enter and hold criterion, returned in decimal format.
  *
  * Calculates the gross return (in percent) of an enter-and-hold strategy:
  * 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -33,7 +33,7 @@ import org.ta4j.core.analysis.Returns;
 import org.ta4j.core.num.Num;
 
 /**
- * Expected Shortfall criterion.
+ * Expected Shortfall criterion, presented in decimal format.
  *
  * Measures the expected shortfall of the strategy log-return time-series.
  *

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -33,7 +33,7 @@ import org.ta4j.core.analysis.Returns;
 import org.ta4j.core.num.Num;
 
 /**
- * Expected Shortfall criterion, presented in decimal format.
+ * Expected Shortfall criterion, returned in decimal format.
  *
  * Measures the expected shortfall of the strategy log-return time-series.
  *

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
@@ -30,8 +30,8 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Calculates the percentage of losing or winning positions, presented in
- * decimal format.
+ * Calculates the percentage of losing or winning positions, returned in decimal
+ * format.
  * 
  * <ul>
  * <li>For {@link #positionFilter} = {@link PositionFilter#PROFIT}:

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
@@ -30,7 +30,8 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Calculates the percentage of losing or winning positions:
+ * Calculates the percentage of losing or winning positions, presented in
+ * decimal format.
  * 
  * <ul>
  * <li>For {@link #positionFilter} = {@link PositionFilter#PROFIT}:

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -33,7 +33,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Reward risk ratio criterion, defined as the {@link ReturnCriterion gross
- * return} over the {@link MaximumDrawdownCriterion maximum drawdown}, presented
+ * return} over the {@link MaximumDrawdownCriterion maximum drawdown}, returned
  * in decimal format.
  */
 public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -33,7 +33,8 @@ import org.ta4j.core.num.Num;
 
 /**
  * Reward risk ratio criterion, defined as the {@link ReturnCriterion gross
- * return} over the {@link MaximumDrawdownCriterion maximum drawdown}.
+ * return} over the {@link MaximumDrawdownCriterion maximum drawdown}, presented
+ * in decimal format.
  */
 public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
@@ -33,7 +33,7 @@ import org.ta4j.core.analysis.Returns;
 import org.ta4j.core.num.Num;
 
 /**
- * Value at Risk criterion.
+ * Value at Risk criterion, presented in decimal format.
  *
  * @see <a href=
  *      "https://en.wikipedia.org/wiki/Value_at_risk">https://en.wikipedia.org/wiki/Value_at_risk</a>

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
@@ -33,7 +33,7 @@ import org.ta4j.core.analysis.Returns;
 import org.ta4j.core.num.Num;
 
 /**
- * Value at Risk criterion, presented in decimal format.
+ * Value at Risk criterion, returned in decimal format.
  *
  * @see <a href=
  *      "https://en.wikipedia.org/wiki/Value_at_risk">https://en.wikipedia.org/wiki/Value_at_risk</a>

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -32,7 +32,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Versus "enter and hold" criterion.
+ * Versus "enter and hold" criterion, presented in decimal format.
  *
  * Compares the value of a provided {@link AnalysisCriterion criterion} with the
  * value of an "enter and hold". The "enter and hold"-strategy is done as

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -32,7 +32,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.num.Num;
 
 /**
- * Versus "enter and hold" criterion, presented in decimal format.
+ * Versus "enter and hold" criterion, returned in decimal format.
  *
  * Compares the value of a provided {@link AnalysisCriterion criterion} with the
  * value of an "enter and hold". The "enter and hold"-strategy is done as

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Net profit and loss in percentage criterion (relative PnL, excludes trading
- * costs), presented in decimal format.
+ * costs), returned in decimal format.
  * 
  * <p>
  * Defined as the position profit over the purchase price. The profit or loss in

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Net profit and loss in percentage criterion (relative PnL, excludes trading
- * costs).
+ * costs), presented in decimal format.
  * 
  * <p>
  * Defined as the position profit over the purchase price. The profit or loss in

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -31,7 +31,8 @@ import org.ta4j.core.num.Num;
 
 /**
  * Ratio gross profit and loss criterion = Average gross profit (includes
- * trading costs) / Average gross loss (includes trading costs).
+ * trading costs) / Average gross loss (includes trading costs), presented in
+ * decimal format.
  */
 public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Ratio gross profit and loss criterion = Average gross profit (includes
- * trading costs) / Average gross loss (includes trading costs), presented in
+ * trading costs) / Average gross loss (includes trading costs), returned in
  * decimal format.
  */
 public class ProfitLossRatioCriterion extends AbstractAnalysisCriterion {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -30,7 +30,8 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Return (in percentage) criterion (includes trading costs).
+ * Return (in percentage) criterion (includes trading costs), presented in
+ * decimal format.
  *
  * <p>
  * The return of the provided {@link Position position(s)} over the provided

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Return (in percentage) criterion (includes trading costs), presented in
+ * Return (in percentage) criterion (includes trading costs), returned in
  * decimal format.
  *
  * <p>


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/948

Changes proposed in this pull request:
- added the phrase "decimal format" to javadoc to make it clear that the returned value represents the percentage value in decimal format

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
