### PR TITLE
Add missing `@Override` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **CachedIndicator** synchronize on getValue()
 - **BaseBar** defaults to **`DecimalNum`** type in all constructors
 - improved javadoc
+- add missing `@Override` annotation
 
 ### Removed/Deprecated
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -345,76 +345,46 @@ public class BaseBar implements Bar {
         return beginTime;
     }
 
-    /**
-     * @return the end timestamp of the bar period
-     */
     @Override
     public ZonedDateTime getEndTime() {
         return endTime;
     }
 
-    /**
-     * @return the open price of the bar period
-     */
     @Override
     public Num getOpenPrice() {
         return openPrice;
     }
 
-    /**
-     * @return the high price of the bar period
-     */
     @Override
     public Num getHighPrice() {
         return highPrice;
     }
 
-    /**
-     * @return the low price of the bar period
-     */
     @Override
     public Num getLowPrice() {
         return lowPrice;
     }
 
-    /**
-     * @return the close price of the bar period
-     */
     @Override
     public Num getClosePrice() {
         return closePrice;
     }
 
-    /**
-     * @return the total traded volume of the bar period
-     */
     @Override
     public Num getVolume() {
         return volume;
     }
 
-    /**
-     * @return the total traded amount (tradePrice x tradeVolume) of the bar period
-     */
     @Override
     public Num getAmount() {
         return amount;
     }
 
-    /**
-     * @return the number of trades of the bar period
-     */
     @Override
     public long getTrades() {
         return trades;
     }
 
-    /**
-     * Adds a trade at the end of the bar period.
-     *
-     * @param tradeVolume the traded volume
-     * @param tradePrice  the trade price per asset
-     */
     @Override
     public void addTrade(Num tradeVolume, Num tradePrice) {
         addPrice(tradePrice);

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -80,7 +80,7 @@ public class FixedTransactionCostModel implements CostModel {
      * <b>Note:</b> Both {@code price} and {@code amount} are irrelevant as the fee
      * in {@code FixedTransactionCostModel} is always the same.
      *
-     * @return {@link feePerTrade}
+     * @return {@link #feePerTrade}
      */
     @Override
     public Num calculate(Num price, Num amount) {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
@@ -52,17 +52,13 @@ public class LinearTransactionCostModel implements CostModel {
      * @param position     the position
      * @param currentIndex current bar index (irrelevant for the
      *                     LinearTransactionCostModel)
-     * @return the absolute trading cost of the single {@code position}
+     * @return the trading cost of the single {@code position}
      */
     @Override
     public Num calculate(Position position, int currentIndex) {
         return this.calculate(position);
     }
 
-    /**
-     * @param position the position
-     * @return the absolute trading cost of the single {@code position}
-     */
     @Override
     public Num calculate(Position position) {
         Num totalPositionCost = null;

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -312,8 +312,6 @@ public final class DecimalNum implements Num {
      * Returns a {@code Num} whose value is {@code (this - augend)}, with rounding
      * according to the context settings.
      *
-     * @param subtrahend value to be subtracted from this {@code Num}.
-     * @return {@code this - subtrahend}, rounded as necessary
      * @see BigDecimal#subtract(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
@@ -331,8 +329,6 @@ public final class DecimalNum implements Num {
      * Returns a {@code Num} whose value is {@code this * multiplicand}, with
      * rounding according to the context settings.
      *
-     * @param multiplicand value to be multiplied by this {@code Num}.
-     * @return {@code this * multiplicand}, rounded as necessary
      * @see BigDecimal#multiply(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
@@ -350,8 +346,6 @@ public final class DecimalNum implements Num {
      * Returns a {@code Num} whose value is {@code (this / divisor)}, with rounding
      * according to the context settings.
      *
-     * @param divisor value by which this {@code Num} is to be divided.
-     * @return {@code this / divisor}, rounded as necessary
      * @see BigDecimal#divide(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
@@ -369,8 +363,6 @@ public final class DecimalNum implements Num {
      * Returns a {@code Num} whose value is {@code (this % divisor)}, with rounding
      * according to the context settings.
      *
-     * @param divisor value by which this {@code Num} is to be divided.
-     * @return {@code this % divisor}, rounded as necessary.
      * @see BigDecimal#remainder(java.math.BigDecimal, java.math.MathContext)
      */
     @Override
@@ -424,7 +416,6 @@ public final class DecimalNum implements Num {
         switch (comparedToZero) {
         case -1:
             return NaN;
-
         case 0:
             return DecimalNum.valueOf(0);
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
@@ -65,6 +65,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
      * @return BarSeries from the file
      * @throws Exception if getSeries throws IOException or DataFormatException
      */
+    @Override
     public BarSeries getSeries() throws Exception {
         if (cachedSeries == null) {
             cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction);
@@ -80,6 +81,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
      * @throws Exception if getFinalCriterionValue throws IOException or
      *                   DataFormatException
      */
+    @Override
     public Num getFinalCriterionValue(Object... params) throws Exception {
         return XlsTestsUtils.getFinalCriterionValue(clazz, fileName, criterionColumn, getSeries().function(), params);
     }
@@ -89,6 +91,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
      * 
      * @return TradingRecord from the file
      */
+    @Override
     public TradingRecord getTradingRecord() throws Exception {
         return XlsTestsUtils.getTradingRecord(clazz, fileName, statesColumn, getSeries().function());
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -59,6 +59,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
      * @return BarSeries from the file
      * @throws Exception if getSeries throws IOException or DataFormatException
      */
+    @Override
     public BarSeries getSeries() throws Exception {
         if (cachedSeries == null) {
             cachedSeries = XlsTestsUtils.getSeries(clazz, fileName, numFunction);
@@ -73,6 +74,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
      * @return Indicator from the file given the parameters
      * @throws Exception if getIndicator throws IOException or DataFormatException
      */
+    @Override
     public Indicator<Num> getIndicator(Object... params) throws Exception {
         return XlsTestsUtils.getIndicator(clazz, fileName, column, getSeries().function(), params);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
@@ -53,6 +53,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
      * @param series   BarSeries is ignored
      * @param position is ignored
      */
+    @Override
     public Num calculate(BarSeries series, Position position) {
         return values.get(values.size() - 1);
     }
@@ -63,6 +64,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
      * @param series        BarSeries is ignored
      * @param tradingRecord is ignored
      */
+    @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         return values.get(values.size() - 1);
     }
@@ -75,6 +77,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
      * @param criterionValue2 second value
      * @return boolean indicating first value is greater than second value
      */
+    @Override
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return criterionValue1.isGreaterThan(criterionValue2);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
@@ -51,6 +51,7 @@ public class MockIndicator implements Indicator<Num> {
      * @param index Indicator value to get
      * @return Num Indicator value at index
      */
+    @Override
     public Num getValue(int index) {
         return values.get(index);
     }
@@ -65,6 +66,7 @@ public class MockIndicator implements Indicator<Num> {
      * 
      * @return TimeSeries of the Indicator
      */
+    @Override
     public BarSeries getBarSeries() {
         return series;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -34,10 +34,10 @@ import org.ta4j.core.criteria.LinearTransactionCostCriterion;
 import org.ta4j.core.criteria.MaximumDrawdownCriterion;
 import org.ta4j.core.criteria.NumberOfBarsCriterion;
 import org.ta4j.core.criteria.NumberOfPositionsCriterion;
+import org.ta4j.core.criteria.PositionsRatioCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
 import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.pnl.ReturnCriterion;
-import org.ta4j.core.criteria.PositionsRatioCriterion;
 
 import ta4jexamples.loaders.CsvTradesLoader;
 import ta4jexamples.strategies.MovingMomentumStrategy;

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -28,7 +28,6 @@ import java.util.Date;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
-import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.DatasetRenderingOrder;

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -26,7 +26,6 @@ package ta4jexamples.loaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -35,14 +34,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.opencsv.CSVParser;
-import com.opencsv.CSVParserBuilder;
-import com.opencsv.CSVReaderBuilder;
-import com.opencsv.exceptions.CsvValidationException;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * This class build a Ta4j bar series from a CSV file containing bars.

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -23,9 +23,7 @@
  */
 package ta4jexamples.loaders;
 
-import java.io.IOException;
 import java.io.InputStream;
-
 import java.io.InputStreamReader;
 import java.time.Duration;
 import java.time.Instant;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- add missing `@Override` annotations
- removed redundant javadoc (because `@Override` annotated methods inherit the javadoc of its parent)

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
