### PR TITLE
Lower values are "better" in StandardDeviationCriterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices
 - **ExpectancyCriterion** fixed calculation
+- **VarianceCriterion**, **StandardDeviationCriterion**, **RelativeStandardDeviationCriterion** fixed betterThan calculation
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -71,10 +71,10 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
         return standardDeviationCriterion.calculate(series, tradingRecord).dividedBy(average);
     }
 
-    /** The higher the criterion value, the better. */
+    /** The lower the criterion value, the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return criterionValue1.isLessThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -63,10 +63,10 @@ public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
         return varianceCriterion.calculate(series, tradingRecord).sqrt();
     }
 
-    /** The higher the criterion value, the better. */
+    /** The lower the criterion value, the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return criterionValue1.isLessThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -83,10 +83,10 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
         return variance;
     }
 
-    /** The higher the criterion value, the better. */
+    /** The lower the criterion value, the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return criterionValue1.isLessThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
@@ -60,8 +60,8 @@ public class RelativeStandardDeviationCriterionTest extends AbstractCriterionTes
     @Test
     public void betterThan() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
-        assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
-        assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
@@ -59,8 +59,8 @@ public class StandardDeviationCriterionTest extends AbstractCriterionTest {
     @Test
     public void betterThan() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
-        assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
-        assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
@@ -59,8 +59,8 @@ public class VarianceCriterionTest extends AbstractCriterionTest {
     @Test
     public void betterThan() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
-        assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
-        assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
     }
 
     @Test


### PR DESCRIPTION
Fixes #957

Changes proposed in this pull request:
- VarianceCriterion's betterThan logic changed to consider lower values better. Unit tests updated.
- StandardDeviationCriterion's betterThan logic changed to consider lower values better. Unit tests updated.
- RelativeStandardDeviationCriterion's betterThan logic changed to consider lower values better. Unit tests updated.

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
