### PR TITLE
BarSeries#getBar(index i): improve javadoc

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -101,7 +101,17 @@ public interface BarSeries extends Serializable {
     }
 
     /**
-     * @param i an index
+     * Gets the bar from {@link #getBarData()} with index {@code i}.
+     * 
+     * <p>
+     * The given {@code i} can return the same bar within the first range of indices
+     * due to {@link #setMaximumBarCount(int)}, for example: If you fill a BarSeries
+     * with 30 bars and then apply a {@code maximumBarCount} of 10 bars, the first
+     * 20 bars will be removed from the BarSeries. The indices going further from 0
+     * to 29 remain but return the same bar from 0 to 20. The remaining 9 bars are
+     * returned from index 21.
+     * 
+     * @param i the index
      * @return the bar at the i-th position
      */
     Bar getBar(int i);
@@ -183,8 +193,9 @@ public interface BarSeries extends Serializable {
      *
      * If a new bar is added to the series such that the number of bars will exceed
      * the maximum bar count, then the FIRST bar in the series is automatically
-     * removed, ensuring that the maximum bar count is not exceeded.
-     *
+     * removed, ensuring that the maximum bar count is not exceeded. The indices of
+     * the bar series do not change.
+     * 
      * @param maximumBarCount the maximum bar count
      */
     void setMaximumBarCount(int maximumBarCount);

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
@@ -34,7 +34,6 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
 import org.ta4j.core.analysis.cost.LinearTransactionCostModel;
 import org.ta4j.core.analysis.cost.ZeroCostModel;
 import org.ta4j.core.criteria.AbstractCriterionTest;

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
@@ -35,7 +35,6 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.analysis.cost.FixedTransactionCostModel;
-import org.ta4j.core.analysis.cost.LinearTransactionCostModel;
 import org.ta4j.core.analysis.cost.ZeroCostModel;
 import org.ta4j.core.criteria.AbstractCriterionTest;
 import org.ta4j.core.mocks.MockBarSeries;


### PR DESCRIPTION
Fix https://github.com/ta4j/ta4j/issues/1009

Changes proposed in this pull request:
- improve javadoc for BarSeries#getBar(index i)
- 
- 

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` (already done by entry "improved javadoc")
