### PR TITLE
Position#getGrossReturn-addBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
       - `BarSeriesManager manager = new BarSeriesManager(barSeries, new TradeOnCurrentCloseModel())`
       - `BarSeriesManager manager = new BarSeriesManager(barSeries, transactionCostModel, holdingCostModel, tradeExecutionModel)`
 - **BarSeriesManager** and **BacktestExecutor** moved to packge **`backtest`**
+- added the parameter `addBase` to the following methods to be able to include or exlude the base from the result. The developer must now make a conscious decision whether to set `addBase` to `true` or `false` to avoid implicit bugs:
+    - changed `Position.getGrossReturn()` to `Position.getGrossReturn(boolean addBase)`
+    - changed `Position.getGrossReturn(Num finalPrice)` to `Position.getGrossReturn(Num finalPrice, boolean addBase)`
+    - changed `Position.getGrossReturn(BarSeries barSeries)` to `Position.getGrossReturn(BarSeries barSeries, boolean addBase)`
+    - changed `Position.getGrossReturn(Num entryPrice, Num exitPrice)` to `Position.getGrossReturn(Num entryPrice, Num exitPrice, boolean addBase)`
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldReturnCriterion.java
@@ -72,14 +72,14 @@ public class EnterAndHoldReturnCriterion extends AbstractAnalysisCriterion {
     public Num calculate(BarSeries series, Position position) {
         int beginIndex = position.getEntry().getIndex();
         int endIndex = series.getEndIndex();
-        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series, true);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
         int beginIndex = tradingRecord.getStartIndex(series);
         int endIndex = tradingRecord.getEndIndex(series);
-        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series);
+        return createEnterAndHoldTrade(series, beginIndex, endIndex).getGrossReturn(series, true);
     }
 
     /** The higher the criterion value the better. */

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -63,14 +63,16 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return calculateProfit(series, position);
+        return calculateProfit(series, position, addBase);
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        // We need to set "addBase = true" when multiplying.
+        // Afterwards we substract the base, if "this.addBase = false".
         return tradingRecord.getPositions()
                 .stream()
-                .map(position -> calculateProfit(series, position))
+                .map(position -> calculateProfit(series, position, true))
                 .reduce(series.one(), Num::multipliedBy)
                 .minus(addBase ? series.zero() : series.one());
     }
@@ -84,13 +86,15 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
     /**
      * Calculates the gross return of a position (Buy and sell).
      *
-     * @param series   a bar series
-     * @param position a position
+     * @param series   the bar series
+     * @param position the position
+     * @param addBase  set to true to add the base percentage of {@code 1}
+     *                 (equivalent to 100%) to the gross return
      * @return the gross return of the position
      */
-    private Num calculateProfit(BarSeries series, Position position) {
+    private Num calculateProfit(BarSeries series, Position position, boolean addBase) {
         if (position.isClosed()) {
-            return position.getGrossReturn(series);
+            return position.getGrossReturn(series, true);
         }
         return addBase ? series.one() : series.zero();
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
@@ -224,9 +224,13 @@ public class PositionTest {
         position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
         position.operate(0, DoubleNum.valueOf(12.00), DoubleNum.valueOf(2));
 
-        final Num profit = position.getGrossReturn();
+        // include base percentage
+        final Num profitWithBase = position.getGrossReturn(true);
+        assertEquals(DoubleNum.valueOf(1.2), profitWithBase);
 
-        assertEquals(DoubleNum.valueOf(1.2), profit);
+        // exclude base percentage
+        final Num profitWithoutBase = position.getGrossReturn(false);
+        assertEquals(DoubleNum.valueOf(0.2), profitWithoutBase);
     }
 
     @Test
@@ -236,23 +240,37 @@ public class PositionTest {
         position.operate(0, DoubleNum.valueOf(10.00), DoubleNum.valueOf(2));
         position.operate(0, DoubleNum.valueOf(8.00), DoubleNum.valueOf(2));
 
-        final Num profit = position.getGrossReturn();
+        // include base percentage
+        final Num profitWith = position.getGrossReturn(true);
+        assertEquals(DoubleNum.valueOf(1.2), profitWith);
 
-        assertEquals(DoubleNum.valueOf(1.2), profit);
+        // exclude base percentage
+        final Num profitWithoutBase = position.getGrossReturn(false);
+        assertEquals(DoubleNum.valueOf(0.2), profitWithoutBase);
     }
 
     @Test
     public void testGetGrossReturnForLongPositionsUsingBarCloseOnNaN() {
         MockBarSeries series = new MockBarSeries(DoubleNum::valueOf, 100, 105);
         Position position = new Position(new Trade(0, TradeType.BUY, NaN, NaN), new Trade(1, TradeType.SELL, NaN, NaN));
-        assertNumEquals(DoubleNum.valueOf(1.05), position.getGrossReturn(series));
+
+        // include base percentage
+        assertNumEquals(DoubleNum.valueOf(1.05), position.getGrossReturn(series, true));
+
+        // exclude base percentage
+        assertNumEquals(DoubleNum.valueOf(0.05), position.getGrossReturn(series, false));
     }
 
     @Test
     public void testGetGrossReturnForShortPositionsUsingBarCloseOnNaN() {
         MockBarSeries series = new MockBarSeries(DoubleNum::valueOf, 100, 95);
         Position position = new Position(new Trade(0, TradeType.SELL, NaN, NaN), new Trade(1, TradeType.BUY, NaN, NaN));
-        assertNumEquals(DoubleNum.valueOf(1.05), position.getGrossReturn(series));
+
+        // include base percentage
+        assertNumEquals(DoubleNum.valueOf(1.05), position.getGrossReturn(series, true));
+
+        // exclude base percentage
+        assertNumEquals(DoubleNum.valueOf(0.05), position.getGrossReturn(series, false));
     }
 
     @Test


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- added the parameter `addBase` to the following methods to be able to include or exlude the base from the result. The developer must now make a conscious decision whether to set `addBase` to `true` or `false` to avoid implicit bugs:
    - changed `Position.getGrossReturn()` to `Position.getGrossReturn(boolean addBase)`
    - changed `Position.getGrossReturn(Num finalPrice)` to `Position.getGrossReturn(Num finalPrice, boolean addBase)`
    - changed `Position.getGrossReturn(BarSeries barSeries)` to `Position.getGrossReturn(BarSeries barSeries, boolean addBase)`
    - changed `Position.getGrossReturn(Num entryPrice, Num exitPrice)` to `Position.getGrossReturn(Num entryPrice, Num exitPrice, boolean addBase)`
- With the above methods, we now make it explicit, whether a method (e.g. `EnterAndHoldCriterion`) is calculated with or without a basis - this will better avoid future bugs as the developer now must make a conscious choice whether to set `addBase` to true or false.
- With the above methods, we also solved a bug in  `ReturnCriterion#calculate(BarSeries series, Position position) `as we are now able to include or exclude the base per position.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
