### PR TITLE
set helpers/indicators#getUnstableBars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LossCriterion** fixed excludeCosts functionality as it was reversed
 - **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
 - **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
+- sets `ClosePriceDifferenceIndicator#getUnstableBars` = `1`
+- sets `ClosePriceRatioIndicator#getUnstableBars` = `1`
+- sets `ConvergenceDivergenceIndicator#getUnstableBars` = `barCount`
+- sets `GainIndicator#getUnstableBars` = `1`
+- sets `HighestValueIndicator#getUnstableBars` = `barCount`
+- sets `LossIndicator#getUnstableBars` = `1`
+- sets `LowestValueIndicator#getUnstableBars` = `barCount`
+- sets `TRIndicator#getUnstableBars` = `1`
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
@@ -49,6 +49,7 @@ public class AmountIndicator extends CachedIndicator<Num> {
         return getBarSeries().getBar(index).getAmount();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -190,6 +190,7 @@ public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
         return false;
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -36,7 +36,7 @@ import org.ta4j.core.num.Num;
  */
 public class CloseLocationValueIndicator extends CachedIndicator<Num> {
 
-    private final Num zero = numOf(0);
+    private final Num zero;
 
     /**
      * Constructor.
@@ -45,6 +45,7 @@ public class CloseLocationValueIndicator extends CachedIndicator<Num> {
      */
     public CloseLocationValueIndicator(BarSeries series) {
         super(series);
+        this.zero = zero();
     }
 
     @Override
@@ -59,6 +60,7 @@ public class CloseLocationValueIndicator extends CachedIndicator<Num> {
         return diffHighLow.isNaN() ? zero : ((close.minus(low)).minus(high.minus(close))).dividedBy(diffHighLow);
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
@@ -61,13 +61,9 @@ public class ClosePriceDifferenceIndicator extends CachedIndicator<Num> {
         return currentBarClosePrice.minus(previousBarClosePrice);
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This indicator is always stable, so it returns 0.
-     */
+    /** @return {@code 1} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return 1;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
@@ -49,6 +49,7 @@ public class ClosePriceIndicator extends AbstractIndicator<Num> {
         return getBarSeries().getBar(index).getClosePrice();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
@@ -64,13 +64,9 @@ public class ClosePriceRatioIndicator extends CachedIndicator<Num> {
         return currentBarClosePrice.dividedBy(previousBarClosePrice);
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * This indicator is always stable, so it returns 0.
-     */
+    /** @return {@code 1} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return 1;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
@@ -65,6 +65,7 @@ public class CombineIndicator extends CachedIndicator<Num> {
         return combineFunction.apply(indicatorLeft.getValue(index), indicatorRight.getValue(index));
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
@@ -52,6 +52,7 @@ public class ConstantIndicator<T> extends AbstractIndicator<T> {
         return value;
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -255,9 +255,10 @@ public class ConvergenceDivergenceIndicator extends CachedIndicator<Boolean> {
         return false;
     }
 
+    /** @return {@link #barCount} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return barCount;
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -66,6 +66,7 @@ public class DateTimeIndicator extends CachedIndicator<ZonedDateTime> {
         return this.action.apply(bar);
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
@@ -68,6 +68,7 @@ public class FixedIndicator<T> extends AbstractIndicator<T> {
         return values.get(index);
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
@@ -59,8 +59,9 @@ public class GainIndicator extends CachedIndicator<Num> {
         return actualValue.isGreaterThan(previousValue) ? actualValue.minus(previousValue) : zero();
     }
 
+    /** @return {@code 1} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return 1;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
@@ -49,6 +49,7 @@ public class HighPriceIndicator extends AbstractIndicator<Num> {
         return getBarSeries().getBar(index).getHighPrice();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
@@ -65,9 +65,10 @@ public class HighestValueIndicator extends CachedIndicator<Num> {
         return highest;
     }
 
+    /** @return {@link #barCount} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return barCount;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
@@ -59,8 +59,9 @@ public class LossIndicator extends CachedIndicator<Num> {
         return actualValue.isLessThan(previousValue) ? previousValue.minus(actualValue) : zero();
     }
 
+    /** @return {@code 1} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return 1;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
@@ -49,6 +49,7 @@ public class LowPriceIndicator extends AbstractIndicator<Num> {
         return getBarSeries().getBar(index).getLowPrice();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
@@ -65,9 +65,10 @@ public class LowestValueIndicator extends CachedIndicator<Num> {
         return lowest;
     }
 
+    /** @return {@link #barCount} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return barCount;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
@@ -55,6 +55,7 @@ public class MedianPriceIndicator extends CachedIndicator<Num> {
         return bar.getHighPrice().plus(bar.getLowPrice()).dividedBy(numOf(2));
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
@@ -66,6 +66,7 @@ public class NumIndicator extends CachedIndicator<Num> {
         return this.action.apply(bar);
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
@@ -49,6 +49,7 @@ public class OpenPriceIndicator extends AbstractIndicator<Num> {
         return getBarSeries().getBar(index).getOpenPrice();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
@@ -64,8 +64,9 @@ public class TRIndicator extends CachedIndicator<Num> {
 
     }
 
+    /** @return {@code 1} */
     @Override
     public int getUnstableBars() {
-        return 0;
+        return 1;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
@@ -48,6 +48,7 @@ public class TradeCountIndicator extends CachedIndicator<Long> {
         return getBarSeries().getBar(index).getTrades();
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
@@ -58,6 +58,7 @@ public class TypicalPriceIndicator extends CachedIndicator<Num> {
         return highPrice.plus(lowPrice).plus(closePrice).dividedBy(numOf(3));
     }
 
+    /** @return {@code 0} */
     @Override
     public int getUnstableBars() {
         return 0;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
@@ -56,6 +56,7 @@ public class UnstableIndicator extends CachedIndicator<Num> {
         return indicator.getValue(index);
     }
 
+    /** @return {@link #unstableBars} */
     @Override
     public int getUnstableBars() {
         return unstableBars;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
@@ -68,6 +68,7 @@ public class VolumeIndicator extends CachedIndicator<Num> {
         return sumOfVolume;
     }
 
+    /** @return {@link #barCount} */
     @Override
     public int getUnstableBars() {
         return barCount;


### PR DESCRIPTION
Part fix https://github.com/ta4j/ta4j/issues/1051

### Changes proposed in this pull request:

**Sets** `getUnstableBars()` of:
- `ClosePriceDifferenceIndicator` = `1`
- `ClosePriceRatioIndicator` = `1`
- `ConvergenceDivergenceIndicator` = `barCount`
- `GainIndicator` = `1`
- `HighestValueIndicator` = `barCount`
- `LossIndicator` = `1`
- `LowestValueIndicator` = `barCount`
- `TRIndicator` = `1`


### The following indicators were checked and found to be correct:

**Checks** `getUnstableBars()` of:
- `AmountIndicator` = `0`
- `BooleanTransformIndicator` = `0`
- `CloseLocationValueIndicator` = `0`
- `ClosePriceIndicator` = `0`
- `CombineIndicator` = `0`
- `ConstantIndicator` = `0`
- `DateTimeIndicator` = `0`
- `FixedBooleanIndicator` = `0`
- `FixedDecimalIndicator` = `0`
- `FixedIndicator` = `0`
- `HighPriceIndicator` = `0`
- `LowPriceIndicator` = `0`
- `MedianPriceIndicator` = `0`
- `NumIndicator` = `0`
- `OpenPriceIndicator` = `0`
- `MedianPriceIndicator` = `0`
- `TradeCountIndicator` = `0`
- `TypicalPriceIndicator` = `0`
- `UnstableIndicator` = `unstableBars`
- `VolumeIndicator` = `barCount`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
