### PR TITLE
Feature/decimal num default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest
-- **BarSeriesManager** add `holdingTransaction
+- **BarSeriesManager** add **`holdingTransaction`**
 - **BacktestExecutor** evaluates strategies in parallel when possible
 - **CachedIndicator** synchronize on getValue()
+- **BaseBar** defaults to **`DecimalNum`** type in all constructors
 
 
 ### Removed/Deprecated

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.ta4j.core.num.DecimalNum;
+import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
 /**
@@ -106,7 +107,7 @@ public class BaseBar implements Bar {
      */
     public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice,
             double closePrice, double volume, double amount) {
-        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, DecimalNum::valueOf);
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, DoubleNum::valueOf);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.ta4j.core.num.DecimalNum;
-import org.ta4j.core.num.DoubleNum;
 import org.ta4j.core.num.Num;
 
 /**
@@ -107,7 +106,7 @@ public class BaseBar implements Bar {
      */
     public BaseBar(Duration timePeriod, ZonedDateTime endTime, double openPrice, double highPrice, double lowPrice,
             double closePrice, double volume, double amount) {
-        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, DoubleNum::valueOf);
+        this(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, 0, DecimalNum::valueOf);
     }
 
     /**


### PR DESCRIPTION
Changes proposed in this pull request:
- `BaseBar` should default to `DecimalNum` in all cases

 --> If the user is not providing any custom `Num`/`NumFunction` the `BaseBarSeries` and `BaseBar` should be compatible in all cases

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
