### PR TITLE
SMA#getUnstableBars checked

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
@@ -45,7 +45,10 @@ public interface Indicator<T> {
     T getValue(int index);
 
     /**
-     * @return the number of bars up to which the indicator calculates wrong values
+     * Returns the number of bars up to which {@code this} Indicator calculates
+     * wrong values.
+     * 
+     * @return unstable bars
      */
     int getUnstableBars();
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -60,6 +60,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
         return sum.dividedBy(numOf(realBarCount));
     }
 
+    /** @return {@link #barCount} */
     @Override
     public int getUnstableBars() {
         return barCount;


### PR DESCRIPTION
Part fix #1051 

Changes proposed in this pull request:
- improved javadoc of `Indicator#getUnstableBars`
- marks `SMA#getUnstableBars = barCount `as correct

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` (already done by entry "improved javadoc")


_For each indicator checked, we should improve the javadoc of that indicator (e.g. `@return barCount` for this case). With this we can also see (in the source code) that this indicator has already been checked and which indicators have not yet been checked (that is then all indicators where a javadoc with a specific `@return ...` is missing._
