### PR TITLE
Fix `ReturnOverMaxDrawdownCriterion` to use Return without base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LossCriterion** fixed excludeCosts functionality as it was reversed
 - **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
 - **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
+- **ReturnOverMaxDrawdownCriterion** uses ReturnCriterion (with `base=false`)
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -298,9 +298,10 @@ public class Position implements Serializable {
 
     /**
      * Calculates the gross return of the position if it is closed. The gross return
-     * excludes any trading costs.
+     * excludes any trading costs (and includes the base).
      *
      * @return the gross return of the position in percent
+     * @see #getGrossReturn(Num)
      */
     public Num getGrossReturn() {
         if (isOpened()) {
@@ -312,11 +313,12 @@ public class Position implements Serializable {
 
     /**
      * Calculates the gross return of the position, if it exited at the provided
-     * price. The gross return excludes any trading costs.
+     * price. The gross return excludes any trading costs (and includes the base).
      *
      * @param finalPrice the price of the final bar to be considered (if position is
      *                   open)
      * @return the gross return of the position in percent
+     * @see #getGrossReturn(Num, Num)
      */
     public Num getGrossReturn(Num finalPrice) {
         return getGrossReturn(getEntry().getPricePerAsset(), finalPrice);
@@ -325,11 +327,12 @@ public class Position implements Serializable {
     /**
      * Calculates the gross return of the position. If either the entry or exit
      * price is {@code NaN}, the close price from given {@code barSeries} is used.
-     * The gross return excludes any trading costs.
+     * The gross return excludes any trading costs (and includes the base).
      *
      * @param barSeries
      * @return the gross return in percent with entry and exit prices from the
      *         barSeries
+     * @see #getGrossReturn(Num, Num)
      */
     public Num getGrossReturn(BarSeries barSeries) {
         Num entryPrice = getEntry().getPricePerAsset(barSeries);

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
@@ -30,7 +30,7 @@ import org.ta4j.core.analysis.CashFlow;
 import org.ta4j.core.num.Num;
 
 /**
- * Maximum drawdown criterion (in percentage).
+ * Maximum drawdown criterion, returned in decimal format.
  *
  * <p>
  * The maximum drawdown measures the largest loss. Its value can be within the

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -32,13 +32,16 @@ import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
- * Reward risk ratio criterion, defined as the {@link ReturnCriterion gross
- * return} over the {@link MaximumDrawdownCriterion maximum drawdown}, returned
- * in decimal format.
+ * Reward risk ratio criterion (also known as "RoMaD"), returned in decimal
+ * format.
+ * 
+ * <pre>
+ * RoMaD = {@link ReturnCriterion gross return (without base)} / {@link MaximumDrawdownCriterion maximum drawdown}
+ * </pre>
  */
 public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
 
-    private final AnalysisCriterion grossReturnCriterion = new ReturnCriterion();
+    private final AnalysisCriterion grossReturnCriterion = new ReturnCriterion(false);
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
@@ -59,7 +59,7 @@ public class ReturnOverMaxDrawdownCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(4, series), Trade.buyAt(5, series), Trade.sellAt(7, series));
 
-        double totalProfit = (105d / 100) * (90d / 95d) * (120d / 95);
+        double totalProfit = (105d / 100) * (90d / 95d) * (120d / 95) - 1;
         double peak = (105d / 100) * (100d / 95);
         double low = (105d / 100) * (90d / 95) * (80d / 95);
 


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/1077

Changes proposed in this pull request:
- `ReturnOverMaxDrawdownCriterion` uses ReturnCriterion (with `base=false`)
- some javadoc improvements

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
