### PR TITLE
set PreviousValueIndicator#getUnstableBars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LossCriterion** fixed excludeCosts functionality as it was reversed
 - **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
 - **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
+- sets `PreviousValueIndicator#getUnstableBars` = `n` (= the n-th previous index)
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
@@ -65,9 +65,10 @@ public class PreviousValueIndicator extends CachedIndicator<Num> {
         return this.indicator.getValue(previousValue);
     }
 
+    /** @return {@link #n} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return n;
     }
 
     @Override


### PR DESCRIPTION
Part fix https://github.com/ta4j/ta4j/issues/1051

Changes proposed in this pull request:
-  sets `PreviousValueIndicator#getUnstableBars` = `n` (= the n-th previous index)

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 