### PR TITLE
ProfitLossPercentageCriterion: fix javdoc

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Net profit and loss in percentage criterion (relative PnL, excludes trading
- * costs), returned in decimal format.
+ * costs), returned in percentage format (e.g. 1 = 1%).
  *
  * <p>
  * Defined as the position profit over the purchase price. The profit or loss in


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- As we do `.multipliedBy(series.hundred())`, the returned value is not in "decimal format" but in "percentage format".


- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` (already done with "improved javadoc")
