### PR TITLE
added `NumIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added "lessIsBetter"-property for **VarianceCriterion**
 - added "lessIsBetter"-property for **NumberOfPositionsCriterion**
 - added "addBase"-property for **ReturnCriterion** to include or exclude the base percentage of 1
+- added **NumIndicator** to calculate any `Num`-value for a `Bar`
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
@@ -1,0 +1,73 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import java.util.function.Function;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * Num indicator.
+ * 
+ * <p>
+ * Returns a {@link Num} of (or for) a bar.
+ * 
+ * <p>
+ * <b>Hint:</b> It is recommended to use the {@code NumIndicator} with its
+ * {@link #action} mainly for complex functions and not for simple get
+ * functions. For simple get functions it might be better to use the
+ * corresponding indicator due to better readability and complexity (e.g. to get
+ * the close price just use the {@code ClosePriceIndicator} instead of the
+ * {@code NumIndicator}).
+ */
+public class NumIndicator extends CachedIndicator<Num> {
+
+    /** The action to calculate or determine a num on the bar. */
+    private final Function<Bar, Num> action;
+
+    /**
+     * Constructor.
+     * 
+     * @param barSeries the bar series
+     * @param action    the action to calculate or determine a num on the bar
+     */
+    public NumIndicator(BarSeries barSeries, Function<Bar, Num> action) {
+        super(barSeries);
+        this.action = action;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+        Bar bar = getBarSeries().getBar(index);
+        return this.action.apply(bar);
+    }
+
+    @Override
+    public int getUnstableBars() {
+        return 0;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
@@ -1,0 +1,60 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.helpers;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
+
+public class NumndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    private NumIndicator closePrice;
+    private BarSeries barSeries;
+
+    public NumndicatorTest(Function<Number, Num> numFunction) {
+        super(numFunction);
+    }
+
+    @Before
+    public void setUp() {
+        barSeries = new MockBarSeries(numFunction);
+        closePrice = new NumIndicator(barSeries, Bar::getClosePrice);
+    }
+
+    @Test
+    public void indicatorShouldRetrieveBarClosePrice() {
+        for (int i = 0; i < 10; i++) {
+            assertEquals(closePrice.getValue(i), barSeries.getBar(i).getClosePrice());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- added **NumIndicator** to calculate any `Num`-value for a `Bar`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 


_The `NumIndicator` complements the existing `DateTimeIndicator`.
With the `NumIndicator`, we can extract or calculate any `Num`-value from/for a bar._
