### PR TITLE
fixed header license year

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2022 Ta4j Organization & respective
+ * Copyright (c) 2017-2023 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Fixes #956

Looks like between the time #956 was checked by CI and when it was actually merged, the header license year was updated. The "all checks passed" status displayed green but was in reality stale and incorrect.

Changes proposed in this pull request:
- Copyright year corrected from 2022 to 2023.
