### PR TITLE
Rename ReturnCriteron to ReturnMultiplierCriteron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **WinningPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars*`**
 - **DateTimeIndicator** moved to package **`indicators/helpers`**
+- **ReturnCriterion** replaced with a more appropriately named **ReturnMultiplierCriteron**, the new **ReturnCriterion** now excludes the cost
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -26,19 +26,19 @@ package org.ta4j.core.criteria;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.num.Num;
 
 /**
  * Calculates the average return per bar criterion, returned in decimal format.
  *
  * <p>
- * The {@link ReturnCriterion gross return} raised to the power of 1 divided by
+ * The {@link ReturnMultiplierCriterion gross return} raised to the power of 1 divided by
  * {@link NumberOfBarsCriterion number of bars}.
  */
 public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
 
-    private final ReturnCriterion grossReturn = new ReturnCriterion();
+    private final ReturnMultiplierCriterion grossReturn = new ReturnMultiplierCriterion();
     private final NumberOfBarsCriterion numberOfBars = new NumberOfBarsCriterion();
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
@@ -27,7 +27,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.num.Num;
 
 /**
@@ -43,7 +43,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
     private final double a;
     private final double b;
 
-    private ReturnCriterion grossReturn;
+    private ReturnMultiplierCriterion grossReturn;
 
     /**
      * Constructor. (a * x)
@@ -69,7 +69,7 @@ public class LinearTransactionCostCriterion extends AbstractAnalysisCriterion {
         this.initialAmount = initialAmount;
         this.a = a;
         this.b = b;
-        grossReturn = new ReturnCriterion();
+        grossReturn = new ReturnMultiplierCriterion();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
@@ -27,7 +27,7 @@
  * Analysis criteria can be used to compare two trading
  * {@link org.ta4j.core.Strategy strategy}.<br>
  * The most common criterion is the
- * {@link org.ta4j.core.criteria.pnl.ReturnCriterion total return criterion}. It
+ * {@link org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion total return criterion}. It
  * measures how much is profitable a strategy.
  */
 package org.ta4j.core.criteria;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -30,8 +30,11 @@ import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Return (in percentage) criterion (includes trading costs), returned in
- * decimal format.
+ * Return (excluding the initial cost) in decimal format.
+ * 
+ * For example:
+ * A 4% return will return 0.04
+ * A 4% loss will return -0.04
  *
  * <p>
  * The return of the provided {@link Position position(s)} over the provided
@@ -49,7 +52,7 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
         return tradingRecord.getPositions()
                 .stream()
                 .map(position -> calculateProfit(series, position))
-                .reduce(series.one(), Num::multipliedBy);
+                .reduce(series.one(), Num::multipliedBy).minus(series.one());
     }
 
     /** The higher the criterion value, the better. */
@@ -69,6 +72,6 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
         if (position.isClosed()) {
             return position.getGrossReturn(series);
         }
-        return series.one();
+        return series.zero();
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnMultiplierCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnMultiplierCriterion.java
@@ -21,51 +21,54 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package org.ta4j.core.criteria;
+package org.ta4j.core.criteria.pnl;
 
-import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
-import org.ta4j.core.num.NaN;
+import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
 
 /**
- * Reward risk ratio criterion, defined as the {@link ReturnMultiplierCriterion gross
- * return} over the {@link MaximumDrawdownCriterion maximum drawdown}, returned
- * in decimal format.
+ * Return (in percentage) criterion (includes trading costs), returned in
+ * decimal format.
+ *
+ * <p>
+ * The return of the provided {@link Position position(s)} over the provided
+ * {@link BarSeries series}.
  */
-public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
-
-    private final AnalysisCriterion grossReturnCriterion = new ReturnMultiplierCriterion();
-    private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
+public class ReturnMultiplierCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, position);
-        if (maxDrawdown.isZero()) {
-            return NaN.NaN;
-        } else {
-            final Num totalProfit = grossReturnCriterion.calculate(series, position);
-            return totalProfit.dividedBy(maxDrawdown);
-        }
+        return calculateProfit(series, position);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
-        if (maxDrawdown.isZero()) {
-            return NaN.NaN;
-        } else {
-            final Num totalProfit = grossReturnCriterion.calculate(series, tradingRecord);
-            return totalProfit.dividedBy(maxDrawdown);
-        }
+        return tradingRecord.getPositions()
+                .stream()
+                .map(position -> calculateProfit(series, position))
+                .reduce(series.one(), Num::multipliedBy);
     }
 
     /** The higher the criterion value, the better. */
     @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    /**
+     * Calculates the gross return of a position (Buy and sell).
+     *
+     * @param series   a bar series
+     * @param position a position
+     * @return the gross return of the position
+     */
+    private Num calculateProfit(BarSeries series, Position position) {
+        if (position.isClosed()) {
+            return position.getGrossReturn(series);
+        }
+        return series.one();
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
@@ -35,7 +35,7 @@ import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.Trade.TradeType;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.BooleanRule;
@@ -50,7 +50,7 @@ public class AbstractAnalysisCriterionTest extends AbstractCriterionTest {
     private List<Strategy> strategies;
 
     public AbstractAnalysisCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new ReturnCriterion(), numFunction);
+        super((params) -> new ReturnMultiplierCriterion(), numFunction);
     }
 
     @Before

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
@@ -36,7 +36,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
@@ -52,7 +52,7 @@ public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new ReturnCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new ReturnMultiplierCriterion());
         assertNumEquals(1.10 * 1.05 / 1.05, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -62,7 +62,7 @@ public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new ReturnCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new ReturnMultiplierCriterion());
         assertNumEquals(0.95 * 0.7 / 0.7, buyAndHold.calculate(series, tradingRecord));
     }
 
@@ -71,7 +71,7 @@ public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         Position position = new Position(Trade.buyAt(0, series), Trade.sellAt(1, series));
 
-        AnalysisCriterion buyAndHold = getCriterion(new ReturnCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new ReturnMultiplierCriterion());
         assertNumEquals((100d / 70) / (100d / 95), buyAndHold.calculate(series, position));
     }
 
@@ -79,7 +79,7 @@ public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
     public void calculateWithNoPositions() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
-        AnalysisCriterion buyAndHold = getCriterion(new ReturnCriterion());
+        AnalysisCriterion buyAndHold = getCriterion(new ReturnMultiplierCriterion());
         assertNumEquals(1 / 0.7, buyAndHold.calculate(series, new BaseTradingRecord()));
     }
 
@@ -108,7 +108,7 @@ public class VersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void betterThan() {
-        AnalysisCriterion criterion = getCriterion(new ReturnCriterion());
+        AnalysisCriterion criterion = getCriterion(new ReturnMultiplierCriterion());
         assertTrue(criterion.betterThan(numOf(2.0), numOf(1.5)));
         assertFalse(criterion.betterThan(numOf(1.5), numOf(2.0)));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnMultiplierCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnMultiplierCriterionTest.java
@@ -39,10 +39,10 @@ import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class ReturnCriterionTest extends AbstractCriterionTest {
+public class ReturnMultiplierCriterionTest extends AbstractCriterionTest {
 
-    public ReturnCriterionTest(Function<Number, Num> numFunction) {
-        super((params) -> new ReturnCriterion(), numFunction);
+    public ReturnMultiplierCriterionTest(Function<Number, Num> numFunction) {
+        super((params) -> new ReturnMultiplierCriterion(), numFunction);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals((1.10 * 1.05) - 1.0, ret.calculate(series, tradingRecord));
+        assertNumEquals(1.10 * 1.05, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals((0.95 * 0.7) - 1.0, ret.calculate(series, tradingRecord));
+        assertNumEquals(0.95 * 0.7, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals((1.05 * 1.30) - 1.0, ret.calculate(series, tradingRecord));
+        assertNumEquals(1.05 * 1.30, ret.calculate(series, tradingRecord));
     }
 
     @Test
@@ -82,25 +82,25 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
                 Trade.sellAt(2, series), Trade.buyAt(5, series));
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals((0.95 * 0.70) - 1.0, ret.calculate(series, tradingRecord));
+        assertNumEquals(0.95 * 0.70, ret.calculate(series, tradingRecord));
     }
 
     @Test
-    public void calculateWithNoPositionsShouldReturnZero() {
+    public void calculateWithNoPositionsShouldReturn1() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
 
         AnalysisCriterion ret = getCriterion();
-        assertNumEquals(0.0, ret.calculate(series, new BaseTradingRecord()));
+        assertNumEquals(1d, ret.calculate(series, new BaseTradingRecord()));
     }
 
     @Test
-    public void calculateWithOpenedPositionShouldReturnZero() {
+    public void calculateWithOpenedPositionShouldReturn1() {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
         AnalysisCriterion ret = getCriterion();
         Position position = new Position();
-        assertNumEquals(0, ret.calculate(series, position));
+        assertNumEquals(1d, ret.calculate(series, position));
         position.operate(0);
-        assertNumEquals(0, ret.calculate(series, position));
+        assertNumEquals(1d, ret.calculate(series, position));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
-    public void testCalculateOneOpenPositionShouldReturnZero() {
-        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 0);
+    public void testCalculateOneOpenPositionShouldReturnOne() {
+        openedPositionUtils.testCalculateOneOpenPositionShouldReturnExpectedValue(numFunction, getCriterion(), 1);
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -33,7 +33,7 @@ import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.PositionsRatioCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
 import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
@@ -106,7 +106,7 @@ public class Quickstart {
         System.out.println("Return over Max Drawdown: " + romad.calculate(series, tradingRecord));
 
         // Total return of our strategy vs total return of a buy-and-hold strategy
-        AnalysisCriterion vsBuyAndHold = new VersusEnterAndHoldCriterion(new ReturnCriterion());
+        AnalysisCriterion vsBuyAndHold = new VersusEnterAndHoldCriterion(new ReturnMultiplierCriterion());
         System.out.println("Our return vs buy-and-hold return: " + vsBuyAndHold.calculate(series, tradingRecord));
 
         // Your turn!

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -36,7 +36,7 @@ import org.ta4j.core.criteria.NumberOfBarsCriterion;
 import org.ta4j.core.criteria.NumberOfPositionsCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
 import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.criteria.PositionsRatioCriterion;
 
 import ta4jexamples.loaders.CsvTradesLoader;
@@ -63,7 +63,7 @@ public class StrategyAnalysis {
          */
 
         // Total profit
-        ReturnCriterion totalReturn = new ReturnCriterion();
+        ReturnMultiplierCriterion totalReturn = new ReturnMultiplierCriterion();
         System.out.println("Total return: " + totalReturn.calculate(series, tradingRecord));
         // Number of bars
         System.out.println("Number of bars: " + new NumberOfBarsCriterion().calculate(series, tradingRecord));

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -36,7 +36,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.DecimalNum;
@@ -61,7 +61,7 @@ public class SimpleMovingAverageBacktest {
                 DecimalNum.valueOf(50));
         System.out.println(tradingRecord2DaySma);
 
-        AnalysisCriterion criterion = new ReturnCriterion();
+        AnalysisCriterion criterion = new ReturnMultiplierCriterion();
         Num calculate3DaySma = criterion.calculate(series, tradingRecord3DaySma);
         Num calculate2DaySma = criterion.calculate(series, tradingRecord2DaySma);
 

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -33,7 +33,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.RSIIndicator;
@@ -94,7 +94,7 @@ public class CompareNumTypes {
         long start = System.currentTimeMillis();
         BarSeriesManager manager = new BarSeriesManager(series);
         TradingRecord record1 = manager.run(strategy1);
-        ReturnCriterion totalReturn1 = new ReturnCriterion();
+        ReturnMultiplierCriterion totalReturn1 = new ReturnMultiplierCriterion();
         Num returnResult1 = totalReturn1.calculate(series, record1);
         long end = System.currentTimeMillis();
 

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.adx.ADXIndicator;
 import org.ta4j.core.indicators.adx.MinusDIIndicator;
@@ -95,6 +95,6 @@ public class ADXStrategy {
         System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
 
         // Analysis
-        System.out.println("Total return for the strategy: " + new ReturnCriterion().calculate(series, tradingRecord));
+        System.out.println("Total return for the strategy: " + new ReturnMultiplierCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.CCIIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
@@ -85,6 +85,6 @@ public class CCICorrectionStrategy {
         System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
 
         // Analysis
-        System.out.println("Total return for the strategy: " + new ReturnCriterion().calculate(series, tradingRecord));
+        System.out.println("Total return for the strategy: " + new ReturnMultiplierCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.indicators.helpers.HighestValueIndicator;
@@ -94,6 +94,6 @@ public class GlobalExtremaStrategy {
         System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
 
         // Analysis
-        System.out.println("Total return for the strategy: " + new ReturnCriterion().calculate(series, tradingRecord));
+        System.out.println("Total return for the strategy: " + new ReturnMultiplierCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.EMAIndicator;
 import org.ta4j.core.indicators.MACDIndicator;
 import org.ta4j.core.indicators.StochasticOscillatorKIndicator;
@@ -100,6 +100,6 @@ public class MovingMomentumStrategy {
         System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
 
         // Analysis
-        System.out.println("Total profit for the strategy: " + new ReturnCriterion().calculate(series, tradingRecord));
+        System.out.println("Total profit for the strategy: " + new ReturnMultiplierCriterion().calculate(series, tradingRecord));
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -29,7 +29,7 @@ import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.indicators.RSIIndicator;
 import org.ta4j.core.indicators.SMAIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -97,7 +97,7 @@ public class RSI2Strategy {
         System.out.println("Number of positions for the strategy: " + tradingRecord.getPositionCount());
 
         // Analysis
-        System.out.println("Total return for the strategy: " + new ReturnCriterion().calculate(series, tradingRecord));
+        System.out.println("Total return for the strategy: " + new ReturnMultiplierCriterion().calculate(series, tradingRecord));
     }
 
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -36,7 +36,7 @@ import org.ta4j.core.BarSeriesManager;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.criteria.pnl.ReturnCriterion;
+import org.ta4j.core.criteria.pnl.ReturnMultiplierCriterion;
 import org.ta4j.core.num.Num;
 
 import ta4jexamples.loaders.CsvTradesLoader;
@@ -174,7 +174,7 @@ public class WalkForward {
         Map<Strategy, String> strategies = buildStrategiesMap(series);
 
         // The analysis criterion
-        AnalysisCriterion returnCriterion = new ReturnCriterion();
+        AnalysisCriterion returnCriterion = new ReturnMultiplierCriterion();
 
         for (BarSeries slice : subseries) {
             // For each sub-series...


### PR DESCRIPTION
Fixes #976 .

Changes proposed in this pull request:
- Rename existing ReturnCriteron to ReturnMultiplierCriteron (existing Ta4j code will continue to use this), e.g. 10% gain = 1.1
- Add new class ReturnCriteron which excludes the initial cost, e.g. 10% gain = 0.1
- Add line in changelog