### PR TITLE
Update ReturnCriterion and ReturnCriterionTest to exclude initial capital of one

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -49,7 +49,7 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
         return tradingRecord.getPositions()
                 .stream()
                 .map(position -> calculateProfit(series, position))
-                .reduce(series.one(), Num::multipliedBy);
+                .reduce(series.one(), Num::multipliedBy).minus(series.one());
     }
 
     /** The higher the criterion value, the better. */
@@ -69,6 +69,6 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
         if (position.isClosed()) {
             return position.getGrossReturn(series);
         }
-        return series.one();
+        return series.zero();
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
@@ -52,7 +52,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(1.10 * 1.05, ret.calculate(series, tradingRecord));
+        assertNumEquals((1.10 * 1.05) - 1.0, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(0.95 * 0.7, ret.calculate(series, tradingRecord));
+        assertNumEquals((0.95 * 0.7) - 1.0, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(1.05 * 1.30, ret.calculate(series, tradingRecord));
+        assertNumEquals((1.05 * 1.30) - 1.0, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -82,25 +82,25 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(0.95 * 0.70, ret.calculate(series, tradingRecord));
+        assertNumEquals((0.95 * 0.70) - 1.0, ret.calculate(series, tradingRecord));
     }
 
     @Test
-    public void calculateWithNoPositionsShouldReturn1() {
+    public void calculateWithNoPositionsShouldReturnZero() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(1d, ret.calculate(series, new BaseTradingRecord()));
+        assertNumEquals(0.0, ret.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
-    public void calculateWithOpenedPositionShouldReturn1() {
+    public void calculateWithOpenedPositionShouldReturnZero() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         AnalysisCriterion ret = getCriterion();
         Position position = new Position();
-        assertNumEquals(1d, ret.calculate(series, position));
+        assertNumEquals(0, ret.calculate(series, position));
         position.operate(0);
-        assertNumEquals(1d, ret.calculate(series, position));
+        assertNumEquals(0, ret.calculate(series, position));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void testCalculateOneOpenPositionShouldReturnOne() {
-        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 1);
+    public void testCalculateOneOpenPositionShouldReturnZero() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
     }
 }


### PR DESCRIPTION
Fixes #976.

Changes proposed in this pull request:
- Return zero when there are no closed trades
- Return the gross return excluding intial cost base of 100% 

This change breaks other tests:

Results :

Failed tests:   calculateOnlyWithLossPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<0.9342654192030251> but was:<NaN>
  calculateWithLosingAShortPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<0.9654893846056297> but was:<NaN>
  calculateOnlyWithGainPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<1.0243> but was:<0.732917823152421>
  calculateWithASimplePosition[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<1.0322801154563672> but was:<0.46415888336127803>
  calculateOnlyWithGainPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<1.0243> but was:<0.7329178231524208>
  calculateWithASimplePosition[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): expected:<1.03228011545636721990604200982488691806793212890625> but was:<0.464158883361277918577769696639734320342540740966796875>
  rewardRiskRatioCriterion[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterionTest): expected:<5.189931350114416> but was:<1.0594965675057202>
  rewardRiskRatioCriterion[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterionTest): expected:<5.189931350114416> but was:<1.0594965675057209>
  calculateWithAverageProfit[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<0.9914875553891528> but was:<0.9601176082609417>
  calculateOnlyWithLossPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<0.95> but was:<1.1166666666666667>
  calculateWithOnlyOnePosition[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.3571428571428572> but was:<-3.166666666666666>
  calculateOnlyWithGainPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.1> but was:<3.1000000000000023>
  calculateWithNoPositions[Test Case: 0 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.4285714285714286> but was:<-0.0>
  calculateWithAverageProfit[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<0.9914875553891528> but was:<0.960117608260942>
  calculateOnlyWithLossPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<0.95> but was:<1.1166666666666667>
  calculateWithOnlyOnePosition[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.3571428571428572> but was:<-3.1666666666666665>
  calculateOnlyWithGainPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.1> but was:<3.1>
  calculateWithNoPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.VersusEnterAndHoldCriterionTest): expected:<1.4285714285714286> but was:<0.0>

Tests in error:
  calculateOnlyWithLossPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): Infinite or NaN
  calculateWithLosingAShortPositions[Test Case: 1 (0=DoubleNum, 1=DecimalNum)](org.ta4j.core.criteria.AverageReturnPerBarCriterionTest): Infinite or NaN

Tests run: 1119, Failures: 18, Errors: 2, Skipped: 0