### PR TITLE
Java Generics for Bar BarSeries

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -45,7 +45,7 @@ import org.ta4j.core.num.Num;
  * <li>limited to a fixed number of bars (e.g. for actual trading)
  * </ul>
  */
-public interface BarSeries extends Serializable {
+public interface BarSeries<T extends Bar> extends Serializable {
 
     /**
      * @return the name of the series
@@ -103,19 +103,19 @@ public interface BarSeries extends Serializable {
      * @param i an index
      * @return the bar at the i-th position
      */
-    Bar getBar(int i);
+    T getBar(int i);
 
     /**
      * @return the first bar of the series
      */
-    default Bar getFirstBar() {
+    default T getFirstBar() {
         return getBar(getBeginIndex());
     }
 
     /**
      * @return the last bar of the series
      */
-    default Bar getLastBar() {
+    default T getLastBar() {
         return getBar(getEndIndex());
     }
 
@@ -141,7 +141,7 @@ public interface BarSeries extends Serializable {
      *
      * @return the raw bar data
      */
-    List<Bar> getBarData();
+    List<T> getBarData();
 
     /**
      * @return the begin index of the series
@@ -160,8 +160,8 @@ public interface BarSeries extends Serializable {
     default String getSeriesPeriodDescription() {
         StringBuilder sb = new StringBuilder();
         if (!getBarData().isEmpty()) {
-            Bar firstBar = getFirstBar();
-            Bar lastBar = getLastBar();
+            T firstBar = getFirstBar();
+            T lastBar = getLastBar();
             sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME))
                     .append(" - ")
                     .append(lastBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
@@ -203,7 +203,7 @@ public interface BarSeries extends Serializable {
      *          bar data directly
      * @see BarSeries#setMaximumBarCount(int)
      */
-    default void addBar(Bar bar) {
+    default void addBar(T bar) {
         addBar(bar, false);
     }
 
@@ -223,7 +223,7 @@ public interface BarSeries extends Serializable {
      *          bar data directly
      * @see BarSeries#setMaximumBarCount(int)
      */
-    void addBar(Bar bar, boolean replace);
+    void addBar(T bar, boolean replace);
 
     /**
      * Adds a bar at the end of the series.
@@ -384,6 +384,6 @@ public interface BarSeries extends Serializable {
      * @return a new BarSeries with Bars from startIndex to endIndex-1
      * @throws IllegalArgumentException if endIndex <= startIndex or startIndex < 0
      */
-    BarSeries getSubSeries(int startIndex, int endIndex);
+    BarSeries<T> getSubSeries(int startIndex, int endIndex);
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesAbstract.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesAbstract.java
@@ -41,7 +41,7 @@ import static org.ta4j.core.num.NaN.NaN;
  * Abstract base implementation of a {@link BarSeries}.
  * </p>
  */
-public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSeries<T> {
+public abstract class BarSeriesAbstract<T extends Bar> implements BarSeries<T> {
 
     /**
      * The logger
@@ -91,7 +91,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
     /**
      * Constructor of an unnamed series.
      */
-    public BaseBarSeriesAbstract() {
+    public BarSeriesAbstract() {
         this(UNNAMED_SERIES_NAME);
     }
 
@@ -100,7 +100,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      *
      * @param name the name of the series
      */
-    public BaseBarSeriesAbstract(String name) {
+    public BarSeriesAbstract(String name) {
         this(name, new ArrayList<>());
     }
 
@@ -109,7 +109,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      *
      * @param bars the list of bars of the series
      */
-    public BaseBarSeriesAbstract(List<T> bars) {
+    public BarSeriesAbstract(List<T> bars) {
         this(UNNAMED_SERIES_NAME, bars);
     }
 
@@ -119,7 +119,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @param name the name of the series
      * @param bars the list of bars of the series
      */
-    public BaseBarSeriesAbstract(String name, List<T> bars) {
+    public BarSeriesAbstract(String name, List<T> bars) {
         this(name, bars, 0, bars.size() - 1, false);
     }
 
@@ -130,7 +130,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @param num  any instance of Num to determine its Num function; with this, we
      *             can convert a {@link Number} to a {@link Num Num implementation}
      */
-    public BaseBarSeriesAbstract(String name, Num num) {
+    public BarSeriesAbstract(String name, Num num) {
         this(name, new ArrayList<>(), num);
     }
 
@@ -142,7 +142,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @param num  any instance of Num to determine its Num function; with this, we
      *             can convert a {@link Number} to a {@link Num Num implementation}
      */
-    public BaseBarSeriesAbstract(String name, List<T> bars, Num num) {
+    public BarSeriesAbstract(String name, List<T> bars, Num num) {
         this(name, bars, 0, bars.size() - 1, false, num);
     }
 
@@ -159,7 +159,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @param constrained      true to constrain the bar series (i.e. indexes cannot
      *                         change), false otherwise
      */
-    private BaseBarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
+    private BarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
         this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum.ZERO);
     }
 
@@ -176,7 +176,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      *                         with this, we can convert a {@link Number} to a
      *                         {@link Num Num implementation}
      */
-    BaseBarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
+    BarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
         this.name = name;
 
         this.bars = bars;
@@ -217,7 +217,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @return a new list of bars with tick from startIndex (inclusive) to endIndex
      *         (exclusive)
      */
-    protected static <T extends BaseBar> List<T> cut(List<T> bars, final int startIndex, final int endIndex) {
+    protected static <T extends Bar> List<T> cut(List<T> bars, final int startIndex, final int endIndex) {
         return new ArrayList<>(bars.subList(startIndex, endIndex));
     }
 
@@ -226,7 +226,7 @@ public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSer
      * @param index  an out of bounds bar index
      * @return a message for an OutOfBoundsException
      */
-    private static <T extends BaseBar> String buildOutOfBoundsMessage(BaseBarSeriesAbstract<T> series, int index) {
+    private static <T extends Bar> String buildOutOfBoundsMessage(BarSeriesAbstract<T> series, int index) {
         return String.format("Size of series: %s bars, %s bars removed, index = %s", series.bars.size(),
                 series.removedBarsCount, index);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
@@ -26,11 +26,11 @@ package org.ta4j.core;
 /**
  * Interface to build a bar series
  */
-public interface BarSeriesBuilder {
+public interface BarSeriesBuilder<T extends Bar> {
     /**
      * Builds the bar series with corresponding parameters
      *
      * @return bar series
      */
-    BarSeries build();
+    BarSeries<T> build();
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -41,7 +41,7 @@ import org.ta4j.core.num.Num;
  * Base implementation of a {@link BarSeries}.
  * </p>
  */
-public class BaseBarSeries implements BarSeries {
+public class BaseBarSeries implements BarSeries<BaseBar> {
 
     private static final long serialVersionUID = -1878027009398790126L;
 
@@ -67,7 +67,7 @@ public class BaseBarSeries implements BarSeries {
     /**
      * List of bars
      */
-    private final List<Bar> bars;
+    private final List<BaseBar> bars;
     /**
      * Begin index of the bar series
      */
@@ -111,7 +111,7 @@ public class BaseBarSeries implements BarSeries {
      *
      * @param bars the list of bars of the series
      */
-    public BaseBarSeries(List<Bar> bars) {
+    public BaseBarSeries(List<BaseBar> bars) {
         this(UNNAMED_SERIES_NAME, bars);
     }
 
@@ -121,7 +121,7 @@ public class BaseBarSeries implements BarSeries {
      * @param name the name of the series
      * @param bars the list of bars of the series
      */
-    public BaseBarSeries(String name, List<Bar> bars) {
+    public BaseBarSeries(String name, List<BaseBar> bars) {
         this(name, bars, 0, bars.size() - 1, false);
     }
 
@@ -144,7 +144,7 @@ public class BaseBarSeries implements BarSeries {
      * @param num  any instance of Num to determine its Num function; with this, we
      *             can convert a {@link Number} to a {@link Num Num implementation}
      */
-    public BaseBarSeries(String name, List<Bar> bars, Num num) {
+    public BaseBarSeries(String name, List<BaseBar> bars, Num num) {
         this(name, bars, 0, bars.size() - 1, false, num);
     }
 
@@ -161,7 +161,7 @@ public class BaseBarSeries implements BarSeries {
      * @param constrained      true to constrain the bar series (i.e. indexes cannot
      *                         change), false otherwise
      */
-    private BaseBarSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
+    private BaseBarSeries(String name, List<BaseBar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
         this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum.ZERO);
     }
 
@@ -178,7 +178,7 @@ public class BaseBarSeries implements BarSeries {
      *                         with this, we can convert a {@link Number} to a
      *                         {@link Num Num implementation}
      */
-    BaseBarSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
+    BaseBarSeries(String name, List<BaseBar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
         this.name = name;
 
         this.bars = bars;
@@ -219,7 +219,7 @@ public class BaseBarSeries implements BarSeries {
      * @return a new list of bars with tick from startIndex (inclusive) to endIndex
      *         (exclusive)
      */
-    private static List<Bar> cut(List<Bar> bars, final int startIndex, final int endIndex) {
+    private static List<BaseBar> cut(List<BaseBar> bars, final int startIndex, final int endIndex) {
         return new ArrayList<>(bars.subList(startIndex, endIndex));
     }
 
@@ -280,7 +280,7 @@ public class BaseBarSeries implements BarSeries {
      * @param bars a List of Bar objects.
      * @return false if a Num implementation of at least one Bar does not fit.
      */
-    private boolean checkBars(List<Bar> bars) {
+    private boolean checkBars(List<BaseBar> bars) {
         for (Bar bar : bars) {
             if (!checkBar(bar)) {
                 return false;
@@ -315,7 +315,7 @@ public class BaseBarSeries implements BarSeries {
     }
 
     @Override
-    public Bar getBar(int i) {
+    public BaseBar getBar(int i) {
         int innerIndex = i - removedBarsCount;
         if (innerIndex < 0) {
             if (i < 0) {
@@ -347,7 +347,7 @@ public class BaseBarSeries implements BarSeries {
     }
 
     @Override
-    public List<Bar> getBarData() {
+    public List<BaseBar> getBarData() {
         return bars;
     }
 
@@ -390,7 +390,7 @@ public class BaseBarSeries implements BarSeries {
      * @throws NullPointerException if bar is null
      */
     @Override
-    public void addBar(Bar bar, boolean replace) {
+    public void addBar(BaseBar bar, boolean replace) {
         Objects.requireNonNull(bar, "bar must not be null");
         if (!checkBar(bar)) {
             throw new IllegalArgumentException(

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -34,7 +34,7 @@ import java.util.List;
  * Base implementation of a {@link BarSeries}.
  * </p>
  */
-public class BaseBarSeries extends BaseBarSeriesAbstract<BaseBar> {
+public class BaseBarSeries extends BarSeriesAbstract<BaseBar> {
 
     private static final long serialVersionUID = -1878027009398790126L;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -23,214 +23,47 @@
  */
 package org.ta4j.core;
 
-import static org.ta4j.core.num.NaN.NaN;
+import org.ta4j.core.num.Num;
 
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.ta4j.core.num.DecimalNum;
-import org.ta4j.core.num.Num;
 
 /**
  * Base implementation of a {@link BarSeries}.
  * </p>
  */
-public class BaseBarSeries implements BarSeries<BaseBar> {
+public class BaseBarSeries extends BaseBarSeriesAbstract<BaseBar> {
 
     private static final long serialVersionUID = -1878027009398790126L;
 
-    /**
-     * The logger
-     */
-    private final transient Logger log = LoggerFactory.getLogger(getClass());
-
-    /**
-     * Name for unnamed series
-     */
-    private static final String UNNAMED_SERIES_NAME = "unnamed_series";
-
-    /**
-     * Any instance of Num to determine its Num type.
-     */
-    protected final transient Num num;
-
-    /**
-     * Name of the series
-     */
-    private final String name;
-    /**
-     * List of bars
-     */
-    private final List<BaseBar> bars;
-    /**
-     * Begin index of the bar series
-     */
-    private int seriesBeginIndex;
-    /**
-     * End index of the bar series
-     */
-    private int seriesEndIndex;
-    /**
-     * Maximum number of bars for the bar series
-     */
-    private int maximumBarCount = Integer.MAX_VALUE;
-    /**
-     * Number of removed bars
-     */
-    private int removedBarsCount = 0;
-    /**
-     * True if the current series is constrained (i.e. its indexes cannot change),
-     * false otherwise
-     */
-    private final boolean constrained;
-
-    /**
-     * Constructor of an unnamed series.
-     */
     public BaseBarSeries() {
-        this(UNNAMED_SERIES_NAME);
+        super();
     }
 
-    /**
-     * Constructor.
-     *
-     * @param name the name of the series
-     */
     public BaseBarSeries(String name) {
-        this(name, new ArrayList<>());
+        super(name);
     }
 
-    /**
-     * Constructor of an unnamed series.
-     *
-     * @param bars the list of bars of the series
-     */
     public BaseBarSeries(List<BaseBar> bars) {
-        this(UNNAMED_SERIES_NAME, bars);
+        super(bars);
     }
 
-    /**
-     * Constructor.
-     *
-     * @param name the name of the series
-     * @param bars the list of bars of the series
-     */
     public BaseBarSeries(String name, List<BaseBar> bars) {
-        this(name, bars, 0, bars.size() - 1, false);
+        super(name, bars);
     }
 
-    /**
-     * Constructor.
-     * 
-     * @param name the name of the series
-     * @param num  any instance of Num to determine its Num function; with this, we
-     *             can convert a {@link Number} to a {@link Num Num implementation}
-     */
     public BaseBarSeries(String name, Num num) {
-        this(name, new ArrayList<>(), num);
+        super(name, num);
     }
 
-    /**
-     * Constructor.
-     *
-     * @param name the name of the series
-     * @param bars the list of bars of the series
-     * @param num  any instance of Num to determine its Num function; with this, we
-     *             can convert a {@link Number} to a {@link Num Num implementation}
-     */
     public BaseBarSeries(String name, List<BaseBar> bars, Num num) {
-        this(name, bars, 0, bars.size() - 1, false, num);
+        super(name, bars, num);
     }
 
-    /**
-     * Constructor.
-     * <p/>
-     * Creates a BaseBarSeries with default {@link DecimalNum} as type for the data
-     * and all operations on it
-     *
-     * @param name             the name of the series
-     * @param bars             the list of bars of the series
-     * @param seriesBeginIndex the begin index (inclusive) of the bar series
-     * @param seriesEndIndex   the end index (inclusive) of the bar series
-     * @param constrained      true to constrain the bar series (i.e. indexes cannot
-     *                         change), false otherwise
-     */
-    private BaseBarSeries(String name, List<BaseBar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
-        this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum.ZERO);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param name             the name of the series
-     * @param bars             the list of bars of the series
-     * @param seriesBeginIndex the begin index (inclusive) of the bar series
-     * @param seriesEndIndex   the end index (inclusive) of the bar series
-     * @param constrained      true to constrain the bar series (i.e. indexes cannot
-     *                         change), false otherwise
-     * @param num              any instance of Num to determine its Num function;
-     *                         with this, we can convert a {@link Number} to a
-     *                         {@link Num Num implementation}
-     */
-    BaseBarSeries(String name, List<BaseBar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
-        this.name = name;
-
-        this.bars = bars;
-        if (bars.isEmpty()) {
-            // Bar list empty
-            this.seriesBeginIndex = -1;
-            this.seriesEndIndex = -1;
-            this.constrained = false;
-            this.num = num;
-            return;
-        }
-        // Bar list not empty: take Function of first bar
-        this.num = bars.get(0).getClosePrice();
-        // Bar list not empty: checking num types
-        if (!checkBars(bars)) {
-            throw new IllegalArgumentException(String.format(
-                    "Num implementation of bars: %s" + " does not match to Num implementation of bar series: %s",
-                    bars.get(0).getClosePrice().getClass(), num.function()));
-        }
-        // Bar list not empty: checking indexes
-        if (seriesEndIndex < seriesBeginIndex - 1) {
-            throw new IllegalArgumentException("End index must be >= to begin index - 1");
-        }
-        if (seriesEndIndex >= bars.size()) {
-            throw new IllegalArgumentException("End index must be < to the bar list size");
-        }
-        this.seriesBeginIndex = seriesBeginIndex;
-        this.seriesEndIndex = seriesEndIndex;
-        this.constrained = constrained;
-    }
-
-    /**
-     * Cuts a list of bars into a new list of bars that is a subset of it
-     *
-     * @param bars       the list of {@link Bar bars}
-     * @param startIndex start index of the subset
-     * @param endIndex   end index of the subset
-     * @return a new list of bars with tick from startIndex (inclusive) to endIndex
-     *         (exclusive)
-     */
-    private static List<BaseBar> cut(List<BaseBar> bars, final int startIndex, final int endIndex) {
-        return new ArrayList<>(bars.subList(startIndex, endIndex));
-    }
-
-    /**
-     * @param series a bar series
-     * @param index  an out of bounds bar index
-     * @return a message for an OutOfBoundsException
-     */
-    private static String buildOutOfBoundsMessage(BaseBarSeries series, int index) {
-        return String.format("Size of series: %s bars, %s bars removed, index = %s", series.bars.size(),
-                series.removedBarsCount, index);
+    public BaseBarSeries(String name, List<BaseBar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
+        super(name, bars, seriesBeginIndex, seriesEndIndex, constrained, num);
     }
 
     /**
@@ -266,158 +99,6 @@ public class BaseBarSeries implements BarSeries<BaseBar> {
         }
         return new BaseBarSeries(name, num);
 
-    }
-
-    @Override
-    public Num num() {
-        return num;
-    }
-
-    /**
-     * Checks if all {@link Bar bars} of a list fits to the {@link Num NumFunction}
-     * used by this bar series.
-     *
-     * @param bars a List of Bar objects.
-     * @return false if a Num implementation of at least one Bar does not fit.
-     */
-    private boolean checkBars(List<BaseBar> bars) {
-        for (Bar bar : bars) {
-            if (!checkBar(bar)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Checks if the {@link Num} implementation of a {@link Bar} fits to the
-     * NumFunction used by bar series.
-     *
-     * @param bar a Bar object.
-     * @return false if another Num implementation is used than by this bar series.
-     * @see Num
-     * @see Bar
-     * @see #addBar(Duration, ZonedDateTime)
-     */
-    private boolean checkBar(Bar bar) {
-        if (bar.getClosePrice() == null) {
-            return true; // bar has not been initialized with data (uses deprecated constructor)
-        }
-        // all other constructors initialize at least the close price, check if Num
-        // implementation fits to numFunction
-        Class<? extends Num> f = one().getClass();
-        return f == bar.getClosePrice().getClass() || bar.getClosePrice().equals(NaN);
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public BaseBar getBar(int i) {
-        int innerIndex = i - removedBarsCount;
-        if (innerIndex < 0) {
-            if (i < 0) {
-                // Cannot return the i-th bar if i < 0
-                throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, i));
-            }
-            if (log.isTraceEnabled()) {
-                log.trace("Bar series `{}` ({} bars): bar {} already removed, use {}-th instead", name, bars.size(), i,
-                        removedBarsCount);
-            }
-            if (bars.isEmpty()) {
-                throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, removedBarsCount));
-            }
-            innerIndex = 0;
-        } else if (innerIndex >= bars.size()) {
-            // Cannot return the n-th bar if n >= bars.size()
-            throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, i));
-        }
-        return bars.get(innerIndex);
-    }
-
-    @Override
-    public int getBarCount() {
-        if (seriesEndIndex < 0) {
-            return 0;
-        }
-        final int startIndex = Math.max(removedBarsCount, seriesBeginIndex);
-        return seriesEndIndex - startIndex + 1;
-    }
-
-    @Override
-    public List<BaseBar> getBarData() {
-        return bars;
-    }
-
-    @Override
-    public int getBeginIndex() {
-        return seriesBeginIndex;
-    }
-
-    @Override
-    public int getEndIndex() {
-        return seriesEndIndex;
-    }
-
-    @Override
-    public int getMaximumBarCount() {
-        return maximumBarCount;
-    }
-
-    @Override
-    public void setMaximumBarCount(int maximumBarCount) {
-        if (constrained) {
-            throw new IllegalStateException("Cannot set a maximum bar count on a constrained bar series");
-        }
-        if (maximumBarCount <= 0) {
-            throw new IllegalArgumentException("Maximum bar count must be strictly positive");
-        }
-        this.maximumBarCount = maximumBarCount;
-        removeExceedingBars();
-    }
-
-    @Override
-    public int getRemovedBarsCount() {
-        return removedBarsCount;
-    }
-
-    /**
-     * @param bar the <code>Bar</code> to be added
-     * @apiNote to add bar data directly use #addBar(Duration, ZonedDateTime, Num,
-     *          Num, Num, Num, Num)
-     * @throws NullPointerException if bar is null
-     */
-    @Override
-    public void addBar(BaseBar bar, boolean replace) {
-        Objects.requireNonNull(bar, "bar must not be null");
-        if (!checkBar(bar)) {
-            throw new IllegalArgumentException(
-                    String.format("Cannot add Bar with data type: %s to series with data" + "type: %s",
-                            bar.getClosePrice().getClass(), one().getClass()));
-        }
-        if (!bars.isEmpty()) {
-            if (replace) {
-                bars.set(bars.size() - 1, bar);
-                return;
-            }
-            final int lastBarIndex = bars.size() - 1;
-            ZonedDateTime seriesEndTime = bars.get(lastBarIndex).getEndTime();
-            if (!bar.getEndTime().isAfter(seriesEndTime)) {
-                throw new IllegalArgumentException(
-                        String.format("Cannot add a bar with end time:%s that is <= to series end time: %s",
-                                bar.getEndTime(), seriesEndTime));
-            }
-        }
-
-        bars.add(bar);
-        if (seriesBeginIndex == -1) {
-            // Begin index set to 0 only if it wasn't initialized
-            seriesBeginIndex = 0;
-        }
-        seriesEndIndex++;
-        removeExceedingBars();
     }
 
     @Override
@@ -458,34 +139,6 @@ public class BaseBarSeries implements BarSeries<BaseBar> {
     @Override
     public void addTrade(String price, String amount) {
         addTrade(numOf(new BigDecimal(price)), numOf(new BigDecimal(amount)));
-    }
-
-    @Override
-    public void addTrade(Num tradeVolume, Num tradePrice) {
-        getLastBar().addTrade(tradeVolume, tradePrice);
-    }
-
-    @Override
-    public void addPrice(Num price) {
-        getLastBar().addPrice(price);
-    }
-
-    /**
-     * Removes the N first bars which exceed the maximum bar count.
-     */
-    private void removeExceedingBars() {
-        int barCount = bars.size();
-        if (barCount > maximumBarCount) {
-            // Removing old bars
-            int nbBarsToRemove = barCount - maximumBarCount;
-            if (nbBarsToRemove == 1) {
-                bars.remove(0);
-            } else {
-                bars.subList(0, nbBarsToRemove).clear();
-            }
-            // Updating removed bars count
-            removedBarsCount += nbBarsToRemove;
-        }
     }
 
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesAbstract.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesAbstract.java
@@ -1,0 +1,424 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2022 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.ta4j.core.num.DecimalNum;
+import org.ta4j.core.num.Num;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.ta4j.core.num.NaN.NaN;
+
+/**
+ * Abstract base implementation of a {@link BarSeries}.
+ * </p>
+ */
+public abstract class BaseBarSeriesAbstract<T extends BaseBar> implements BarSeries<T> {
+
+    /**
+     * The logger
+     */
+    private final transient Logger log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Name for unnamed series
+     */
+    private static final String UNNAMED_SERIES_NAME = "unnamed_series";
+
+    /**
+     * Any instance of Num to determine its Num type.
+     */
+    protected final transient Num num;
+
+    /**
+     * Name of the series
+     */
+    protected final String name;
+    /**
+     * List of bars
+     */
+    protected final List<T> bars;
+    /**
+     * Begin index of the bar series
+     */
+    protected int seriesBeginIndex;
+    /**
+     * End index of the bar series
+     */
+    protected int seriesEndIndex;
+    /**
+     * Maximum number of bars for the bar series
+     */
+    protected int maximumBarCount = Integer.MAX_VALUE;
+    /**
+     * Number of removed bars
+     */
+    protected int removedBarsCount = 0;
+    /**
+     * True if the current series is constrained (i.e. its indexes cannot change),
+     * false otherwise
+     */
+    protected final boolean constrained;
+
+    /**
+     * Constructor of an unnamed series.
+     */
+    public BaseBarSeriesAbstract() {
+        this(UNNAMED_SERIES_NAME);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name the name of the series
+     */
+    public BaseBarSeriesAbstract(String name) {
+        this(name, new ArrayList<>());
+    }
+
+    /**
+     * Constructor of an unnamed series.
+     *
+     * @param bars the list of bars of the series
+     */
+    public BaseBarSeriesAbstract(List<T> bars) {
+        this(UNNAMED_SERIES_NAME, bars);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name the name of the series
+     * @param bars the list of bars of the series
+     */
+    public BaseBarSeriesAbstract(String name, List<T> bars) {
+        this(name, bars, 0, bars.size() - 1, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name the name of the series
+     * @param num  any instance of Num to determine its Num function; with this, we
+     *             can convert a {@link Number} to a {@link Num Num implementation}
+     */
+    public BaseBarSeriesAbstract(String name, Num num) {
+        this(name, new ArrayList<>(), num);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name the name of the series
+     * @param bars the list of bars of the series
+     * @param num  any instance of Num to determine its Num function; with this, we
+     *             can convert a {@link Number} to a {@link Num Num implementation}
+     */
+    public BaseBarSeriesAbstract(String name, List<T> bars, Num num) {
+        this(name, bars, 0, bars.size() - 1, false, num);
+    }
+
+    /**
+     * Constructor.
+     * <p/>
+     * Creates a BaseBarSeries with default {@link DecimalNum} as type for the data
+     * and all operations on it
+     *
+     * @param name             the name of the series
+     * @param bars             the list of bars of the series
+     * @param seriesBeginIndex the begin index (inclusive) of the bar series
+     * @param seriesEndIndex   the end index (inclusive) of the bar series
+     * @param constrained      true to constrain the bar series (i.e. indexes cannot
+     *                         change), false otherwise
+     */
+    private BaseBarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained) {
+        this(name, bars, seriesBeginIndex, seriesEndIndex, constrained, DecimalNum.ZERO);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name             the name of the series
+     * @param bars             the list of bars of the series
+     * @param seriesBeginIndex the begin index (inclusive) of the bar series
+     * @param seriesEndIndex   the end index (inclusive) of the bar series
+     * @param constrained      true to constrain the bar series (i.e. indexes cannot
+     *                         change), false otherwise
+     * @param num              any instance of Num to determine its Num function;
+     *                         with this, we can convert a {@link Number} to a
+     *                         {@link Num Num implementation}
+     */
+    BaseBarSeriesAbstract(String name, List<T> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
+        this.name = name;
+
+        this.bars = bars;
+        if (bars.isEmpty()) {
+            // Bar list empty
+            this.seriesBeginIndex = -1;
+            this.seriesEndIndex = -1;
+            this.constrained = false;
+            this.num = num;
+            return;
+        }
+        // Bar list not empty: take Function of first bar
+        this.num = bars.get(0).getClosePrice();
+        // Bar list not empty: checking num types
+        if (!checkBars(bars)) {
+            throw new IllegalArgumentException(String.format(
+                    "Num implementation of bars: %s" + " does not match to Num implementation of bar series: %s",
+                    bars.get(0).getClosePrice().getClass(), num.function()));
+        }
+        // Bar list not empty: checking indexes
+        if (seriesEndIndex < seriesBeginIndex - 1) {
+            throw new IllegalArgumentException("End index must be >= to begin index - 1");
+        }
+        if (seriesEndIndex >= bars.size()) {
+            throw new IllegalArgumentException("End index must be < to the bar list size");
+        }
+        this.seriesBeginIndex = seriesBeginIndex;
+        this.seriesEndIndex = seriesEndIndex;
+        this.constrained = constrained;
+    }
+
+    /**
+     * Cuts a list of bars into a new list of bars that is a subset of it
+     *
+     * @param bars       the list of {@link Bar bars}
+     * @param startIndex start index of the subset
+     * @param endIndex   end index of the subset
+     * @return a new list of bars with tick from startIndex (inclusive) to endIndex
+     *         (exclusive)
+     */
+    protected static <T extends BaseBar> List<T> cut(List<T> bars, final int startIndex, final int endIndex) {
+        return new ArrayList<>(bars.subList(startIndex, endIndex));
+    }
+
+    /**
+     * @param series a bar series
+     * @param index  an out of bounds bar index
+     * @return a message for an OutOfBoundsException
+     */
+    private static <T extends BaseBar> String buildOutOfBoundsMessage(BaseBarSeriesAbstract<T> series, int index) {
+        return String.format("Size of series: %s bars, %s bars removed, index = %s", series.bars.size(),
+                series.removedBarsCount, index);
+    }
+
+    @Override
+    public Num num() {
+        return num;
+    }
+
+    /**
+     * Checks if all {@link Bar bars} of a list fits to the {@link Num NumFunction}
+     * used by this bar series.
+     *
+     * @param bars a List of Bar objects.
+     * @return false if a Num implementation of at least one Bar does not fit.
+     */
+    private boolean checkBars(List<T> bars) {
+        for (T bar : bars) {
+            if (!checkBar(bar)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the {@link Num} implementation of a {@link Bar} fits to the
+     * NumFunction used by bar series.
+     *
+     * @param bar a Bar object.
+     * @return false if another Num implementation is used than by this bar series.
+     * @see Num
+     * @see Bar
+     * @see #addBar(Duration, ZonedDateTime)
+     */
+    protected boolean checkBar(T bar) {
+        if (bar.getClosePrice() == null) {
+            return true; // bar has not been initialized with data (uses deprecated constructor)
+        }
+        // all other constructors initialize at least the close price, check if Num
+        // implementation fits to numFunction
+        Class<? extends Num> f = one().getClass();
+        return f == bar.getClosePrice().getClass() || bar.getClosePrice().equals(NaN);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public T getBar(int i) {
+        int innerIndex = i - removedBarsCount;
+        if (innerIndex < 0) {
+            if (i < 0) {
+                // Cannot return the i-th bar if i < 0
+                throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, i));
+            }
+            if (log.isTraceEnabled()) {
+                log.trace("Bar series `{}` ({} bars): bar {} already removed, use {}-th instead", name, bars.size(), i,
+                        removedBarsCount);
+            }
+            if (bars.isEmpty()) {
+                throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, removedBarsCount));
+            }
+            innerIndex = 0;
+        } else if (innerIndex >= bars.size()) {
+            // Cannot return the n-th bar if n >= bars.size()
+            throw new IndexOutOfBoundsException(buildOutOfBoundsMessage(this, i));
+        }
+        return bars.get(innerIndex);
+    }
+
+    @Override
+    public int getBarCount() {
+        if (seriesEndIndex < 0) {
+            return 0;
+        }
+        final int startIndex = Math.max(removedBarsCount, seriesBeginIndex);
+        return seriesEndIndex - startIndex + 1;
+    }
+
+    @Override
+    public List<T> getBarData() {
+        return bars;
+    }
+
+    @Override
+    public int getBeginIndex() {
+        return seriesBeginIndex;
+    }
+
+    @Override
+    public int getEndIndex() {
+        return seriesEndIndex;
+    }
+
+    @Override
+    public int getMaximumBarCount() {
+        return maximumBarCount;
+    }
+
+    @Override
+    public void setMaximumBarCount(int maximumBarCount) {
+        if (constrained) {
+            throw new IllegalStateException("Cannot set a maximum bar count on a constrained bar series");
+        }
+        if (maximumBarCount <= 0) {
+            throw new IllegalArgumentException("Maximum bar count must be strictly positive");
+        }
+        this.maximumBarCount = maximumBarCount;
+        removeExceedingBars();
+    }
+
+    @Override
+    public int getRemovedBarsCount() {
+        return removedBarsCount;
+    }
+
+    /**
+     * @param bar the <code>Bar</code> to be added
+     * @apiNote to add bar data directly use #addBar(Duration, ZonedDateTime, Num,
+     *          Num, Num, Num, Num)
+     * @throws NullPointerException if bar is null
+     */
+    @Override
+    public void addBar(T bar, boolean replace) {
+        Objects.requireNonNull(bar, "bar must not be null");
+        if (!checkBar(bar)) {
+            throw new IllegalArgumentException(
+                    String.format("Cannot add Bar with data type: %s to series with data" + "type: %s",
+                            bar.getClosePrice().getClass(), one().getClass()));
+        }
+        if (!bars.isEmpty()) {
+            if (replace) {
+                bars.set(bars.size() - 1, bar);
+                return;
+            }
+            final int lastBarIndex = bars.size() - 1;
+            ZonedDateTime seriesEndTime = bars.get(lastBarIndex).getEndTime();
+            if (!bar.getEndTime().isAfter(seriesEndTime)) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot add a bar with end time:%s that is <= to series end time: %s",
+                                bar.getEndTime(), seriesEndTime));
+            }
+        }
+
+        bars.add(bar);
+        if (seriesBeginIndex == -1) {
+            // Begin index set to 0 only if it wasn't initialized
+            seriesBeginIndex = 0;
+        }
+        seriesEndIndex++;
+        removeExceedingBars();
+    }
+
+    @Override
+    public void addTrade(Number price, Number amount) {
+        addTrade(numOf(price), numOf(amount));
+    }
+
+    @Override
+    public void addTrade(String price, String amount) {
+        addTrade(numOf(new BigDecimal(price)), numOf(new BigDecimal(amount)));
+    }
+
+    @Override
+    public void addTrade(Num tradeVolume, Num tradePrice) {
+        getLastBar().addTrade(tradeVolume, tradePrice);
+    }
+
+    @Override
+    public void addPrice(Num price) {
+        getLastBar().addPrice(price);
+    }
+
+    /**
+     * Removes the N first bars which exceed the maximum bar count.
+     */
+    protected void removeExceedingBars() {
+        int barCount = bars.size();
+        if (barCount > maximumBarCount) {
+            // Removing old bars
+            int nbBarsToRemove = barCount - maximumBarCount;
+            if (nbBarsToRemove == 1) {
+                bars.remove(0);
+            } else {
+                bars.subList(0, nbBarsToRemove).clear();
+            }
+            // Updating removed bars count
+            removedBarsCount += nbBarsToRemove;
+        }
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -31,13 +31,13 @@ import org.ta4j.core.num.DecimalNum;
 import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
-public class BaseBarSeriesBuilder implements BarSeriesBuilder {
+public class BaseBarSeriesBuilder implements BarSeriesBuilder<BaseBar> {
 
     /**
      * Default instance of Num to determine its Num type and function.
      **/
     private static Num defaultNum = DecimalNum.ZERO;
-    private List<Bar> bars;
+    private List<BaseBar> bars;
     private String name;
     private Num num;
     private boolean constrained;
@@ -109,7 +109,7 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
      * @param bars to set {@link BaseBarSeries#getBarData()}
      * @return {@code this}
      */
-    public BaseBarSeriesBuilder withBars(List<Bar> bars) {
+    public BaseBarSeriesBuilder withBars(List<BaseBar> bars) {
         this.bars = bars;
         return this;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
@@ -25,12 +25,10 @@ package org.ta4j.core.aggregator;
 
 import java.util.List;
 
-import org.ta4j.core.Bar;
-
 /**
  * Bar aggregator interface to aggregate list of bars into another list of bars.
  */
-public interface BarAggregator {
+public interface BarAggregator<T> {
 
     /**
      * Aggregate bars.
@@ -38,5 +36,5 @@ public interface BarAggregator {
      * @param bars bars to aggregate bars
      * @return aggregated bars
      */
-    List<Bar> aggregate(List<Bar> bars);
+    List<T> aggregate(List<T> bars);
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
@@ -23,12 +23,13 @@
  */
 package org.ta4j.core.aggregator;
 
+import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 
 /**
  * Bar aggregator interface to aggregate list of bars into another list of bars.
  */
-public interface BarSeriesAggregator {
+public interface BarSeriesAggregator<T extends Bar> {
 
     /**
      * Aggregates bar series.
@@ -36,7 +37,7 @@ public interface BarSeriesAggregator {
      * @param series series to aggregate
      * @return aggregated series
      */
-    default BarSeries aggregate(BarSeries series) {
+    default BarSeries<T> aggregate(BarSeries<T> series) {
         return aggregate(series, series.getName());
     }
 
@@ -47,5 +48,5 @@ public interface BarSeriesAggregator {
      * @param aggregatedSeriesName name for aggregated series
      * @return aggregated series with specified name
      */
-    BarSeries aggregate(BarSeries series, String aggregatedSeriesName);
+    BarSeries<T> aggregate(BarSeries<T> series, String aggregatedSeriesName);
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
@@ -25,14 +25,14 @@ package org.ta4j.core.aggregator;
 
 import java.util.List;
 
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 
 /**
  * Bar series aggregator based on provided bar aggregator.
  */
-public class BaseBarSeriesAggregator implements BarSeriesAggregator {
+public class BaseBarSeriesAggregator implements BarSeriesAggregator<BaseBar> {
 
     private final BarAggregator barAggregator;
 
@@ -41,8 +41,8 @@ public class BaseBarSeriesAggregator implements BarSeriesAggregator {
     }
 
     @Override
-    public BarSeries aggregate(BarSeries series, String aggregatedSeriesName) {
-        final List<Bar> aggregatedBars = barAggregator.aggregate(series.getBarData());
+    public BarSeries<BaseBar> aggregate(BarSeries<BaseBar> series, String aggregatedSeriesName) {
+        final List<BaseBar> aggregatedBars = barAggregator.aggregate(series.getBarData());
         return new BaseBarSeries(aggregatedSeriesName, aggregatedBars);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
@@ -35,7 +35,7 @@ import org.ta4j.core.num.Num;
 /**
  * Bar aggregator basing on duration.
  */
-public class DurationBarAggregator implements BarAggregator {
+public class DurationBarAggregator implements BarAggregator<BaseBar> {
 
     /**
      * Target time period to aggregate
@@ -73,8 +73,8 @@ public class DurationBarAggregator implements BarAggregator {
      * @return the aggregated bars with new <code>timePeriod</code>
      */
     @Override
-    public List<Bar> aggregate(List<Bar> bars) {
-        final List<Bar> aggregated = new ArrayList<>();
+    public List<BaseBar> aggregate(List<BaseBar> bars) {
+        final List<BaseBar> aggregated = new ArrayList<>();
         if (bars.isEmpty()) {
             return aggregated;
         }
@@ -133,7 +133,7 @@ public class DurationBarAggregator implements BarAggregator {
             }
 
             if (!onlyFinalBars || i <= bars.size()) {
-                final Bar aggregatedBar = new BaseBar(timePeriod, beginTime.plus(timePeriod), open, high, low, close,
+                final BaseBar aggregatedBar = new BaseBar(timePeriod, beginTime.plus(timePeriod), open, high, low, close,
                         volume, amount, trades);
                 aggregated.add(aggregatedBar);
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -26,15 +26,11 @@ package org.ta4j.core.utils;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.ConvertibleBaseBarBuilder;
+import org.ta4j.core.*;
 import org.ta4j.core.aggregator.BarAggregator;
 import org.ta4j.core.aggregator.BarSeriesAggregator;
 import org.ta4j.core.aggregator.BaseBarSeriesAggregator;
@@ -151,15 +147,15 @@ public final class BarSeriesUtils {
      *                  implementation}
      * @return new cloned BarSeries with bars converted by the Num function of num
      */
-    public static BarSeries convertBarSeries(BarSeries barSeries, Num num) {
-        List<Bar> bars = barSeries.getBarData();
+    public static BarSeries<BaseBar> convertBarSeries(BarSeries<BaseBar> barSeries, Num num) {
+        List<BaseBar> bars = barSeries.getBarData();
         if (bars == null || bars.isEmpty())
             return barSeries;
-        List<Bar> convertedBars = new ArrayList<>();
+        List<BaseBar> convertedBars = new ArrayList<>();
         for (int i = barSeries.getBeginIndex(); i <= barSeries.getEndIndex(); i++) {
             Bar bar = bars.get(i);
             Function<Number, Num> conversionFunction = num.function();
-            Bar convertedBar = new ConvertibleBaseBarBuilder<Number>(conversionFunction::apply)
+            BaseBar convertedBar = new ConvertibleBaseBarBuilder<Number>(conversionFunction::apply)
                     .timePeriod(bar.getTimePeriod())
                     .endTime(bar.getEndTime())
                     .openPrice(bar.getOpenPrice().getDelegate())
@@ -172,7 +168,7 @@ public final class BarSeriesUtils {
                     .build();
             convertedBars.add(convertedBar);
         }
-        BarSeries convertedBarSeries = new BaseBarSeries(barSeries.getName(), convertedBars, num);
+        BarSeries<BaseBar> convertedBarSeries = new BaseBarSeries(barSeries.getName(), convertedBars, num);
         if (barSeries.getMaximumBarCount() > 0) {
             convertedBarSeries.setMaximumBarCount(barSeries.getMaximumBarCount());
         }
@@ -211,10 +207,10 @@ public final class BarSeriesUtils {
      * @param barSeries the BarSeries
      * @param newBars   the new bars to be added
      */
-    public static void addBars(BarSeries barSeries, List<Bar> newBars) {
+    public static <T extends Bar> void addBars(BarSeries<T> barSeries, List<T> newBars) {
         if (newBars != null && !newBars.isEmpty()) {
             sortBars(newBars);
-            for (Bar bar : newBars) {
+            for (T bar : newBars) {
                 if (barSeries.isEmpty() || bar.getEndTime().isAfter(barSeries.getLastBar().getEndTime())) {
                     barSeries.addBar(bar);
                 }
@@ -229,9 +225,9 @@ public final class BarSeriesUtils {
      * @param bars the bars
      * @return the sorted bars
      */
-    public static List<Bar> sortBars(List<Bar> bars) {
+    public static <T extends Bar> List<T> sortBars(List<T> bars) {
         if (!bars.isEmpty()) {
-            Collections.sort(bars, BarSeriesUtils.sortBarsByTime);
+            bars.sort(BarSeriesUtils.sortBarsByTime);
         }
         return bars;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -62,7 +62,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     private BarSeries emptySeries;
 
-    private List<Bar> bars;
+    private List<BaseBar> bars;
 
     private String defaultName;
 

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
@@ -34,8 +34,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -51,12 +51,12 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
 
     @Test
     public void testAggregateWithNewName() {
-        final List<Bar> bars = new LinkedList<>();
+        final List<BaseBar> bars = new LinkedList<>();
         final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
 
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 6d, 7, numFunction);
-        final Bar bar1 = new MockBar(time.plusDays(1), 2d, 3d, 3d, 4d, 5d, 6d, 7, numFunction);
-        final Bar bar2 = new MockBar(time.plusDays(2), 3d, 4d, 4d, 5d, 6d, 7d, 7, numFunction);
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 6d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time.plusDays(1), 2d, 3d, 3d, 4d, 5d, 6d, 7, numFunction);
+        final BaseBar bar2 = new MockBar(time.plusDays(2), 3d, 4d, 4d, 5d, 6d, 7d, 7, numFunction);
         bars.add(bar0);
         bars.add(bar1);
         bars.add(bar2);
@@ -73,12 +73,12 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
 
     @Test
     public void testAggregateWithTheSameName() {
-        final List<Bar> bars = new LinkedList<>();
+        final List<BaseBar> bars = new LinkedList<>();
         final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
 
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 6d, 7, numFunction);
-        final Bar bar1 = new MockBar(time.plusDays(1), 2d, 3d, 3d, 4d, 5d, 6d, 7, numFunction);
-        final Bar bar2 = new MockBar(time.plusDays(2), 3d, 4d, 4d, 5d, 6d, 7d, 7, numFunction);
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 6d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time.plusDays(1), 2d, 3d, 3d, 4d, 5d, 6d, 7, numFunction);
+        final BaseBar bar2 = new MockBar(time.plusDays(2), 3d, 4d, 4d, 5d, 6d, 7d, 7, numFunction);
         bars.add(bar0);
         bars.add(bar1);
         bars.add(bar2);
@@ -97,10 +97,10 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
      * This bar aggregator created only for test purposes is returning first and
      * last bar.
      */
-    private static class BarAggregatorForTest implements BarAggregator {
+    private static class BarAggregatorForTest implements BarAggregator<BaseBar> {
         @Override
-        public List<Bar> aggregate(List<Bar> bars) {
-            final List<Bar> aggregated = new ArrayList<>();
+        public List<BaseBar> aggregate(List<BaseBar> bars) {
+            final List<BaseBar> aggregated = new ArrayList<>();
             if (bars.isEmpty()) {
                 return aggregated;
             }

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
@@ -36,19 +36,20 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
-public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, Num> {
+public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries<BaseBar>, Num> {
 
     public DurationBarAggregatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
     }
 
-    private List<Bar> getOneDayBars() {
-        final List<Bar> bars = new LinkedList<>();
+    private List<BaseBar> getOneDayBars() {
+        final List<BaseBar> bars = new LinkedList<>();
         final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
 
         // days 1 - 5
@@ -84,7 +85,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
     public void upscaledTo5DayBars() {
         final DurationBarAggregator barAggregator = new DurationBarAggregator(Duration.ofDays(5), true);
 
-        final List<Bar> bars = barAggregator.aggregate(getOneDayBars());
+        final List<BaseBar> bars = barAggregator.aggregate(getOneDayBars());
 
         // must be 3 bars
         assertEquals(3, bars.size());
@@ -123,7 +124,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
     @Test
     public void upscaledTo10DayBars() {
         final DurationBarAggregator barAggregator = new DurationBarAggregator(Duration.ofDays(10), true);
-        final List<Bar> bars = barAggregator.aggregate(getOneDayBars());
+        final List<BaseBar> bars = barAggregator.aggregate(getOneDayBars());
 
         // must be 1 bars
         assertEquals(1, bars.size());
@@ -145,7 +146,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
     @Test
     public void upscaledTo10DayBarsNotOnlyFinalBars() {
         final DurationBarAggregator barAggregator = new DurationBarAggregator(Duration.ofDays(10), false);
-        final List<Bar> bars = barAggregator.aggregate(getOneDayBars());
+        final List<BaseBar> bars = barAggregator.aggregate(getOneDayBars());
 
         // must be 2 bars
         assertEquals(2, bars.size());

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -49,7 +49,7 @@ public class AccelerationDecelerationIndicatorTest extends AbstractIndicatorTest
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(0, 0, 16, 8, numFunction));
         bars.add(new MockBar(0, 0, 12, 6, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.MedianPriceIndicator;
 import org.ta4j.core.mocks.MockBar;
@@ -54,7 +54,7 @@ public class AwesomeOscillatorIndicatorTest extends AbstractIndicatorTest<Indica
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(0, 0, 16, 8, numFunction));
         bars.add(new MockBar(0, 0, 12, 6, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -55,7 +55,7 @@ public class CCIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
     @Before
     public void setUp() {
-        ArrayList<Bar> bars = new ArrayList<Bar>();
+        ArrayList<BaseBar> bars = new ArrayList<>();
         for (Double price : typicalPrices) {
             bars.add(new MockBar(price, price, price, price, numFunction));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
@@ -48,7 +45,7 @@ public class ChandelierExitLongIndicatorTest extends AbstractIndicatorTest<Indic
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
@@ -48,7 +45,7 @@ public class ChandelierExitShortIndicatorTest extends AbstractIndicatorTest<Indi
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
@@ -33,11 +33,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TestUtils;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -76,7 +72,7 @@ public class EMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
     @Test
     public void stackOverflowError() throws Exception {
-        List<Bar> bigListOfBars = new ArrayList<Bar>();
+        List<BaseBar> bigListOfBars = new ArrayList<>();
         for (int i = 0; i < 10000; i++) {
             bigListOfBars.add(new MockBar(i, numFunction));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
@@ -32,11 +32,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.ExternalIndicatorTest;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.TestUtils;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -75,7 +71,7 @@ public class MMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
     @Test
     public void stackOverflowError() throws Exception {
-        List<Bar> bigListOfBars = new ArrayList<>();
+        List<BaseBar> bigListOfBars = new ArrayList<>();
         for (int i = 0; i < 10000; i++) {
             bigListOfBars.add(new MockBar(i, numFunction));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
@@ -48,7 +45,7 @@ public class MassIndexIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -48,7 +48,7 @@ public class PVOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(0, 10, numFunction));
         bars.add(new MockBar(0, 11, numFunction));
         bars.add(new MockBar(0, 12, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -47,7 +47,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void startUpAndDownTrendTest() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(74.5, 75.1, 75.11, 74.06, numFunction));
         bars.add(new MockBar(75.09, 75.9, 76.030000, 74.640000, numFunction));
@@ -98,7 +98,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void startWithDownAndUpTrendTest() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(4261.48, 4285.08, 4485.39, 4200.74, numFunction)); // The first daily candle of BTCUSDT in
                                                                                 // the Binance cryptocurrency exchange.
                                                                                 // 17 Aug 2017
@@ -128,7 +128,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void testSameValueForSameIndex() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(4261.48, 4285.08, 4485.39, 4200.74, numFunction));
         bars.add(new MockBar(4285.08, 4108.37, 4371.52, 3938.77, numFunction));
         bars.add(new MockBar(4108.37, 4139.98, 4184.69, 3850.00, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
@@ -48,7 +45,7 @@ public class StochasticOscillatorDIndicatorTest extends AbstractIndicatorTest<In
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 119.13, 119.50, 116.00, numFunction));
         bars.add(new MockBar(45.05, 116.75, 119.94, 116.00, numFunction));
         bars.add(new MockBar(45.11, 113.50, 118.44, 111.63, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.num.Num;
 
@@ -49,7 +46,7 @@ public class StochasticOscillatorKIndicatorTest extends AbstractIndicatorTest<In
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 119.13, 119.50, 116.00, numFunction));
         bars.add(new MockBar(45.05, 116.75, 119.94, 116.00, numFunction));
         bars.add(new MockBar(45.11, 113.50, 118.44, 111.63, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
@@ -31,10 +31,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
+import org.ta4j.core.*;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.indicators.helpers.LowPriceIndicator;
@@ -51,7 +48,7 @@ public class WilliamsRIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));
         bars.add(new MockBar(45.11, 45.19, 45.32, 45.11, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -47,7 +47,7 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
     public void zeroDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 10, 2, numFunction);
         MockBar todayBar = new MockBar(0, 0, 6, 6, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -59,7 +59,7 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
     public void zeroDirectionalMovement2() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 12, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 6, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -71,7 +71,7 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
     public void zeroDirectionalMovement3() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 6, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -83,7 +83,7 @@ public class MinusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
     public void positiveDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 20, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
@@ -23,19 +23,19 @@
  */
 package org.ta4j.core.indicators.adx;
 
-import static org.ta4j.core.TestUtils.assertNumEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
@@ -47,7 +47,7 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void zeroDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 10, 2, numFunction);
         MockBar todayBar = new MockBar(0, 0, 6, 6, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -59,7 +59,7 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void zeroDirectionalMovement2() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 12, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 6, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -71,7 +71,7 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void zeroDirectionalMovement3() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 20, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);
@@ -83,7 +83,7 @@ public class PlusDMIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void positiveDirectionalMovement() {
         MockBar yesterdayBar = new MockBar(0, 0, 6, 6, numFunction);
         MockBar todayBar = new MockBar(0, 0, 12, 4, numFunction);
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(yesterdayBar);
         bars.add(todayBar);
         MockBarSeries series = new MockBarSeries(bars);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class BearishEngulfingIndicatorTest extends AbstractIndicatorTest<Indicat
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 20, 21, 17, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class BearishHaramiIndicatorTest extends AbstractIndicatorTest<Indicator<
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(15, 18, 19, 14, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class BullishEngulfingIndicatorTest extends AbstractIndicatorTest<Indicat
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 16, 19, 15, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class BullishHaramiIndicatorTest extends AbstractIndicatorTest<Indicator<
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(21, 15, 22, 14, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class DojiIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean>,
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(19, 19, 22, 16, numFunction));
         bars.add(new MockBar(10, 18, 20, 10, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -49,7 +49,7 @@ public class LowerShadowIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 20, 21, 17, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -48,7 +48,7 @@ public class RealBodyIndicatorTest extends AbstractIndicatorTest<BarSeries, Num>
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 20, 21, 17, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class ThreeBlackCrowsIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(19, 19, 22, 15, numFunction));
         bars.add(new MockBar(10, 18, 20, 8, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class ThreeWhiteSoldiersIndicatorTest extends AbstractIndicatorTest<Indic
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(19, 19, 22, 15, numFunction));
         bars.add(new MockBar(10, 18, 20, 8, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
@@ -48,7 +48,7 @@ public class UpperShadowIndicatorTest extends AbstractIndicatorTest<BarSeries, N
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 20, 21, 17, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
@@ -52,7 +51,7 @@ public class DonchianChannelLowerIndicatorTest extends AbstractIndicatorTest<Bar
     @Before
     public void setUp() {
         ZonedDateTime startDateTime = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime, 100d, 105d, 95d, 100d, 0d, 0, 0, this::numOf));
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime.plusHours(1), 105, 110, 100, 105, 0d, 0, 0,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
@@ -52,7 +51,7 @@ public class DonchianChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ba
     @Before
     public void setUp() {
         ZonedDateTime startDateTime = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime, 100d, 105d, 95d, 100d, 0d, 0, 0, this::numOf));
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime.plusHours(1), 105, 110, 100, 105, 0d, 0, 0,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
@@ -23,7 +23,14 @@
  */
 package org.ta4j.core.indicators.donchian;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -31,15 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBar;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.num.Num;
+import static org.junit.Assert.assertEquals;
 
 public class DonchianChannelUpperIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
 
@@ -52,7 +51,7 @@ public class DonchianChannelUpperIndicatorTest extends AbstractIndicatorTest<Bar
     @Before
     public void setUp() {
         ZonedDateTime startDateTime = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime, 100d, 105d, 95d, 100d, 0d, 0, 0, this::numOf));
         bars.add(new BaseBar(Duration.ofHours(1), startDateTime.plusHours(1), 105, 110, 100, 105, 0d, 0, 0,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class CloseLocationValueIndicatorTest extends AbstractIndicatorTest<Indic
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         // open, close, high, low
         bars.add(new MockBar(10, 18, 20, 10, numFunction));
         bars.add(new MockBar(17, 20, 21, 17, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -51,7 +52,7 @@ public class DateTimeIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
     @Test
     public void test() {
         ZonedDateTime expectedZonedDateTime = ZonedDateTime.parse("2019-09-17T00:04:00-00:00", DATE_TIME_FORMATTER);
-        List<Bar> bars = Arrays.asList(new MockBar(expectedZonedDateTime, 1, numFunction));
+        List<BaseBar> bars = Arrays.asList(new MockBar(expectedZonedDateTime, 1, numFunction));
         BarSeries series = new MockBarSeries(bars);
         DateTimeIndicator dateTimeIndicator = new DateTimeIndicator(series, Bar::getEndTime);
         assertEquals(expectedZonedDateTime, dateTimeIndicator.getValue(0));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class MedianPriceIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(0, 0, 16, 8, numFunction));
         bars.add(new MockBar(0, 0, 12, 6, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -45,7 +45,7 @@ public class TRIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
 
     @Test
     public void getValue() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(0, 12, 15, 8, numFunction));
         bars.add(new MockBar(0, 8, 11, 6, numFunction));
         bars.add(new MockBar(0, 15, 17, 14, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -56,7 +56,7 @@ public class VolumeIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
 
     @Test
     public void sumOfVolume() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(0, 10, numFunction));
         bars.add(new MockBar(0, 11, numFunction));
         bars.add(new MockBar(0, 12, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -45,12 +45,12 @@ public class IchimokuChikouSpanIndicatorTest extends AbstractIndicatorTest<BarSe
         super(numFunction);
     }
 
-    private Bar bar(int i) {
+    private BaseBar bar(int i) {
         return new MockBar(i, this::numOf);
     }
 
     private BarSeries barSeries(int count) {
-        final List<Bar> bars = IntStream.range(0, count).boxed().map(this::bar).collect(toList());
+        final List<BaseBar> bars = IntStream.range(0, count).boxed().map(this::bar).collect(toList());
         return new BaseBarSeries(bars);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class IchimokuIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
 
     @Before
     public void setUp() {
-        final List<Bar> bars = new ArrayList<>();
+        final List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));
         bars.add(new MockBar(45.11, 45.19, 45.32, 45.11, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -52,7 +52,7 @@ public class KeltnerChannelFacadeTest extends AbstractIndicatorTest<Indicator<Nu
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(11577.43, 11670.75, 11711.47, 11577.35, numFunction));
         bars.add(new MockBar(11670.90, 11691.18, 11698.22, 11635.74, numFunction));
         bars.add(new MockBar(11688.61, 11722.89, 11742.68, 11652.89, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -51,7 +51,7 @@ public class KeltnerChannelLowerIndicatorTest extends AbstractIndicatorTest<Indi
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(11577.43, 11670.75, 11711.47, 11577.35, numFunction));
         bars.add(new MockBar(11670.90, 11691.18, 11698.22, 11635.74, numFunction));
         bars.add(new MockBar(11688.61, 11722.89, 11742.68, 11652.89, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -51,7 +51,7 @@ public class KeltnerChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ind
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(11577.43, 11670.75, 11711.47, 11577.35, numFunction));
         bars.add(new MockBar(11670.90, 11691.18, 11698.22, 11635.74, numFunction));
         bars.add(new MockBar(11688.61, 11722.89, 11742.68, 11652.89, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -51,7 +51,7 @@ public class KeltnerChannelUpperIndicatorTest extends AbstractIndicatorTest<Indi
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(11577.43, 11670.75, 11711.47, 11577.35, numFunction));
         bars.add(new MockBar(11670.90, 11691.18, 11698.22, 11635.74, numFunction));
         bars.add(new MockBar(11688.61, 11722.89, 11742.68, 11652.89, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(23.17, 21.48, 23.39, 21.35, numFunction));
         bars.add(new MockBar(21.25, 19.94, 21.29, 20.07, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class SuperTrendLowerBandIndicatorTest extends AbstractIndicatorTest<Indi
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(23.17, 21.48, 23.39, 21.35, numFunction));
         bars.add(new MockBar(21.25, 19.94, 21.29, 20.07, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -50,7 +50,7 @@ public class SuperTrendUpperBandIndicatorTest extends AbstractIndicatorTest<Indi
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
 
         bars.add(new MockBar(23.17, 21.48, 23.39, 21.35, numFunction));
         bars.add(new MockBar(21.25, 19.94, 21.29, 20.07, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -48,7 +48,7 @@ public class AccumulationDistributionIndicatorTest extends AbstractIndicatorTest
     @Test
     public void accumulationDistribution() {
         ZonedDateTime now = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(now, 0d, 10d, 12d, 8d, 0d, 200d, 0, numFunction));// 2-2 * 200 / 4
         bars.add(new MockBar(now, 0d, 8d, 10d, 7d, 0d, 100d, 0, numFunction));// 1-2 *100 / 3
         bars.add(new MockBar(now, 0d, 9d, 15d, 6d, 0d, 300d, 0, numFunction));// 3-6 *300 /9

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -46,7 +46,7 @@ public class ChaikinOscillatorIndicatorTest extends AbstractIndicatorTest<Indica
 
     @Test
     public void getValue() {
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(12.915, 13.600, 12.890, 13.550, 264266, numFunction));
         bars.add(new MockBar(13.550, 13.770, 13.310, 13.505, 305427, numFunction));
         bars.add(new MockBar(13.510, 13.590, 13.425, 13.490, 104077, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -47,7 +47,7 @@ public class IIIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     @Test
     public void intradayIntensityIndex() {
         ZonedDateTime now = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(now, 0d, 10d, 12d, 8d, 0d, 200d, 0, numFunction));// 2-2 * 200 / 4
         bars.add(new MockBar(now, 0d, 8d, 10d, 7d, 0d, 100d, 0, numFunction));// 1-2 *100 / 3
         bars.add(new MockBar(now, 0d, 9d, 15d, 6d, 0d, 300d, 0, numFunction));// 3-6 *300 /9

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -49,7 +49,7 @@ public class MVWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Nu
     @Before
     public void setUp() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, 1, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, 2, numFunction));
         bars.add(new MockBar(45.11, 45.19, 45.32, 45.11, 1, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -47,7 +47,7 @@ public class NVIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     @Test
     public void getValue() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(1355.69, 2739.55, numFunction));
         bars.add(new MockBar(1325.51, 3119.46, numFunction));
         bars.add(new MockBar(1335.02, 3466.88, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -47,7 +47,7 @@ public class OnBalanceVolumeIndicatorTest extends AbstractIndicatorTest<Indicato
     @Test
     public void getValue() {
         ZonedDateTime now = ZonedDateTime.now();
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(now, 0, 10, 0, 0, 0, 4, 0, numFunction));
         bars.add(new MockBar(now, 0, 5, 0, 0, 0, 2, 0, numFunction));
         bars.add(new MockBar(now, 0, 6, 0, 0, 0, 3, 0, numFunction));
@@ -66,7 +66,7 @@ public class OnBalanceVolumeIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void stackOverflowError() {
-        List<Bar> bigListOfBars = new ArrayList<Bar>();
+        List<BaseBar> bigListOfBars = new ArrayList<>();
         for (int i = 0; i < 10000; i++) {
             bigListOfBars.add(new MockBar(i, numFunction));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -47,7 +47,7 @@ public class PVIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     @Test
     public void getValue() {
 
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(1355.69, 2739.55, numFunction));
         bars.add(new MockBar(1325.51, 3119.46, numFunction));
         bars.add(new MockBar(1335.02, 3466.88, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
@@ -23,21 +23,21 @@
  */
 package org.ta4j.core.indicators.volume;
 
-import static org.ta4j.core.TestUtils.assertNumEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.ta4j.core.TestUtils.assertNumEquals;
 
 public class ROCVIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
@@ -49,7 +49,7 @@ public class ROCVIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
 
     @Before
     public void setUp() {
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(1355.69, 1000, numFunction));
         bars.add(new MockBar(1325.51, 3000, numFunction));
         bars.add(new MockBar(1335.02, 3500, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBar;
@@ -51,7 +51,7 @@ public class VWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
     public void setUp() {
 
         // @TODO add volumes
-        List<Bar> bars = new ArrayList<Bar>();
+        List<BaseBar> bars = new ArrayList<>();
         bars.add(new MockBar(44.98, 45.05, 45.17, 44.96, numFunction));
         bars.add(new MockBar(45.05, 45.10, 45.15, 44.99, numFunction));
         bars.add(new MockBar(45.11, 45.19, 45.32, 45.11, numFunction));

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -47,7 +47,7 @@ public class MockBarSeries extends BaseBarSeries {
         super(doublesToBars(nf, data));
     }
 
-    public MockBarSeries(List<Bar> bars) {
+    public MockBarSeries(List<BaseBar> bars) {
         super(bars);
     }
 
@@ -63,35 +63,35 @@ public class MockBarSeries extends BaseBarSeries {
         super(arbitraryBars(nf));
     }
 
-    private static List<Bar> doublesToBars(Function<Number, Num> nf, List<Double> data) {
-        ArrayList<Bar> bars = new ArrayList<>();
+    private static List<BaseBar> doublesToBars(Function<Number, Num> nf, List<Double> data) {
+        ArrayList<BaseBar> bars = new ArrayList<>();
         for (int i = 0; i < data.size(); i++) {
             bars.add(new MockBar(ZonedDateTime.now().minusSeconds((data.size() + 1 - i)), data.get(i), nf));
         }
         return bars;
     }
 
-    private static List<Bar> doublesToBars(Function<Number, Num> nf, double... data) {
-        ArrayList<Bar> bars = new ArrayList<>();
+    private static List<BaseBar> doublesToBars(Function<Number, Num> nf, double... data) {
+        ArrayList<BaseBar> bars = new ArrayList<>();
         for (int i = 0; i < data.length; i++) {
             bars.add(new MockBar(ZonedDateTime.now().minusSeconds((data.length + 1 - i)), data[i], nf));
         }
         return bars;
     }
 
-    private static List<Bar> doublesAndTimesToBars(Function<Number, Num> nf, double[] data, ZonedDateTime[] times) {
+    private static List<BaseBar> doublesAndTimesToBars(Function<Number, Num> nf, double[] data, ZonedDateTime[] times) {
         if (data.length != times.length) {
             throw new IllegalArgumentException();
         }
-        ArrayList<Bar> bars = new ArrayList<>();
+        ArrayList<BaseBar> bars = new ArrayList<>();
         for (int i = 0; i < data.length; i++) {
             bars.add(new MockBar(times[i], data[i], nf));
         }
         return bars;
     }
 
-    private static List<Bar> timesToBars(Function<Number, Num> nf, ZonedDateTime... dates) {
-        ArrayList<Bar> bars = new ArrayList<>();
+    private static List<BaseBar> timesToBars(Function<Number, Num> nf, ZonedDateTime... dates) {
+        ArrayList<BaseBar> bars = new ArrayList<>();
         int i = 1;
         for (ZonedDateTime date : dates) {
             bars.add(new MockBar(date, i++, nf));
@@ -99,8 +99,8 @@ public class MockBarSeries extends BaseBarSeries {
         return bars;
     }
 
-    private static List<Bar> arbitraryBars(Function<Number, Num> nf) {
-        ArrayList<Bar> bars = new ArrayList<>();
+    private static List<BaseBar> arbitraryBars(Function<Number, Num> nf) {
+        ArrayList<BaseBar> bars = new ArrayList<>();
         for (double i = 0d; i < 5000; i++) {
             bars.add(new MockBar(ZonedDateTime.now().minusMinutes((long) (5001 - i)), i, i + 1, i + 2, i + 3, i + 4,
                     i + 5, (int) (i + 6), nf));

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarSeriesBuilder;
@@ -124,14 +123,14 @@ public class DecimalNumTest {
     }
 
     private void init() {
-        List<Bar> superPrecisionBarList = new ArrayList<>();
-        List<Bar> precisionBarList = new ArrayList<>();
-        List<Bar> precision32BarList = new ArrayList<>();
-        List<Bar> doubleBarList = new ArrayList<>();
-        List<Bar> lowPrecisionBarList = new ArrayList<>();
+        List<BaseBar> superPrecisionBarList = new ArrayList<>();
+        List<BaseBar> precisionBarList = new ArrayList<>();
+        List<BaseBar> precision32BarList = new ArrayList<>();
+        List<BaseBar> doubleBarList = new ArrayList<>();
+        List<BaseBar> lowPrecisionBarList = new ArrayList<>();
         Duration timePeriod = Duration.ofDays(1);
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar bar;
+        BaseBar bar;
         double[] deltas = { 20.8, 30.1, -15.3, 10.2, -16.7, -9.8 };
         Num superPrecisionNum = FIRST_SUPER_PRECISION_NUM;
         for (int i = 0; i < NUMBARS; i++) {

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -62,16 +62,16 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void replaceBarIfChangedTest() {
 
-        final List<Bar> bars = new ArrayList<>();
+        final List<BaseBar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
 
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
-        final Bar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        final Bar bar2 = new MockBar(time.plusDays(2), 2d, 2d, 2d, 2d, 2d, 2d, 2, numFunction);
-        final Bar bar3 = new MockBar(time.plusDays(3), 3d, 3d, 3d, 3d, 3d, 3d, 3, numFunction);
-        final Bar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
-        final Bar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
-        final Bar bar6 = new MockBar(time.plusDays(6), 6d, 6d, 6d, 6d, 6d, 6d, 6, numFunction);
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        final BaseBar bar2 = new MockBar(time.plusDays(2), 2d, 2d, 2d, 2d, 2d, 2d, 2, numFunction);
+        final BaseBar bar3 = new MockBar(time.plusDays(3), 3d, 3d, 3d, 3d, 3d, 3d, 3, numFunction);
+        final BaseBar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
+        final BaseBar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
+        final BaseBar bar6 = new MockBar(time.plusDays(6), 6d, 6d, 6d, 6d, 6d, 6d, 6, numFunction);
 
         bars.add(bar0);
         bars.add(bar1);
@@ -113,15 +113,15 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void findMissingBarsTest() {
 
-        final List<Bar> bars = new ArrayList<>();
+        final List<BaseBar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
 
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
-        final Bar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        final Bar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
-        final Bar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
-        final Bar bar7 = new MockBar(time.plusDays(7), 0, 0, 0, 0, 0, 0, 0, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        final BaseBar bar4 = new MockBar(time.plusDays(4), 3d, 4d, 4d, 5d, 6d, 4d, 4, numFunction);
+        final BaseBar bar5 = new MockBar(time.plusDays(5), 5d, 5d, 5d, 5d, 5d, 5d, 5, numFunction);
+        final BaseBar bar7 = new MockBar(time.plusDays(7), 0, 0, 0, 0, 0, 0, 0, numFunction);
+        BaseBar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
                 .timePeriod(Duration.ofDays(1))
                 .endTime(time.plusDays(8))
                 .openPrice(NaN.NaN)
@@ -159,7 +159,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         final Num doubleNum = DoubleNum.ZERO;
         final Num nanNum = NaN.NaN;
 
-        final List<Bar> bars = new ArrayList<>();
+        final List<BaseBar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
         bars.add(new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, decimalNumFunction));
         bars.add(new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, decimalNumFunction));
@@ -189,12 +189,12 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void findOverlappingBarsTest() {
 
-        final List<Bar> bars = new ArrayList<>();
+        final List<BaseBar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
 
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
-        final Bar bar1 = new MockBar(time, 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        Bar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time, 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        BaseBar bar8 = BaseBar.builder(DoubleNum::valueOf, Double.class)
                 .timePeriod(Duration.ofDays(1))
                 .endTime(time.plusDays(8))
                 .openPrice(NaN.NaN)
@@ -219,11 +219,11 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     public void addBars() {
         BarSeries barSeries = new BaseBarSeries("1day", numFunction.apply(0));
 
-        List<Bar> bars = new ArrayList<>();
+        List<BaseBar> bars = new ArrayList<>();
         time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
-        final Bar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
-        final Bar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
-        final Bar bar2 = new MockBar(time.plusDays(2), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        final BaseBar bar0 = new MockBar(time, 1d, 2d, 3d, 4d, 5d, 0d, 7, numFunction);
+        final BaseBar bar1 = new MockBar(time.plusDays(1), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        final BaseBar bar2 = new MockBar(time.plusDays(2), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
         bars.add(bar2);
         bars.add(bar0);
         bars.add(bar1);
@@ -234,7 +234,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(bar0.getEndTime(), barSeries.getFirstBar().getEndTime());
         assertEquals(bar2.getEndTime(), barSeries.getLastBar().getEndTime());
 
-        final Bar bar3 = new MockBar(time.plusDays(3), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
+        final BaseBar bar3 = new MockBar(time.plusDays(3), 1d, 1d, 1d, 1d, 1d, 1d, 1, numFunction);
         bars.add(bar3);
 
         // add 1 bar to non empty barSeries

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -47,7 +47,7 @@ public class BuildBarSeries {
      */
     @SuppressWarnings("unused")
     public static void main(String[] args) {
-        BarSeries a = buildAndAddData();
+        BarSeries<Bar> a = buildAndAddData();
         System.out.println("a: " + a.getBar(0).getClosePrice().getName());
         BaseBarSeriesBuilder.setDefaultNum(DoubleNum::valueOf);
         a = buildAndAddData();
@@ -167,7 +167,7 @@ public class BuildBarSeries {
         // Store Bars in a list and add them later. The bars must have the same Num type
         // as the series
         ZonedDateTime endTime = ZonedDateTime.now();
-        Bar b1 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+        BaseBar b1 = barBuilderFromString().timePeriod(Duration.ofDays(1))
                 .endTime(endTime)
                 .openPrice("105.42")
                 .highPrice("112.99")
@@ -175,7 +175,7 @@ public class BuildBarSeries {
                 .closePrice("111.42")
                 .volume("1337")
                 .build();
-        Bar b2 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+        BaseBar b2 = barBuilderFromString().timePeriod(Duration.ofDays(1))
                 .endTime(endTime.plusDays(1))
                 .openPrice("111.43")
                 .highPrice("112.83")
@@ -183,7 +183,7 @@ public class BuildBarSeries {
                 .closePrice("107.99")
                 .volume("1234")
                 .build();
-        Bar b3 = barBuilderFromString().timePeriod(Duration.ofDays(1))
+        BaseBar b3 = barBuilderFromString().timePeriod(Duration.ofDays(1))
                 .endTime(endTime.plusDays(2))
                 .openPrice("107.90")
                 .highPrice("117.50")
@@ -191,7 +191,7 @@ public class BuildBarSeries {
                 .closePrice("115.42")
                 .volume("4242")
                 .build();
-        List<Bar> bars = Arrays.asList(b1, b2, b3);
+        List<BaseBar> bars = Arrays.asList(b1, b2, b3);
 
         return new BaseBarSeriesBuilder().withName("mySeries")
                 .withNumTypeOf(DoubleNum::valueOf)

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -28,7 +28,6 @@ import java.util.Date;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
-import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.DatasetRenderingOrder;

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -26,7 +26,6 @@ package ta4jexamples.loaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -35,7 +34,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.opencsv.CSVParser;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvValidationException;

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -23,7 +23,6 @@
  */
 package ta4jexamples.loaders;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import java.io.InputStreamReader;


### PR DESCRIPTION
Changes proposed in this pull request:
- Introduction of Java generics for Bar and BarSeries
- `BarSeries` changed to `BarSeries<T extends Bar>`
- `BaseBarSeries` implementation moved to `BaseBarSeriesAbstract<T extends BaseBar> implements BarSeries<T>`
- `BaseBarSeries` refactored to `BaseBarSeries<BaseBar> extends BaseBarSeriesAbstract<T extends BaseBar>` for those wishing to use `BaseBarSeries` with own implementation of `BaseBar`

- All test are passing

- This update introduces a warning for all indicators `Raw use of parameterized class BarSeries`

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` #962 
