### PR TITLE
Bugfix/1019 profit criterion exclude costs functionality reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices
 - **ExpectancyCriterion** fixed calculation
+- **ProfitCriterion** fixed excludeCosts functionality as it was reversed
+- **LossCriterion** fixed excludeCosts functionality as it was reversed
+- **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
@@ -59,7 +59,7 @@ public class LossCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
-            Num loss = excludeCosts ? position.getProfit() : position.getGrossProfit();
+            Num loss = excludeCosts ? position.getGrossProfit() : position.getProfit();
             return loss.isNegative() ? loss : series.zero();
         }
         return series.zero();

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
@@ -60,7 +60,7 @@ public class ProfitCriterion extends AbstractAnalysisCriterion {
     @Override
     public Num calculate(BarSeries series, Position position) {
         if (position.isClosed()) {
-            Num profit = excludeCosts ? position.getProfit() : position.getGrossProfit();
+            Num profit = excludeCosts ? position.getGrossProfit() : position.getProfit();
             return profit.isPositive() ? profit : series.zero();
         }
         return series.zero();

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
@@ -42,8 +42,8 @@ public class PerformanceReportGenerator implements ReportGenerator<PerformanceRe
     public PerformanceReport generate(Strategy strategy, TradingRecord tradingRecord, BarSeries series) {
         final Num pnl = new ProfitLossCriterion().calculate(series, tradingRecord);
         final Num pnlPercentage = new ProfitLossPercentageCriterion().calculate(series, tradingRecord);
-        final Num netProfit = new ProfitCriterion(true).calculate(series, tradingRecord);
-        final Num netLoss = new LossCriterion(true).calculate(series, tradingRecord);
+        final Num netProfit = new ProfitCriterion(false).calculate(series, tradingRecord);
+        final Num netLoss = new LossCriterion(false).calculate(series, tradingRecord);
         return new PerformanceReport(pnl, pnlPercentage, netProfit, netLoss);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
@@ -34,6 +34,9 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.LinearTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
 import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
@@ -62,6 +65,26 @@ public class LossCriterionTest extends AbstractCriterionTest {
 
         AnalysisCriterion loss = getCriterion(true);
         assertNumEquals(-35, loss.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateComparingIncludingVsExcludingCosts() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 95, 100, 80, 85, 70);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY, new LinearTransactionCostModel(0.01),
+                new ZeroCostModel());
+        tradingRecord.enter(0, series.getBar(0).getClosePrice(), numOf(1));
+        tradingRecord.exit(1, series.getBar(1).getClosePrice(),
+                tradingRecord.getCurrentPosition().getEntry().getAmount());
+        tradingRecord.enter(2, series.getBar(2).getClosePrice(), numOf(1));
+        ;
+        tradingRecord.exit(5, series.getBar(5).getClosePrice(),
+                tradingRecord.getCurrentPosition().getEntry().getAmount());
+
+        AnalysisCriterion lossIncludingCosts = getCriterion(false);
+        assertNumEquals(-38.65, lossIncludingCosts.calculate(series, tradingRecord));
+
+        AnalysisCriterion lossExcludingCosts = getCriterion(true);
+        assertNumEquals(-35, lossExcludingCosts.calculate(series, tradingRecord));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
@@ -34,6 +34,9 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
+import org.ta4j.core.analysis.cost.LinearTransactionCostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
 import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
@@ -62,6 +65,26 @@ public class ProfitCriterionTest extends AbstractCriterionTest {
 
         AnalysisCriterion profit = getCriterion(false);
         assertNumEquals(25, profit.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateComparingIncludingVsExcludingCosts() {
+        MockBarSeries series = new MockBarSeries(numFunction, 100, 105, 100, 80, 85, 120);
+        TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.BUY, new FixedTransactionCostModel(1),
+                new ZeroCostModel());
+        tradingRecord.enter(0, series.getBar(0).getClosePrice(), numOf(1));
+        tradingRecord.exit(1, series.getBar(1).getClosePrice(),
+                tradingRecord.getCurrentPosition().getEntry().getAmount());
+        tradingRecord.enter(2, series.getBar(2).getClosePrice(), numOf(1));
+        ;
+        tradingRecord.exit(5, series.getBar(5).getClosePrice(),
+                tradingRecord.getCurrentPosition().getEntry().getAmount());
+
+        AnalysisCriterion profitIncludingCosts = getCriterion(false);
+        assertNumEquals(21, profitIncludingCosts.calculate(series, tradingRecord));
+
+        AnalysisCriterion profitExcludingCosts = getCriterion(true);
+        assertNumEquals(25, profitExcludingCosts.calculate(series, tradingRecord));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1019 

Changes proposed in this pull request:
- **ProfitCriterion** fixed excludeCosts functionality as it was reversed
- **LossCriterion** fixed excludeCosts functionality as it was reversed
- **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
