### PR TITLE
EnterAndHoldReturnCriterion: addBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - add missing `@Override` annotation
 - **LossIndicator**: optimize calculation
 - **GainIndicator**: improved calculation
-
 - **PriceVariationIndicator** renamed to **ClosePriceRatioIndicator** for consistency with new **ClosePriceDifferenceIndicator**
 
 ### Removed/Deprecated
@@ -90,6 +89,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added "lessIsBetter"-property for **VarianceCriterion**
 - added "lessIsBetter"-property for **NumberOfPositionsCriterion**
 - added "addBase"-property for **ReturnCriterion** to include or exclude the base percentage of 1
+- added "addBase"-property for **EnterAndHoldReturnCriterion** to include or exclude the base percentage of 1
 - added **MoneyFlowIndexIndicator**
 - added **IntraDayMomentumIndexIndicator**
 - added **ClosePriceDifferenceIndicator**

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -298,9 +298,10 @@ public class Position implements Serializable {
 
     /**
      * Calculates the gross return of the position if it is closed. The gross return
-     * excludes any trading costs.
+     * excludes any trading costs (and includes the base).
      *
      * @return the gross return of the position in percent
+     * @see #getGrossReturn(Num)
      */
     public Num getGrossReturn() {
         if (isOpened()) {
@@ -312,11 +313,12 @@ public class Position implements Serializable {
 
     /**
      * Calculates the gross return of the position, if it exited at the provided
-     * price. The gross return excludes any trading costs.
+     * price. The gross return excludes any trading costs (and includes the base).
      *
      * @param finalPrice the price of the final bar to be considered (if position is
      *                   open)
      * @return the gross return of the position in percent
+     * @see #getGrossReturn(Num, Num)
      */
     public Num getGrossReturn(Num finalPrice) {
         return getGrossReturn(getEntry().getPricePerAsset(), finalPrice);
@@ -325,11 +327,12 @@ public class Position implements Serializable {
     /**
      * Calculates the gross return of the position. If either the entry or exit
      * price is {@code NaN}, the close price from given {@code barSeries} is used.
-     * The gross return excludes any trading costs.
+     * The gross return excludes any trading costs (and includes the base).
      *
      * @param barSeries
      * @return the gross return in percent with entry and exit prices from the
      *         barSeries
+     * @see #getGrossReturn(Num, Num)
      */
     public Num getGrossReturn(BarSeries barSeries) {
         Num entryPrice = getEntry().getPricePerAsset(barSeries);

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -47,11 +47,18 @@ import org.ta4j.core.num.Num;
  */
 public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
 
+    /**
+     * If true, then the base percentage of {@code 1} (equivalent to 100%) is added
+     * to the criterion value.
+     */
+    private final boolean addBase;
+
+    /** The {@link TradeType} used to open the position. */
     private final TradeType tradeType;
 
     /**
-     * Constructor.
-     *
+     * Constructor with {@link #addBase} == true.
+     * 
      * <p>
      * For buy-and-hold strategy.
      */
@@ -60,26 +67,40 @@ public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
     }
 
     /**
-     * Constructor.
+     * Constructor with {@link #addBase} == true.
      *
      * @param tradeType the {@link TradeType} used to open the position
      */
     public EnterAndHoldReturnCriterion(TradeType tradeType) {
         this.tradeType = tradeType;
+        this.addBase = true;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param tradeType the {@link TradeType} used to open the position
+     * @param addBase   the {@link #addBase}
+     */
+    public EnterAndHoldReturnCriterion(TradeType tradeType, boolean addBase) {
+        this.tradeType = tradeType;
+        this.addBase = addBase;
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
         int beginIndex = position.getEntry().getIndex();
         int endIndex = series.getEndIndex();
-        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        Num grossReturn = createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        return addBase ? grossReturn : grossReturn.minus(grossReturn.isZero() ? series.zero() : series.one());
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         int beginIndex = tradingRecord.getStartIndex(series);
         int endIndex = tradingRecord.getEndIndex(series);
-        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        Num grossReturn = createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        return addBase ? grossReturn : grossReturn.minus(grossReturn.isZero() ? series.zero() : series.one());
     }
 
     /** The higher the criterion value the better. */


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- added `addBase`-property for `EnterAndHoldReturnCriterion` to include or exclude the base percentage of 1
- improved javadoc for `Position` to make clear that its _return()_-methods includes the base.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

_As we included the option for the base in https://github.com/ta4j/ta4j/pull/980, we have to include this also for "EnterAndHold-**ReturnCriterion**"._
