### PR TITLE
`FixedDecimalIndicator` renamed to `FixedNumIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **NetLossCriterion** and **GrossLossCriterion** replaced by **`LossCriterion`**
 - **LosingPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
 - **WinningPositionsRatioCriterion** replaced by **`PositionsRatioCriterion`**
-- **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars*`**
+- **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars`**
 - **DateTimeIndicator** moved to package **`indicators/helpers`**
 - **UnstableIndicator** moved to package **`indicators/helpers`**
+- **FixedDecimalIndicator** renamed to **`FixedNumIndicator`**
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedNumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedNumIndicator.java
@@ -34,15 +34,14 @@ import org.ta4j.core.num.Num;
  * <p>
  * Returns constant {@link Num} values for a bar.
  */
-public class FixedDecimalIndicator extends FixedIndicator<Num> {
+public class FixedNumIndicator extends FixedIndicator<Num> {
 
     /**
      * Constructor.
-     *
-     * @param series the bar series
+     * 
      * @param values the values to be returned by this indicator
      */
-    public FixedDecimalIndicator(BarSeries series, double... values) {
+    public FixedNumIndicator(BarSeries series, double... values) {
         super(series);
         for (double value : values) {
             addValue(numOf(value));
@@ -51,11 +50,10 @@ public class FixedDecimalIndicator extends FixedIndicator<Num> {
 
     /**
      * Constructor.
-     *
-     * @param series the bar series
+     * 
      * @param values the values to be returned by this indicator
      */
-    public FixedDecimalIndicator(BarSeries series, String... values) {
+    public FixedNumIndicator(BarSeries series, String... values) {
         super(series);
         for (String value : values) {
             addValue(numOf(new BigDecimal(value)));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
@@ -64,17 +64,17 @@ public class ConvergenceDivergenceIndicatorTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        refPosCon = new FixedDecimalIndicator(series, 1, 2, 3, 4, 5, 8, 3, 2, -2, 1);
-        otherPosCon = new FixedDecimalIndicator(series, 10, 20, 30, 40, 50, 60, 7, 5, 3, 2);
+        refPosCon = new FixedNumIndicator(series, 1, 2, 3, 4, 5, 8, 3, 2, -2, 1);
+        otherPosCon = new FixedNumIndicator(series, 10, 20, 30, 40, 50, 60, 7, 5, 3, 2);
 
-        refNegCon = new FixedDecimalIndicator(series, 150, 60, 20, 10, -20, -60, -200, -1, -200, 100);
-        otherNegCon = new FixedDecimalIndicator(series, 80, 50, 40, 20, 10, 0, -30, -50, -150, 7);
+        refNegCon = new FixedNumIndicator(series, 150, 60, 20, 10, -20, -60, -200, -1, -200, 100);
+        otherNegCon = new FixedNumIndicator(series, 80, 50, 40, 20, 10, 0, -30, -50, -150, 7);
 
-        refPosDiv = new FixedDecimalIndicator(series, 1, 4, 8, 12, 15, 20, 3, 2, -2, 1);
-        otherNegDiv = new FixedDecimalIndicator(series, 80, 50, 20, -10, 0, -100, -200, -2, 5, 7);
+        refPosDiv = new FixedNumIndicator(series, 1, 4, 8, 12, 15, 20, 3, 2, -2, 1);
+        otherNegDiv = new FixedNumIndicator(series, 80, 50, 20, -10, 0, -100, -200, -2, 5, 7);
 
-        refNegDig = new FixedDecimalIndicator(series, 100, 30, 15, 4, 2, -10, -3, -100, -2, 100);
-        otherPosDiv = new FixedDecimalIndicator(series, 20, 40, 70, 80, 90, 100, 200, 220, -50, 7);
+        refNegDig = new FixedNumIndicator(series, 100, 30, 15, 4, 2, -10, -3, -100, -2, 100);
+        otherPosDiv = new FixedNumIndicator(series, 20, 40, 70, 80, 90, 100, 200, 220, -50, 7);
 
         // for convergence and divergence
         isPosCon = new ConvergenceDivergenceIndicator(refPosCon, otherPosCon, 3,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedNumIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedNumIndicatorTest.java
@@ -30,17 +30,17 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 
-public class FixedIndicatorTest {
+public class FixedNumIndicatorTest {
 
     @Test
     public void getValueOnFixedDecimalIndicator() {
         BarSeries series = new BaseBarSeries();
-        FixedDecimalIndicator fixedDecimalIndicator = new FixedDecimalIndicator(series, 13.37, 42, -17);
+        FixedNumIndicator fixedDecimalIndicator = new FixedNumIndicator(series, 13.37, 42, -17);
         assertNumEquals(13.37, fixedDecimalIndicator.getValue(0));
         assertNumEquals(42, fixedDecimalIndicator.getValue(1));
         assertNumEquals(-17, fixedDecimalIndicator.getValue(2));
 
-        fixedDecimalIndicator = new FixedDecimalIndicator(series, "3.0", "-123.456", "0.0");
+        fixedDecimalIndicator = new FixedNumIndicator(series, "3.0", "-123.456", "0.0");
         assertNumEquals("3.0", fixedDecimalIndicator.getValue(0));
         assertNumEquals("-123.456", fixedDecimalIndicator.getValue(1));
         assertNumEquals("0.0", fixedDecimalIndicator.getValue(2));

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.helper.ChainLink;
 
@@ -42,7 +42,7 @@ public class ChainRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 6, 5, 8, 5, 1, 10, 2, 30);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 6, 5, 8, 5, 1, 10, 2, 30);
         UnderIndicatorRule underIndicatorRule = new UnderIndicatorRule(indicator, series.numOf(5));
         OverIndicatorRule overIndicatorRule = new OverIndicatorRule(indicator, 7);
         IsEqualRule isEqualRule = new IsEqualRule(indicator, 5);

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class CrossedDownIndicatorRuleTest {
@@ -41,7 +41,7 @@ public class CrossedDownIndicatorRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 12, 11, 10, 9, 11, 8, 7, 6);
+        Indicator<Num> evaluatedIndicator = new FixedNumIndicator(series, 12, 11, 10, 9, 11, 8, 7, 6);
         rule = new CrossedDownIndicatorRule(evaluatedIndicator, 10);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class CrossedUpIndicatorRuleTest {
@@ -39,8 +39,8 @@ public class CrossedUpIndicatorRuleTest {
 
     @Before
     public void setUp() {
-        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(new BaseBarSeries(), 8d, 9d, 10d, 12d, 9d, 11d,
-                12d, 13d);
+        Indicator<Num> evaluatedIndicator = new FixedNumIndicator(new BaseBarSeries(), 8d, 9d, 10d, 12d, 9d, 11d, 12d,
+                13d);
         rule = new CrossedUpIndicatorRule(evaluatedIndicator, 10);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class InPipeRuleTest {
@@ -41,7 +41,7 @@ public class InPipeRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries("I am empty");
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 50d, 70d, 80d, 90d, 99d, 60d, 30d, 20d, 10d, 0d);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 50d, 70d, 80d, 90d, 99d, 60d, 30d, 20d, 10d, 0d);
         rule = new InPipeRule(indicator, series.numOf(80), series.numOf(20));
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class InSlopeRuleTest {
@@ -42,7 +42,7 @@ public class InSlopeRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 50, 70, 80, 90, 99, 60, 30, 20, 10, 0);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 50, 70, 80, 90, 99, 60, 30, 20, 10, 0);
         rulePositiveSlope = new InSlopeRule(indicator, series.numOf(20), series.numOf(30));
         ruleNegativeSlope = new InSlopeRule(indicator, series.numOf(-40), series.numOf(-20));
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class IsEqualRuleTest {
@@ -41,7 +41,7 @@ public class IsEqualRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 20, 10, 0, -20);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 20, 10, 0, -20);
         rule = new IsEqualRule(indicator, series.numOf(20));
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class IsFallingRuleTest {
@@ -41,7 +41,7 @@ public class IsFallingRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 6, 5, 4, 3, 2, 1, 0, -1, 2, 3);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 6, 5, 4, 3, 2, 1, 0, -1, 2, 3);
         rule = new IsFallingRule(indicator, 3);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class IsHighestRuleTest {
@@ -41,7 +41,7 @@ public class IsHighestRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 1, 5, 3, 6, 5, 7, 0, -1, 2, 3);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 1, 5, 3, 6, 5, 7, 0, -1, 2, 3);
         rule = new IsHighestRule(indicator, 3);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class IsLowestRuleTest {
@@ -41,7 +41,7 @@ public class IsLowestRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 1, -5, 3, -6, 5, -7, 0, -1, 2, -8);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 1, -5, 3, -6, 5, -7, 0, -1, 2, -8);
         rule = new IsLowestRule(indicator, 3);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class IsRisingRuleTest {
@@ -41,7 +41,7 @@ public class IsRisingRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3);
         rule = new IsRisingRule(indicator, 3);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class OverIndicatorRuleTest {
@@ -41,7 +41,7 @@ public class OverIndicatorRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 20, 15, 10, 5, 0, -5, -10, 100);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 20, 15, 10, 5, 0, -5, -10, 100);
         rule = new OverIndicatorRule(indicator, series.numOf(5));
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
+import org.ta4j.core.indicators.helpers.FixedNumIndicator;
 import org.ta4j.core.num.Num;
 
 public class UnderIndicatorRuleTest {
@@ -41,7 +41,7 @@ public class UnderIndicatorRuleTest {
     @Before
     public void setUp() {
         BarSeries series = new BaseBarSeries();
-        Indicator<Num> indicator = new FixedDecimalIndicator(series, 0, 5, 8, 5, 1, 10, 20, 30);
+        Indicator<Num> indicator = new FixedNumIndicator(series, 0, 5, 8, 5, 1, 10, 20, 30);
         rule = new UnderIndicatorRule(indicator, series.numOf(5));
     }
 


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- `FixedDecimalIndicator` renamed to `FixedNumIndicator`

Reason:
The name `Decimal` was the former name of `Num`.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
