### PR TITLE
TrailingStopLossRule #906 Remove instance variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **ProfitCriterion** fixed excludeCosts functionality as it was reversed
 - **LossCriterion** fixed excludeCosts functionality as it was reversed
 - **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
+- **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -117,8 +117,8 @@ public class TrailingStopLossRule extends AbstractRule {
     @Override
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
         if (log.isTraceEnabled()) {
-            log.trace("{}#isSatisfied({}): {}. Current price: {}",
-                    getClass().getSimpleName(), index, isSatisfied, priceIndicator.getValue(index));
+            log.trace("{}#isSatisfied({}): {}. Current price: {}", getClass().getSimpleName(), index, isSatisfied,
+                    priceIndicator.getValue(index));
         }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -47,9 +47,6 @@ public class TrailingStopLossRule extends AbstractRule {
     /** the loss-distance as percentage. */
     private final Num lossPercentage;
 
-    /** The current stop loss price activation. */
-    private Num currentStopLossLimitActivation;
-
     /**
      * Constructor.
      *
@@ -100,12 +97,8 @@ public class TrailingStopLossRule extends AbstractRule {
                 getValueIndicatorBarCount(index, positionIndex));
         Num highestCloseNum = highest.getValue(index);
         Num lossRatioThreshold = highestCloseNum.numOf(100).minus(lossPercentage).dividedBy(highestCloseNum.numOf(100));
-        currentStopLossLimitActivation = highestCloseNum.multipliedBy(lossRatioThreshold);
+        Num currentStopLossLimitActivation = highestCloseNum.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(currentStopLossLimitActivation);
-    }
-
-    public Num getCurrentStopLossLimitActivation() {
-        return currentStopLossLimitActivation;
     }
 
     private boolean isSellSatisfied(Num currentPrice, int index, int positionIndex) {
@@ -113,7 +106,7 @@ public class TrailingStopLossRule extends AbstractRule {
                 getValueIndicatorBarCount(index, positionIndex));
         Num lowestCloseNum = lowest.getValue(index);
         Num lossRatioThreshold = lowestCloseNum.numOf(100).plus(lossPercentage).dividedBy(lowestCloseNum.numOf(100));
-        currentStopLossLimitActivation = lowestCloseNum.multipliedBy(lossRatioThreshold);
+        Num currentStopLossLimitActivation = lowestCloseNum.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(currentStopLossLimitActivation);
     }
 
@@ -124,9 +117,8 @@ public class TrailingStopLossRule extends AbstractRule {
     @Override
     protected void traceIsSatisfied(int index, boolean isSatisfied) {
         if (log.isTraceEnabled()) {
-            log.trace("{}#isSatisfied({}): {}. Current price: {}, Current stop loss activation: {}",
-                    getClass().getSimpleName(), index, isSatisfied, priceIndicator.getValue(index),
-                    currentStopLossLimitActivation);
+            log.trace("{}#isSatisfied({}): {}. Current price: {}",
+                    getClass().getSimpleName(), index, isSatisfied, priceIndicator.getValue(index));
         }
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -45,9 +45,7 @@
  */
 package org.ta4j.core.rules;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.function.Function;
@@ -74,32 +72,22 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
 
         // 10% trailing-stop-loss
         TrailingStopLossRule rule = new TrailingStopLossRule(closePrice, numOf(10));
-
         assertFalse(rule.isSatisfied(0, null));
-        assertNull(rule.getCurrentStopLossLimitActivation());
-
         assertFalse(rule.isSatisfied(1, tradingRecord));
-        assertNull(rule.getCurrentStopLossLimitActivation());
 
         // Enter at 114
         tradingRecord.enter(2, numOf(114), numOf(1));
         assertFalse(rule.isSatisfied(2, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
-
         assertFalse(rule.isSatisfied(3, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
-
         assertTrue(rule.isSatisfied(4, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
+
         // Exit
         tradingRecord.exit(5);
 
         // Enter at 128
         tradingRecord.enter(5, numOf(128), numOf(1));
         assertFalse(rule.isSatisfied(5, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
         assertTrue(rule.isSatisfied(6, tradingRecord));
-        assertEquals(numOf(130).multipliedBy(numOf(0.9)), rule.getCurrentStopLossLimitActivation());
     }
 
     @Test
@@ -138,32 +126,23 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
 
         // 10% trailing-stop-loss
         TrailingStopLossRule rule = new TrailingStopLossRule(closePrice, numOf(10));
-
         assertFalse(rule.isSatisfied(0, null));
-        assertNull(rule.getCurrentStopLossLimitActivation());
-
         assertFalse(rule.isSatisfied(1, tradingRecord));
-        assertNull(rule.getCurrentStopLossLimitActivation());
 
         // Enter at 84
         tradingRecord.enter(2, numOf(84), numOf(1));
+
         assertFalse(rule.isSatisfied(2, tradingRecord));
-        assertEquals(numOf(80).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
-
         assertFalse(rule.isSatisfied(3, tradingRecord));
-        assertEquals(numOf(70).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
-
         assertTrue(rule.isSatisfied(4, tradingRecord));
-        assertEquals(numOf(70).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
+
         // Exit
         tradingRecord.exit(5);
 
         // Enter at 128
         tradingRecord.enter(5, numOf(128), numOf(1));
         assertFalse(rule.isSatisfied(5, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
         assertTrue(rule.isSatisfied(6, tradingRecord));
-        assertEquals(numOf(120).multipliedBy(numOf(1.1)), rule.getCurrentStopLossLimitActivation());
     }
 
     @Test


### PR DESCRIPTION
Fixes #906 .

Changes proposed in this pull request:
- Remove instance variable for currentStopLossLimitActivation. It is not proven, that the value of the currentStopLossLimitActivation is always the last value. It depends on the last getValue(anyPossibleIndex) call

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
