### PR TITLE
add-DecimalNum#valueOf(DoubleNum val)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added "lessIsBetter"-property for **VarianceCriterion**
 - added "lessIsBetter"-property for **NumberOfPositionsCriterion**
 - added "addBase"-property for **ReturnCriterion** to include or exclude the base percentage of 1
+- added `DecimalNum#valueOf(DoubleNum)` to convert a DoubleNum exactly to a DecimalNum
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -230,13 +230,18 @@ public final class DecimalNum implements Num {
     }
 
     /**
-     * Returns a {@code Num} version of the given {@code Num}.
+     * Returns a {@code Num} version of the given {@code Number}.
+     * 
+     * <p>
+     * <b>Warning:</b> It first converts {@code val} to a {@code String} and then to
+     * a {@code Num}.
      *
      * @param val the number
      * @return the {@code Num}
+     * @see #valueOf(Number)
      */
-    public static DecimalNum valueOf(DecimalNum val) {
-        return val;
+    public static DecimalNum valueOf(DoubleNum val) {
+        return valueOf(val);
     }
 
     /**

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -34,10 +34,10 @@ import org.ta4j.core.criteria.LinearTransactionCostCriterion;
 import org.ta4j.core.criteria.MaximumDrawdownCriterion;
 import org.ta4j.core.criteria.NumberOfBarsCriterion;
 import org.ta4j.core.criteria.NumberOfPositionsCriterion;
+import org.ta4j.core.criteria.PositionsRatioCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
 import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;
 import org.ta4j.core.criteria.pnl.ReturnCriterion;
-import org.ta4j.core.criteria.PositionsRatioCriterion;
 
 import ta4jexamples.loaders.CsvTradesLoader;
 import ta4jexamples.strategies.MovingMomentumStrategy;

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -28,7 +28,6 @@ import java.util.Date;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
-import org.jfree.chart.ChartUtils;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.plot.DatasetRenderingOrder;

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -26,7 +26,6 @@ package ta4jexamples.loaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -35,14 +34,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.opencsv.CSVParser;
-import com.opencsv.CSVParserBuilder;
-import com.opencsv.CSVReaderBuilder;
-import com.opencsv.exceptions.CsvValidationException;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * This class build a Ta4j bar series from a CSV file containing bars.

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -23,9 +23,7 @@
  */
 package ta4jexamples.loaders;
 
-import java.io.IOException;
 import java.io.InputStream;
-
 import java.io.InputStreamReader;
 import java.time.Duration;
 import java.time.Instant;


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
-  added `DecimalNum#valueOf(DoubleNum)` to convert a `DoubleNum` exactly to a `DecimalNum`
- some minor `import` cleanups

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

This method is a more convenient and exact method instead of using `DecimalNum.valueOf(double)` which does not convert exactly like `new BigDecimal(String)`. And I also think that this was the origin idea of https://github.com/ta4j/ta4j/pull/1000.