### PR TITLE
Criteria: add lessBetter to dedicated criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,12 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added `Indicator.getUnstableBars()`
 - added `TransformIndicator.pow()`
 - added javadoc improvements for percentage criteria
-- added "lessBetter"-property for **AverageCriterion**
-- added "lessBetter"-property for **RelativeStandardDeviation**
-- added "lessBetter"-property for **StandardDeviationCriterion**
-- added "lessBetter"-property for **StandardErrorCriterion**
-- added "lessBetter"-property for **VarianceCriterion**
-- added "lessBetter"-property for **NumberOfPositionsCriterion**
+- added "lessIsBetter"-property for **AverageCriterion**
+- added "lessIsBetter"-property for **RelativeStandardDeviation**
+- added "lessIsBetter"-property for **StandardDeviationCriterion**
+- added "lessIsBetter"-property for **StandardErrorCriterion**
+- added "lessIsBetter"-property for **VarianceCriterion**
+- added "lessIsBetter"-property for **NumberOfPositionsCriterion**
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added `Indicator.getUnstableBars()`
 - added `TransformIndicator.pow()`
 - added javadoc improvements for percentage criteria
+- added "lessBetter"-property for **AverageCriterion**
+- added "lessBetter"-property for **RelativeStandardDeviation**
+- added "lessBetter"-property for **StandardDeviationCriterion**
+- added "lessBetter"-property for **StandardErrorCriterion**
+- added "lessBetter"-property for **VarianceCriterion**
+- added "lessBetter"-property for **NumberOfPositionsCriterion**
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -42,6 +42,7 @@ import org.ta4j.core.num.Num;
  *
  */
 public class ExpectedShortfallCriterion extends AbstractAnalysisCriterion {
+
     /**
      * Confidence level as absolute value (e.g. 0.95)
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -38,22 +38,22 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     /**
-     * Constructor with {@link #lessBetter} == true.
+     * Constructor with {@link #lessIsBetter} == true.
      */
     public NumberOfPositionsCriterion() {
-        this.lessBetter = true;
+        this.lessIsBetter = true;
     }
 
     /**
      * Constructor.
      * 
-     * @param lessBetter the {@link #lessBetter}
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public NumberOfPositionsCriterion(boolean lessBetter) {
-        this.lessBetter = lessBetter;
+    public NumberOfPositionsCriterion(boolean lessIsBetter) {
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override
@@ -67,12 +67,12 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -33,6 +33,29 @@ import org.ta4j.core.num.Num;
  */
 public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
+    /**
+     * Constructor with {@link #lessBetter} == true.
+     */
+    public NumberOfPositionsCriterion() {
+        this.lessBetter = true;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public NumberOfPositionsCriterion(boolean lessBetter) {
+        this.lessBetter = lessBetter;
+    }
+
     @Override
     public Num calculate(BarSeries series, Position position) {
         return series.one();
@@ -43,9 +66,13 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
         return series.numOf(tradingRecord.getPositionCount());
     }
 
-    /** The lower the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isLessThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
@@ -40,16 +40,35 @@ import org.ta4j.core.num.Num;
  */
 public class AverageCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
     private final AnalysisCriterion criterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor.
+     * Constructor with {@link #lessBetter} == false.
      * 
      * @param criterion the criterion from which the "average" is calculated
      */
     public AverageCriterion(AnalysisCriterion criterion) {
         this.criterion = criterion;
+        this.lessBetter = false;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param criterion  the criterion from which the "average" is calculated
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public AverageCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+        this.criterion = criterion;
+        this.lessBetter = lessBetter;
     }
 
     @Override
@@ -67,10 +86,14 @@ public class AverageCriterion extends AbstractAnalysisCriterion {
         return criterion.calculate(series, tradingRecord).dividedBy(numberOfPositions);
     }
 
-    /** The higher the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
@@ -45,30 +45,30 @@ public class AverageCriterion extends AbstractAnalysisCriterion {
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     private final AnalysisCriterion criterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor with {@link #lessBetter} == false.
+     * Constructor with {@link #lessIsBetter} == false.
      * 
      * @param criterion the criterion from which the "average" is calculated
      */
     public AverageCriterion(AnalysisCriterion criterion) {
         this.criterion = criterion;
-        this.lessBetter = false;
+        this.lessIsBetter = false;
     }
 
     /**
      * Constructor.
      * 
-     * @param criterion  the criterion from which the "average" is calculated
-     * @param lessBetter the {@link #lessBetter}
+     * @param criterion    the criterion from which the "average" is calculated
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public AverageCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+    public AverageCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.criterion = criterion;
-        this.lessBetter = lessBetter;
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override
@@ -87,12 +87,12 @@ public class AverageCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -42,11 +42,18 @@ import org.ta4j.core.num.Num;
  */
 public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
     private final StandardDeviationCriterion standardDeviationCriterion;
     private final AverageCriterion averageCriterion;
 
     /**
-     * Constructor.
+     * Constructor with {@link #lessBetter} == false.
      * 
      * @param criterion the criterion from which the "relative standard deviation"
      *                  is calculated
@@ -54,6 +61,20 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
     public RelativeStandardDeviationCriterion(AnalysisCriterion criterion) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
         this.averageCriterion = new AverageCriterion(criterion);
+        this.lessBetter = false;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param criterion  the criterion from which the "relative standard deviation"
+     *                   is calculated
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public RelativeStandardDeviationCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+        this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
+        this.averageCriterion = new AverageCriterion(criterion);
+        this.lessBetter = lessBetter;
     }
 
     @Override
@@ -71,10 +92,14 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
         return standardDeviationCriterion.calculate(series, tradingRecord).dividedBy(average);
     }
 
-    /** The higher the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -47,13 +47,13 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     private final StandardDeviationCriterion standardDeviationCriterion;
     private final AverageCriterion averageCriterion;
 
     /**
-     * Constructor with {@link #lessBetter} == false.
+     * Constructor with {@link #lessIsBetter} == false.
      * 
      * @param criterion the criterion from which the "relative standard deviation"
      *                  is calculated
@@ -61,20 +61,20 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
     public RelativeStandardDeviationCriterion(AnalysisCriterion criterion) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
         this.averageCriterion = new AverageCriterion(criterion);
-        this.lessBetter = false;
+        this.lessIsBetter = false;
     }
 
     /**
      * Constructor.
      * 
-     * @param criterion  the criterion from which the "relative standard deviation"
-     *                   is calculated
-     * @param lessBetter the {@link #lessBetter}
+     * @param criterion    the criterion from which the "relative standard
+     *                     deviation" is calculated
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public RelativeStandardDeviationCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+    public RelativeStandardDeviationCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
         this.averageCriterion = new AverageCriterion(criterion);
-        this.lessBetter = lessBetter;
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override
@@ -93,12 +93,12 @@ public class RelativeStandardDeviationCriterion extends AbstractAnalysisCriterio
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -38,16 +38,36 @@ import org.ta4j.core.num.Num;
  */
 public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
     private final VarianceCriterion varianceCriterion;
 
     /**
-     * Constructor.
+     * Constructor with {@link #lessBetter} == false.
      * 
      * @param criterion the criterion from which the "standard deviation" is
      *                  calculated
      */
     public StandardDeviationCriterion(AnalysisCriterion criterion) {
         this.varianceCriterion = new VarianceCriterion(criterion);
+        this.lessBetter = false;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param criterion  the criterion from which the "standard deviation" is
+     *                   calculated
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public StandardDeviationCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+        this.varianceCriterion = new VarianceCriterion(criterion);
+        this.lessBetter = false;
     }
 
     @Override
@@ -63,10 +83,14 @@ public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
         return varianceCriterion.calculate(series, tradingRecord).sqrt();
     }
 
-    /** The higher the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -67,7 +67,7 @@ public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
      */
     public StandardDeviationCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.varianceCriterion = new VarianceCriterion(criterion);
-        this.lessIsBetter = false;
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -43,31 +43,31 @@ public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     private final VarianceCriterion varianceCriterion;
 
     /**
-     * Constructor with {@link #lessBetter} == false.
+     * Constructor with {@link #lessIsBetter} == false.
      * 
      * @param criterion the criterion from which the "standard deviation" is
      *                  calculated
      */
     public StandardDeviationCriterion(AnalysisCriterion criterion) {
         this.varianceCriterion = new VarianceCriterion(criterion);
-        this.lessBetter = false;
+        this.lessIsBetter = false;
     }
 
     /**
      * Constructor.
      * 
-     * @param criterion  the criterion from which the "standard deviation" is
-     *                   calculated
-     * @param lessBetter the {@link #lessBetter}
+     * @param criterion    the criterion from which the "standard deviation" is
+     *                     calculated
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public StandardDeviationCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+    public StandardDeviationCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.varianceCriterion = new VarianceCriterion(criterion);
-        this.lessBetter = false;
+        this.lessIsBetter = false;
     }
 
     @Override
@@ -84,12 +84,12 @@ public class StandardDeviationCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -44,32 +44,32 @@ public class StandardErrorCriterion extends AbstractAnalysisCriterion {
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     private final StandardDeviationCriterion standardDeviationCriterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor with {@link #lessBetter} == true.
+     * Constructor with {@link #lessIsBetter} == true.
      * 
      * @param criterion the criterion from which the "standard deviation error" is
      *                  calculated
      */
     public StandardErrorCriterion(AnalysisCriterion criterion) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
-        this.lessBetter = true;
+        this.lessIsBetter = true;
     }
 
     /**
      * Constructor.
      * 
-     * @param criterion  the criterion from which the "standard deviation error" is
-     *                   calculated
-     * @param lessBetter the {@link #lessBetter}
+     * @param criterion    the criterion from which the "standard deviation error"
+     *                     is calculated
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public StandardErrorCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+    public StandardErrorCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
-        this.lessBetter = lessBetter;
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override
@@ -88,12 +88,12 @@ public class StandardErrorCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -39,17 +39,37 @@ import org.ta4j.core.num.Num;
  */
 public class StandardErrorCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
     private final StandardDeviationCriterion standardDeviationCriterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor.
+     * Constructor with {@link #lessBetter} == true.
      * 
      * @param criterion the criterion from which the "standard deviation error" is
      *                  calculated
      */
     public StandardErrorCriterion(AnalysisCriterion criterion) {
         this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
+        this.lessBetter = true;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param criterion  the criterion from which the "standard deviation error" is
+     *                   calculated
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public StandardErrorCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+        this.standardDeviationCriterion = new StandardDeviationCriterion(criterion);
+        this.lessBetter = lessBetter;
     }
 
     @Override
@@ -67,10 +87,14 @@ public class StandardErrorCriterion extends AbstractAnalysisCriterion {
         return standardDeviationCriterion.calculate(series, tradingRecord).dividedBy(numberOfPositions.sqrt());
     }
 
-    /** The lower the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isLessThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -39,16 +39,35 @@ import org.ta4j.core.num.Num;
  */
 public class VarianceCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the lower the criterion value the better, otherwise the higher
+     * the criterion value the better. This property is only used for
+     * {@link #betterThan(Num, Num)}.
+     */
+    private final boolean lessBetter;
+
     private final AnalysisCriterion criterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor.
+     * Constructor with {@link #lessBetter} == false.
      * 
      * @param criterion the criterion from which the "variance" is calculated
      */
     public VarianceCriterion(AnalysisCriterion criterion) {
         this.criterion = criterion;
+        this.lessBetter = false;
+    }
+
+    /**
+     * Constructor.
+     * 
+     * @param criterion  the criterion from which the "variance" is calculated
+     * @param lessBetter the {@link #lessBetter}
+     */
+    public VarianceCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+        this.criterion = criterion;
+        this.lessBetter = lessBetter;
     }
 
     @Override
@@ -83,10 +102,14 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
         return variance;
     }
 
-    /** The higher the criterion value, the better. */
+    /**
+     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * better, otherwise the higher the criterion value the better.
+     */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return criterionValue1.isGreaterThan(criterionValue2);
+        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+                : criterionValue1.isGreaterThan(criterionValue2);
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -44,30 +44,30 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
-    private final boolean lessBetter;
+    private final boolean lessIsBetter;
 
     private final AnalysisCriterion criterion;
     private final NumberOfPositionsCriterion numberOfPositionsCriterion = new NumberOfPositionsCriterion();
 
     /**
-     * Constructor with {@link #lessBetter} == false.
+     * Constructor with {@link #lessIsBetter} == false.
      * 
      * @param criterion the criterion from which the "variance" is calculated
      */
     public VarianceCriterion(AnalysisCriterion criterion) {
         this.criterion = criterion;
-        this.lessBetter = false;
+        this.lessIsBetter = false;
     }
 
     /**
      * Constructor.
      * 
-     * @param criterion  the criterion from which the "variance" is calculated
-     * @param lessBetter the {@link #lessBetter}
+     * @param criterion    the criterion from which the "variance" is calculated
+     * @param lessIsBetter the {@link #lessIsBetter}
      */
-    public VarianceCriterion(AnalysisCriterion criterion, boolean lessBetter) {
+    public VarianceCriterion(AnalysisCriterion criterion, boolean lessIsBetter) {
         this.criterion = criterion;
-        this.lessBetter = lessBetter;
+        this.lessIsBetter = lessIsBetter;
     }
 
     @Override
@@ -103,12 +103,12 @@ public class VarianceCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * If {@link #lessBetter} == false, then the lower the criterion value, the
+     * If {@link #lessIsBetter} == false, then the lower the criterion value, the
      * better, otherwise the higher the criterion value the better.
      */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
-        return lessBetter ? criterionValue1.isLessThan(criterionValue2)
+        return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
@@ -41,7 +41,8 @@ import org.ta4j.core.num.Num;
 public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     public NumberOfPositionsCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new NumberOfPositionsCriterion(), numFunction);
+        super((params) -> params.length == 0 ? new NumberOfPositionsCriterion()
+                : new NumberOfPositionsCriterion((boolean) params[0]), numFunction);
     }
 
     @Test
@@ -72,9 +73,16 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
         AnalysisCriterion criterion = getCriterion();
         assertTrue(criterion.betterThan(numOf(3), numOf(6)));
         assertFalse(criterion.betterThan(numOf(7), numOf(4)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
+        AnalysisCriterion criterion = getCriterion(false);
+        assertFalse(criterion.betterThan(numOf(3), numOf(6)));
+        assertTrue(criterion.betterThan(numOf(7), numOf(4)));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
@@ -42,7 +42,8 @@ import org.ta4j.core.num.Num;
 public class AverageCriterionTest extends AbstractCriterionTest {
 
     public AverageCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new AverageCriterion((AnalysisCriterion) params[0]), numFunction);
+        super((params) -> params.length == 2 ? new AverageCriterion((AnalysisCriterion) params[0], (boolean) params[1])
+                : new AverageCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -57,7 +58,14 @@ public class AverageCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
+        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion(), true);
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
@@ -43,7 +43,9 @@ import org.ta4j.core.num.Num;
 public class RelativeStandardDeviationCriterionTest extends AbstractCriterionTest {
 
     public RelativeStandardDeviationCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new RelativeStandardDeviationCriterion((AnalysisCriterion) params[0]), numFunction);
+        super((params) -> params.length == 2
+                ? new RelativeStandardDeviationCriterion((AnalysisCriterion) params[0], (boolean) params[1])
+                : new RelativeStandardDeviationCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -58,7 +60,14 @@ public class RelativeStandardDeviationCriterionTest extends AbstractCriterionTes
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
+        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion(), true);
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
@@ -42,7 +42,9 @@ import org.ta4j.core.num.Num;
 public class StandardDeviationCriterionTest extends AbstractCriterionTest {
 
     public StandardDeviationCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new StandardDeviationCriterion((AnalysisCriterion) params[0]), numFunction);
+        super((params) -> params.length == 2
+                ? new StandardDeviationCriterion((AnalysisCriterion) params[0], (boolean) params[1])
+                : new StandardDeviationCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -57,7 +59,14 @@ public class StandardDeviationCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
+        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion(), true);
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
@@ -42,7 +42,9 @@ import org.ta4j.core.num.Num;
 public class StandardErrorCriterionTest extends AbstractCriterionTest {
 
     public StandardErrorCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new StandardErrorCriterion((AnalysisCriterion) params[0]), numFunction);
+        super((params) -> params.length == 2
+                ? new StandardErrorCriterion((AnalysisCriterion) params[0], (boolean) params[1])
+                : new StandardErrorCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -57,10 +59,17 @@ public class StandardErrorCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
         assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
         assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
+        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion(), false);
+        assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
@@ -42,7 +42,8 @@ import org.ta4j.core.num.Num;
 public class VarianceCriterionTest extends AbstractCriterionTest {
 
     public VarianceCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new VarianceCriterion((AnalysisCriterion) params[0]), numFunction);
+        super((params) -> params.length == 2 ? new VarianceCriterion((AnalysisCriterion) params[0], (boolean) params[1])
+                : new VarianceCriterion((AnalysisCriterion) params[0]), numFunction);
     }
 
     @Test
@@ -57,7 +58,14 @@ public class VarianceCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void betterThan() {
+    public void betterThanWithLessIsBetter() {
+        AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion(), true);
+        assertFalse(criterion.betterThan(numOf(5000), numOf(4500)));
+        assertTrue(criterion.betterThan(numOf(4500), numOf(5000)));
+    }
+
+    @Test
+    public void betterThanWithLessIsNotBetter() {
         AnalysisCriterion criterion = getCriterion(new ProfitLossCriterion());
         assertTrue(criterion.betterThan(numOf(5000), numOf(4500)));
         assertFalse(criterion.betterThan(numOf(4500), numOf(5000)));


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/957.

Changes proposed in this pull request:
- added "lessBetter"-property for **AverageCriterion**
- added "lessBetter"-property for **RelativeStandardDeviation**
- added "lessBetter"-property for **StandardDeviationCriterion**
- added "lessBetter"-property for **StandardErrorCriterion**
- added "lessBetter"-property for **VarianceCriterion**
- added "lessBetter"-property for **NumberOfPositionsCriterion**

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md`
