### PR TITLE
adds spread extension in bar class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest
+- **Extends Bar with spread**
 
 ### Removed/Deprecated
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -70,6 +70,11 @@ public interface Bar extends Serializable {
     long getTrades();
 
     /**
+     * @return the spread size
+     */
+    Num getSpread();
+
+    /**
      * @return the whole traded amount of the period
      */
     Num getAmount();
@@ -171,4 +176,6 @@ public interface Bar extends Serializable {
     }
 
     void addPrice(Num price);
+
+    void addPrice(Num price, Num spread);
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -175,6 +175,10 @@ public interface Bar extends Serializable {
         addPrice(numFunction.apply(price));
     }
 
+    default void addPrice(Number price, Number spread, Function<Number, Num> numFunction) {
+        addPrice(numFunction.apply(price), numFunction.apply(spread));
+    }
+
     void addPrice(Num price);
 
     void addPrice(Num price, Num spread);

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -371,7 +371,7 @@ public interface BarSeries extends Serializable {
     }
 
     default void addPrice(Number price, Number spread) {
-        addPrice(numOf(price), numOf(price));
+        addPrice(numOf(price), numOf(spread));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -360,12 +360,18 @@ public interface BarSeries extends Serializable {
      */
     void addPrice(Num price);
 
+    void addPrice(Num price, Num spread);
+
     default void addPrice(String price) {
         addPrice(new BigDecimal(price));
     }
 
     default void addPrice(Number price) {
         addPrice(numOf(price));
+    }
+
+    default void addPrice(Number price, Number spread) {
+        addPrice(numOf(price), numOf(price));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -303,7 +303,7 @@ public class BaseBar implements Bar {
      * @param spread     the actual spread size
      */
     public BaseBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
-                   Num closePrice, Num volume, Num amount, long trades, Num spread) {
+            Num closePrice, Num volume, Num amount, long trades, Num spread) {
         checkTimeArguments(timePeriod, endTime);
         this.timePeriod = timePeriod;
         this.endTime = endTime;
@@ -461,8 +461,10 @@ public class BaseBar implements Bar {
 
     /**
      * Adds the actual price to the last bar and also the actual spread
-     * @param price - actual closing price
-     * @param spread - actual spread (have to be calculated out of bid/offer price before passing to this method)
+     * 
+     * @param price  - actual closing price
+     * @param spread - actual spread (have to be calculated out of bid/offer price
+     *               before passing to this method)
      */
     @Override
     public void addPrice(Num price, Num spread) {

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -60,6 +60,8 @@ public class BaseBar implements Bar {
     private Num volume;
     /** Trade count */
     private long trades = 0;
+    /** Spread size */
+    private Num spread = null;
 
     /**
      * Constructor.
@@ -287,6 +289,36 @@ public class BaseBar implements Bar {
     }
 
     /**
+     * Constructor.
+     *
+     * @param timePeriod the time period
+     * @param endTime    the end time of the bar period
+     * @param openPrice  the open price of the bar period
+     * @param highPrice  the highest price of the bar period
+     * @param lowPrice   the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume     the volume of the bar period
+     * @param amount     the amount of the bar period
+     * @param trades     the trades count of the bar period
+     * @param spread     the actual spread size
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
+                   Num closePrice, Num volume, Num amount, long trades, Num spread) {
+        checkTimeArguments(timePeriod, endTime);
+        this.timePeriod = timePeriod;
+        this.endTime = endTime;
+        this.beginTime = endTime.minus(timePeriod);
+        this.openPrice = openPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.closePrice = closePrice;
+        this.volume = volume;
+        this.amount = amount;
+        this.trades = trades;
+        this.spread = spread;
+    }
+
+    /**
      * Returns BaseBarBuilder
      * 
      * @return builder of class BaseBarBuilder
@@ -365,6 +397,13 @@ public class BaseBar implements Bar {
     }
 
     /**
+     * @return the actual size of a spread
+     */
+    public Num getSpread() {
+        return spread;
+    }
+
+    /**
      * @return the whole traded amount (tradePrice x tradeVolume) of the period
      */
     public Num getAmount() {
@@ -420,6 +459,17 @@ public class BaseBar implements Bar {
         }
     }
 
+    /**
+     * Adds the actual price to the last bar and also the actual spread
+     * @param price - actual closing price
+     * @param spread - actual spread (have to be calculated out of bid/offer price before passing to this method)
+     */
+    @Override
+    public void addPrice(Num price, Num spread) {
+        addPrice(price);
+        this.spread = spread;
+    }
+
     @Override
     public String toString() {
         return String.format(
@@ -441,7 +491,7 @@ public class BaseBar implements Bar {
     @Override
     public int hashCode() {
         return Objects.hash(beginTime, endTime, timePeriod, openPrice, highPrice, lowPrice, closePrice, volume, amount,
-                trades);
+                trades, spread);
     }
 
     @Override
@@ -455,6 +505,7 @@ public class BaseBar implements Bar {
                 && Objects.equals(timePeriod, other.timePeriod) && Objects.equals(openPrice, other.openPrice)
                 && Objects.equals(highPrice, other.highPrice) && Objects.equals(lowPrice, other.lowPrice)
                 && Objects.equals(closePrice, other.closePrice) && Objects.equals(volume, other.volume)
-                && Objects.equals(amount, other.amount) && trades == other.trades;
+                && Objects.equals(amount, other.amount) && trades == other.trades
+                && Objects.equals(spread, other.spread);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -135,6 +135,28 @@ public class BaseBar implements Bar {
 
     /**
      * Constructor.
+     *
+     * @param timePeriod  the time period
+     * @param endTime     the end time of the bar period
+     * @param openPrice   the open price of the bar period
+     * @param highPrice   the highest price of the bar period
+     * @param lowPrice    the lowest price of the bar period
+     * @param closePrice  the close price of the bar period
+     * @param volume      the volume of the bar period
+     * @param amount      the amount of the bar period
+     * @param trades      the trades count of the bar period
+     * @param numFunction the numbers precision
+     * @param spread      the spread size
+     */
+    public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice,
+                   double closePrice, double volume, double amount, long trades, double spread, Function<Number, Num> numFunction) {
+        this(timePeriod, endTime, numFunction.apply(openPrice), numFunction.apply(highPrice),
+                numFunction.apply(lowPrice), numFunction.apply(closePrice), numFunction.apply(volume),
+                numFunction.apply(amount), trades, numFunction.apply(spread));
+    }
+
+    /**
+     * Constructor.
      * 
      * @param timePeriod the time period
      * @param endTime    the end time of the bar period
@@ -345,7 +367,7 @@ public class BaseBar implements Bar {
      * Returns BaseBarBuilder.
      * 
      * @param <T>   the type of the clazz
-     * @param num   any Num function; with this, we can convert a {@link Number} to
+     * @param conversionFunction   any Num function; with this, we can convert a {@link Number} to
      *              a {@link Num Num implementation}
      * @param clazz any type convertable to Num
      * @return builder of class BaseBarBuilder

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
@@ -95,6 +95,7 @@ public class BaseBarBuilder {
     }
 
     public BaseBar build() {
-        return new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades, spread);
+        return new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades,
+                spread);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
@@ -39,6 +39,7 @@ public class BaseBarBuilder {
     private Num amount;
     private Num volume;
     private long trades;
+    private Num spread;
 
     BaseBarBuilder() {
     }
@@ -88,7 +89,12 @@ public class BaseBarBuilder {
         return this;
     }
 
+    public BaseBarBuilder spread(Num spread) {
+        this.spread = spread;
+        return this;
+    }
+
     public BaseBar build() {
-        return new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        return new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades, spread);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -470,6 +470,11 @@ public class BaseBarSeries implements BarSeries {
         getLastBar().addPrice(price);
     }
 
+    @Override
+    public void addPrice(Num price, Num spread) {
+        getLastBar().addPrice(price, spread);
+    }
+
     /**
      * Removes the N first bars which exceed the maximum bar count.
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/ConvertibleBaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConvertibleBaseBarBuilder.java
@@ -55,9 +55,8 @@ public class ConvertibleBaseBarBuilder<T> extends BaseBarBuilder {
         return this;
     }
 
-    @Override
-    public ConvertibleBaseBarBuilder<T> spread(Num spread) {
-        super.spread(spread);
+    public ConvertibleBaseBarBuilder<T> spread(T spread) {
+        super.spread(conversionFunction.apply(spread));
         return this;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/ConvertibleBaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConvertibleBaseBarBuilder.java
@@ -55,6 +55,12 @@ public class ConvertibleBaseBarBuilder<T> extends BaseBarBuilder {
         return this;
     }
 
+    @Override
+    public ConvertibleBaseBarBuilder<T> spread(Num spread) {
+        super.spread(spread);
+        return this;
+    }
+
     public ConvertibleBaseBarBuilder<T> openPrice(T openPrice) {
         super.openPrice(conversionFunction.apply(openPrice));
         return this;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SpreadIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SpreadIndicator.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.indicators.AbstractIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Spread indicator.
+ */
+public class SpreadIndicator extends AbstractIndicator<Num> {
+
+    public SpreadIndicator(BarSeries series) {
+        super(series);
+    }
+
+    @Override
+    public Num getValue(int index) {
+        return getBarSeries().getBar(index).getSpread();
+    }
+
+    @Override
+    public int getUnstableBars() {
+        return 0;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
@@ -31,6 +31,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalUnit;
 import java.util.function.Function;
 
 import org.junit.Before;
@@ -72,6 +73,39 @@ public class BarTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertNumEquals(198, bar.getLowPrice());
         assertNumEquals(201, bar.getHighPrice());
         assertNumEquals(9, bar.getVolume());
+    }
+
+    @Test
+    public void addPrice() {
+        bar.addPrice(3.0, 2.1, numFunction);
+
+        assertNumEquals(3.0, bar.getClosePrice());
+        assertNumEquals(2.1, bar.getSpread());
+
+
+        // BaseBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice,
+        //            Num closePrice, Num volume, Num amount, long trades, Num spread)
+        Bar bar2 = new BaseBar(
+                Duration.ZERO.plusMinutes(15),
+                endTime,
+                numFunction.apply(3.0),
+                numFunction.apply(4.0),
+                numFunction.apply(2.0),
+                numFunction.apply(3.0),
+                numFunction.apply(100),
+                numFunction.apply(12.3),
+                3,
+                numFunction.apply(1.2));
+
+        assertNumEquals(3.0, bar2.getOpenPrice());
+        assertNumEquals(4.0, bar2.getHighPrice());
+        assertNumEquals(2.0, bar2.getLowPrice());
+        assertNumEquals(3.0, bar2.getClosePrice());
+        assertNumEquals(100, bar2.getVolume());
+        assertNumEquals(12.3, bar2.getAmount());
+        assertEquals(3, bar2.getTrades());
+        assertNumEquals(1.2, bar2.getSpread());
+
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -55,6 +55,7 @@ public class BaseBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(4)
                 .volume(numOf(40))
                 .amount(numOf(4020))
+                .spread(numOf(1.2))
                 .build();
 
         assertEquals(duration, bar.getTimePeriod());
@@ -67,5 +68,6 @@ public class BaseBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(4, bar.getTrades());
         assertEquals(numOf(40), bar.getVolume());
         assertEquals(numOf(4020), bar.getAmount());
+        assertEquals(numOf(1.2), bar.getSpread());
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SpreadIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SpreadIndicatorTest.java
@@ -1,0 +1,59 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class SpreadIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+    private SpreadIndicator spreadIndicator;
+
+    BarSeries barSeries;
+
+    public SpreadIndicatorTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Before
+    public void setUp() {
+        barSeries = new MockBarSeries(numFunction);
+        spreadIndicator = new SpreadIndicator(barSeries);
+    }
+
+    @Test
+    public void indicatorShouldRetrieveBarSpread() {
+        for (int i = 0; i < 10; i++) {
+            assertEquals(spreadIndicator.getValue(i), barSeries.getBar(i).getSpread());
+        }
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
@@ -73,6 +73,12 @@ public class MockBar extends BaseBar {
         this.trades = trades;
     }
 
+    public MockBar(ZonedDateTime endTime, double openPrice, double closePrice, double highPrice, double lowPrice,
+                   double amount, double volume, long trades, double spread, Function<Number, Num> numFunction) {
+        super(Duration.ofDays(1), endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, spread, numFunction);
+        this.trades = trades;
+    }
+
     @Override
     public long getTrades() {
         return trades;

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
@@ -103,7 +103,7 @@ public class MockBarSeries extends BaseBarSeries {
         ArrayList<Bar> bars = new ArrayList<>();
         for (double i = 0d; i < 5000; i++) {
             bars.add(new MockBar(ZonedDateTime.now().minusMinutes((long) (5001 - i)), i, i + 1, i + 2, i + 3, i + 4,
-                    i + 5, (int) (i + 6), nf));
+                    i + 5, (int) (i + 6), i, nf));
         }
         return bars;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new member to the bar class. The spread is an important value that must be considered when opening new trades. By adding the spread to the current bar and using the new SpreadIndicator it can be used in Rules.
Not so useful for backtesting, but extremely important for live trading.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md`  (no related ticket)
