### PR TITLE
rename `operate()` to `trade()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Strategy#unstablePeriod** renamed to **`Strategy#unstableBars*`**
 - **DateTimeIndicator** moved to package **`indicators/helpers`**
 - **UnstableIndicator** moved to package **`indicators/helpers`**
+- **Strategy#shouldOperate** renamed to **`Strategy#shouldTrade`**
+- **TradingRecord#operate** renamed to **`TradingRecord#trade`**
+- **Position#operate** renamed to **`Position#trade`**
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesManager.java
@@ -184,8 +184,8 @@ public class BarSeriesManager {
 
         for (int i = runBeginIndex; i <= runEndIndex; i++) {
             // For each bar between both indexes...
-            if (strategy.shouldOperate(i, tradingRecord)) {
-                tradingRecord.operate(i, barSeries.getBar(i).getClosePrice(), amount);
+            if (strategy.shouldTrade(i, tradingRecord)) {
+                tradingRecord.trade(i, barSeries.getBar(i).getClosePrice(), amount);
             }
         }
 
@@ -197,8 +197,8 @@ public class BarSeriesManager {
             for (int i = runEndIndex + 1; i < seriesMaxSize; i++) {
                 // For each bar after the end index of this run...
                 // --> Trying to close the last position
-                if (strategy.shouldOperate(i, tradingRecord)) {
-                    tradingRecord.operate(i, barSeries.getBar(i).getClosePrice(), amount);
+                if (strategy.shouldTrade(i, tradingRecord)) {
+                    tradingRecord.trade(i, barSeries.getBar(i).getClosePrice(), amount);
                     break;
                 }
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -203,7 +203,7 @@ public class BaseTradingRecord implements TradingRecord {
                 // BUY, SELL
                 currentPosition = new Position(o.getType(), transactionCostModel, holdingCostModel);
             }
-            Trade newTrade = currentPosition.operate(o.getIndex(), o.getPricePerAsset(), o.getAmount());
+            Trade newTrade = currentPosition.trade(o.getIndex(), o.getPricePerAsset(), o.getAmount());
             recordTrade(newTrade, newTradeWillBeAnEntry);
         }
     }
@@ -224,20 +224,20 @@ public class BaseTradingRecord implements TradingRecord {
     }
 
     @Override
-    public void operate(int index, Num price, Num amount) {
+    public void trade(int index, Num price, Num amount) {
         if (currentPosition.isClosed()) {
             // Current position closed, should not occur
             throw new IllegalStateException("Current position should not be closed");
         }
         boolean newTradeWillBeAnEntry = currentPosition.isNew();
-        Trade newTrade = currentPosition.operate(index, price, amount);
+        Trade newTrade = currentPosition.trade(index, price, amount);
         recordTrade(newTrade, newTradeWillBeAnEntry);
     }
 
     @Override
     public boolean enter(int index, Num price, Num amount) {
         if (currentPosition.isNew()) {
-            operate(index, price, amount);
+            trade(index, price, amount);
             return true;
         }
         return false;
@@ -246,7 +246,7 @@ public class BaseTradingRecord implements TradingRecord {
     @Override
     public boolean exit(int index, Num price, Num amount) {
         if (currentPosition.isOpened()) {
-            operate(index, price, amount);
+            trade(index, price, amount);
             return true;
         }
         return false;

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -158,24 +158,30 @@ public class Position implements Serializable {
     }
 
     /**
-     * Operates the position at the index-th position
+     * Executes a trade on the position at the index-th position.
      * 
      * @param index the bar index
      * @return the trade
+     * @see #trade(int, Num, Num)
      */
-    public Trade operate(int index) {
-        return operate(index, NaN, NaN);
+    public Trade trade(int index) {
+        return trade(index, NaN, NaN);
     }
 
     /**
-     * Operates the position at the index-th position
+     * Executes a trade on the position at the index-th position.
+     * 
+     * <p>
+     * Creates an entry trade if {@link #isNew()} (i.e. opens the new position).
+     * Otherwise, creates an exit trade (i.e. closes the existing position).
      * 
      * @param index  the bar index
      * @param price  the price
      * @param amount the amount
      * @return the trade
+     * @throws IllegalStateException if {@link #isOpened()} and index < entry.index
      */
-    public Trade operate(int index, Num price, Num amount) {
+    public Trade trade(int index, Num price, Num amount) {
         Trade trade = null;
         if (isNew()) {
             trade = new Trade(index, startingType, price, amount, transactionCostModel);

--- a/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
@@ -106,7 +106,7 @@ public interface Strategy {
      * @param tradingRecord the potentially needed trading history
      * @return true to recommend a trade, false otherwise (no recommendation)
      */
-    default boolean shouldOperate(int index, TradingRecord tradingRecord) {
+    default boolean shouldTrade(int index, TradingRecord tradingRecord) {
         Position position = tradingRecord.getCurrentPosition();
         if (position.isNew()) {
             return shouldEnter(index, tradingRecord);

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -59,8 +59,8 @@ public interface TradingRecord extends Serializable {
      * 
      * @param index the index to place the trade
      */
-    default void operate(int index) {
-        operate(index, NaN, NaN);
+    default void trade(int index) {
+        trade(index, NaN, NaN);
     }
 
     /**
@@ -70,7 +70,7 @@ public interface TradingRecord extends Serializable {
      * @param price  the trade price
      * @param amount the trade amount
      */
-    void operate(int index, Num price, Num amount);
+    void trade(int index, Num price, Num amount);
 
     /**
      * Places an entry trade in the trading record.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -89,8 +89,8 @@ public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
 
     private Position createEnterAndHoldTrade(BarSeries series, int beginIndex, int endIndex) {
         Position position = new Position(this.tradeType);
-        position.operate(beginIndex, series.getBar(beginIndex).getClosePrice(), series.one());
-        position.operate(endIndex, series.getBar(endIndex).getClosePrice(), series.one());
+        position.trade(beginIndex, series.getBar(beginIndex).getClosePrice(), series.one());
+        position.trade(endIndex, series.getBar(endIndex).getClosePrice(), series.one());
         return position;
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
@@ -57,20 +57,20 @@ public class PositionTest {
         this.uncoveredPosition = new Position(TradeType.SELL);
 
         posEquals1 = new Position();
-        posEquals1.operate(1);
-        posEquals1.operate(2);
+        posEquals1.trade(1);
+        posEquals1.trade(2);
 
         posEquals2 = new Position();
-        posEquals2.operate(1);
-        posEquals2.operate(2);
+        posEquals2.trade(1);
+        posEquals2.trade(2);
 
         posNotEquals1 = new Position(TradeType.SELL);
-        posNotEquals1.operate(1);
-        posNotEquals1.operate(2);
+        posNotEquals1.trade(1);
+        posNotEquals1.trade(2);
 
         posNotEquals2 = new Position(TradeType.SELL);
-        posNotEquals2.operate(1);
-        posNotEquals2.operate(2);
+        posNotEquals2.trade(1);
+        posNotEquals2.trade(2);
 
         transactionModel = new LinearTransactionCostModel(0.01);
         holdingModel = new LinearBorrowingCostModel(0.001);
@@ -82,7 +82,7 @@ public class PositionTest {
 
     @Test
     public void whenNewShouldCreateBuyOrderWhenEntering() {
-        newPosition.operate(0);
+        newPosition.trade(0);
         assertEquals(Trade.buyAt(0, NaN, NaN), newPosition.getEntry());
     }
 
@@ -93,30 +93,30 @@ public class PositionTest {
 
     @Test
     public void whenOpenedShouldCreateSellOrderWhenExiting() {
-        newPosition.operate(0);
-        newPosition.operate(1);
+        newPosition.trade(0);
+        newPosition.trade(1);
         assertEquals(Trade.sellAt(1, NaN, NaN), newPosition.getExit());
     }
 
     @Test
     public void whenClosedShouldNotEnter() {
-        newPosition.operate(0);
-        newPosition.operate(1);
+        newPosition.trade(0);
+        newPosition.trade(1);
         assertTrue(newPosition.isClosed());
-        newPosition.operate(2);
+        newPosition.trade(2);
         assertTrue(newPosition.isClosed());
     }
 
     @Test(expected = IllegalStateException.class)
     public void whenExitIndexIsLessThanEntryIndexShouldThrowException() {
-        newPosition.operate(3);
-        newPosition.operate(1);
+        newPosition.trade(3);
+        newPosition.trade(1);
     }
 
     @Test
     public void shouldClosePositionOnSameIndex() {
-        newPosition.operate(3);
-        newPosition.operate(3);
+        newPosition.trade(3);
+        newPosition.trade(3);
         assertTrue(newPosition.isClosed());
     }
 
@@ -132,14 +132,14 @@ public class PositionTest {
 
     @Test
     public void whenNewShouldCreateSellOrderWhenEnteringUncovered() {
-        uncoveredPosition.operate(0);
+        uncoveredPosition.trade(0);
         assertEquals(Trade.sellAt(0, NaN, NaN), uncoveredPosition.getEntry());
     }
 
     @Test
     public void whenOpenedShouldCreateBuyOrderWhenExitingUncovered() {
-        uncoveredPosition.operate(0);
-        uncoveredPosition.operate(1);
+        uncoveredPosition.trade(0);
+        uncoveredPosition.trade(1);
         assertEquals(Trade.buyAt(1, NaN, NaN), uncoveredPosition.getExit());
     }
 
@@ -163,11 +163,11 @@ public class PositionTest {
         Position trRightEquals = new Position();
         Position trRightNotEquals = new Position();
 
-        assertEquals(TradeType.BUY, trRightNotEquals.operate(2).getType());
+        assertEquals(TradeType.BUY, trRightNotEquals.trade(2).getType());
         assertNotEquals(trLeft, trRightNotEquals);
 
-        assertEquals(TradeType.BUY, trLeft.operate(1).getType());
-        assertEquals(TradeType.BUY, trRightEquals.operate(1).getType());
+        assertEquals(TradeType.BUY, trLeft.trade(1).getType());
+        assertEquals(TradeType.BUY, trRightEquals.trade(1).getType());
         assertEquals(trLeft, trRightEquals);
 
         assertNotEquals(trLeft, trRightNotEquals);
@@ -179,15 +179,15 @@ public class PositionTest {
         Position trRightEquals = new Position();
         Position trRightNotEquals = new Position();
 
-        assertEquals(TradeType.BUY, trLeft.operate(1).getType());
-        assertEquals(TradeType.BUY, trRightEquals.operate(1).getType());
-        assertEquals(TradeType.BUY, trRightNotEquals.operate(1).getType());
+        assertEquals(TradeType.BUY, trLeft.trade(1).getType());
+        assertEquals(TradeType.BUY, trRightEquals.trade(1).getType());
+        assertEquals(TradeType.BUY, trRightNotEquals.trade(1).getType());
 
-        assertEquals(TradeType.SELL, trRightNotEquals.operate(3).getType());
+        assertEquals(TradeType.SELL, trRightNotEquals.trade(3).getType());
         assertNotEquals(trLeft, trRightNotEquals);
 
-        assertEquals(TradeType.SELL, trLeft.operate(2).getType());
-        assertEquals(TradeType.SELL, trRightEquals.operate(2).getType());
+        assertEquals(TradeType.SELL, trLeft.trade(2).getType());
+        assertEquals(TradeType.SELL, trRightEquals.trade(2).getType());
         assertEquals(trLeft, trRightEquals);
 
         assertNotEquals(trLeft, trRightNotEquals);
@@ -197,8 +197,8 @@ public class PositionTest {
     public void testGetProfitForLongPositions() {
         Position position = new Position(TradeType.BUY);
 
-        position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
-        position.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
 
         final Num profit = position.getProfit();
 
@@ -209,8 +209,8 @@ public class PositionTest {
     public void testGetProfitForShortPositions() {
         Position position = new Position(TradeType.SELL);
 
-        position.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
-        position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
 
         final Num profit = position.getProfit();
 
@@ -221,8 +221,8 @@ public class PositionTest {
     public void testGetGrossReturnForLongPositions() {
         Position position = new Position(TradeType.BUY);
 
-        position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
-        position.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
 
         final Num profit = position.getGrossReturn();
 
@@ -233,8 +233,8 @@ public class PositionTest {
     public void testGetGrossReturnForShortPositions() {
         Position position = new Position(TradeType.SELL);
 
-        position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
-        position.operate(0, DoubleNum.valueOf(8.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
+        position.trade(0, DoubleNum.valueOf(8.00), DoubleNum.valueOf(2));
 
         final Num profit = position.getGrossReturn();
 
@@ -274,7 +274,7 @@ public class PositionTest {
     public void getProfitLongNoFinalBarTest() {
         Position closedPosition = new Position(enter, exitSameType, transactionModel, holdingModel);
         Position openPosition = new Position(TradeType.BUY, transactionModel, holdingModel);
-        openPosition.operate(5, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        openPosition.trade(5, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
 
         Num profitOfClosedPosition = closedPosition.getProfit();
         Num proftOfOpenPosition = openPosition.getProfit();
@@ -287,7 +287,7 @@ public class PositionTest {
     public void getProfitLongWithFinalBarTest() {
         Position closedPosition = new Position(enter, exitSameType, transactionModel, holdingModel);
         Position openPosition = new Position(TradeType.BUY, transactionModel, holdingModel);
-        openPosition.operate(5, DoubleNum.valueOf(2), DoubleNum.valueOf(1));
+        openPosition.trade(5, DoubleNum.valueOf(2), DoubleNum.valueOf(1));
 
         Num profitOfClosedPosition = closedPosition.getProfit(10, DoubleNum.valueOf(12));
         Num profitOfOpenPosition = openPosition.getProfit(10, DoubleNum.valueOf(12));
@@ -303,7 +303,7 @@ public class PositionTest {
 
         Position closedPosition = new Position(sell, buyBack, transactionModel, holdingModel);
         Position openPosition = new Position(TradeType.SELL, transactionModel, holdingModel);
-        openPosition.operate(5, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        openPosition.trade(5, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
 
         Num profitOfClosedPosition = closedPosition.getProfit();
         Num proftOfOpenPosition = openPosition.getProfit();
@@ -322,7 +322,7 @@ public class PositionTest {
 
         Position closedPosition = new Position(sell, buyBack, transactionModel, holdingModel);
         Position openPosition = new Position(TradeType.SELL, transactionModel, holdingModel);
-        openPosition.operate(5, DoubleNum.valueOf(2), DoubleNum.valueOf(1));
+        openPosition.trade(5, DoubleNum.valueOf(2), DoubleNum.valueOf(1));
 
         Num profitOfClosedPositionFinalAfter = closedPosition.getProfit(20, DoubleNum.valueOf(3));
         Num profitOfOpenPositionFinalAfter = openPosition.getProfit(20, DoubleNum.valueOf(3));

--- a/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
@@ -56,7 +56,7 @@ public class TradingRecordTest {
     public void operate() {
         TradingRecord record = new BaseTradingRecord();
 
-        record.operate(1);
+        record.trade(1);
         assertTrue(record.getCurrentPosition().isOpened());
         assertEquals(0, record.getPositionCount());
         assertNull(record.getLastPosition());
@@ -66,7 +66,7 @@ public class TradingRecordTest {
         assertEquals(Trade.buyAt(1, NaN, NaN), record.getLastEntry());
         assertNull(record.getLastExit());
 
-        record.operate(3);
+        record.trade(3);
         assertTrue(record.getCurrentPosition().isNew());
         assertEquals(1, record.getPositionCount());
         assertEquals(new Position(Trade.buyAt(1, NaN, NaN), Trade.sellAt(3, NaN, NaN)), record.getLastPosition());
@@ -76,7 +76,7 @@ public class TradingRecordTest {
         assertEquals(Trade.buyAt(1, NaN, NaN), record.getLastEntry());
         assertEquals(Trade.sellAt(3, NaN, NaN), record.getLastExit());
 
-        record.operate(5);
+        record.trade(5);
         assertTrue(record.getCurrentPosition().isOpened());
         assertEquals(1, record.getPositionCount());
         assertEquals(new Position(Trade.buyAt(1, NaN, NaN), Trade.sellAt(3, NaN, NaN)), record.getLastPosition());

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
@@ -51,7 +51,7 @@ public class FixedTransactionCostModelTest {
         FixedTransactionCostModel model = new FixedTransactionCostModel(feePerTrade);
 
         Position position = new Position(TradeType.BUY, model, null);
-        position.operate(0, PRICE, AMOUNT);
+        position.trade(0, PRICE, AMOUNT);
         Num cost = model.calculate(position);
 
         assertNumEquals(cost, DoubleNum.valueOf(feePerTrade * positionTrades));

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
@@ -91,7 +91,7 @@ public class LinearBorrowingCostModelTest {
         // for until current index
         int currentIndex = 4;
         Position position = new Position(Trade.TradeType.SELL, new ZeroCostModel(), borrowingModel);
-        position.operate(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        position.trade(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
 
         Num costsFromPosition = position.getHoldingCost(currentIndex);
         Num costsFromModel = borrowingModel.calculate(position, currentIndex);

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
@@ -108,7 +108,7 @@ public class LinearTransactionCostModelTest {
         // Calculate the transaction costs of an open position
         int currentIndex = 4;
         Position position = new Position(Trade.TradeType.BUY, transactionModel, new ZeroCostModel());
-        position.operate(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        position.trade(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
 
         Num costsFromModel = transactionModel.calculate(position, currentIndex);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
@@ -70,17 +70,17 @@ public class LinearTransactionCostCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord();
         Num criterion;
 
-        tradingRecord.operate(0);
-        tradingRecord.operate(1);
+        tradingRecord.trade(0);
+        tradingRecord.trade(1);
         criterion = getCriterion(1000d, 0.005, 0.2).calculate(series, tradingRecord);
         assertNumEquals(12.861, criterion);
 
-        tradingRecord.operate(2);
-        tradingRecord.operate(3);
+        tradingRecord.trade(2);
+        tradingRecord.trade(3);
         criterion = getCriterion(1000d, 0.005, 0.2).calculate(series, tradingRecord);
         assertNumEquals(24.3759, criterion);
 
-        tradingRecord.operate(5);
+        tradingRecord.trade(5);
         criterion = getCriterion(1000d, 0.005, 0.2).calculate(series, tradingRecord);
         assertNumEquals(28.2488, criterion);
     }
@@ -91,17 +91,17 @@ public class LinearTransactionCostCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord();
         Num criterion;
 
-        tradingRecord.operate(0);
-        tradingRecord.operate(1);
+        tradingRecord.trade(0);
+        tradingRecord.trade(1);
         criterion = getCriterion(1000d, 0d, 1.3d).calculate(series, tradingRecord);
         assertNumEquals(2.6d, criterion);
 
-        tradingRecord.operate(2);
-        tradingRecord.operate(3);
+        tradingRecord.trade(2);
+        tradingRecord.trade(3);
         criterion = getCriterion(1000d, 0d, 1.3d).calculate(series, tradingRecord);
         assertNumEquals(5.2d, criterion);
 
-        tradingRecord.operate(0);
+        tradingRecord.trade(0);
         criterion = getCriterion(1000d, 0d, 1.3d).calculate(series, tradingRecord);
         assertNumEquals(6.5d, criterion);
     }
@@ -115,15 +115,15 @@ public class LinearTransactionCostCriterionTest extends AbstractCriterionTest {
         criterion = getCriterion(1000d, 0d, 0.75d).calculate(series, position);
         assertNumEquals(0d, criterion);
 
-        position.operate(1);
+        position.trade(1);
         criterion = getCriterion(1000d, 0d, 0.75d).calculate(series, position);
         assertNumEquals(0.75d, criterion);
 
-        position.operate(3);
+        position.trade(3);
         criterion = getCriterion(1000d, 0d, 0.75d).calculate(series, position);
         assertNumEquals(1.5d, criterion);
 
-        position.operate(4);
+        position.trade(4);
         criterion = getCriterion(1000d, 0d, 0.75d).calculate(series, position);
         assertNumEquals(1.5d, criterion);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
@@ -40,7 +40,7 @@ public class OpenedPositionUtils {
         MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 110, 100, 95, 105);
 
         Position trade = new Position(Trade.TradeType.BUY);
-        trade.operate(0, series.numOf(2.5), series.one());
+        trade.trade(0, series.numOf(2.5), series.one());
 
         final Num value = criterion.calculate(series, trade);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
@@ -127,14 +127,14 @@ public class ReturnCriterionTest extends AbstractCriterionTest {
         AnalysisCriterion retWithBase = getCriterion();
         Position position1 = new Position();
         assertNumEquals(1d, retWithBase.calculate(series, position1));
-        position1.operate(0);
+        position1.trade(0);
         assertNumEquals(1d, retWithBase.calculate(series, position1));
 
         // without base percentage should return 0
         AnalysisCriterion retWithoutBase = getCriterion(false);
         Position position2 = new Position();
         assertNumEquals(0, retWithoutBase.calculate(series, position2));
-        position2.operate(0);
+        position2.trade(0);
         assertNumEquals(0, retWithoutBase.calculate(series, position2));
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
@@ -35,7 +35,7 @@ public class MockTradingRecord extends BaseTradingRecord {
     /*
      * Constructor. Builds a TradingRecord from a list of states. Initial state
      * value is zero. Then at each index where the state value changes, the
-     * TradingRecord operates at that index.
+     * TradingRecord executes a trade at that index.
      *
      * @param states List<Num> of state values
      */
@@ -45,7 +45,7 @@ public class MockTradingRecord extends BaseTradingRecord {
         for (int i = 0; i < states.size(); i++) {
             double state = states.get(i).doubleValue();
             if (state != lastState) {
-                this.operate(i);
+                this.trade(i);
             }
             lastState = state;
         }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- **Strategy#shouldOperate** renamed to `Strategy#shouldTrade`
- **TradingRecord#operate** renamed to `TradingRecord#trade`
- **Position#operate** renamed to `Position#trade`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 