### PR TITLE
`PreviousValueIndicator` must return `NaN` if below first bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **LossCriterion** fixed excludeCosts functionality as it was reversed
 - **PerformanceReportGenerator** fixed netProfit and netLoss calculations to include costs
 - **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
+- **PreviousValueIndicator** returns `NaN` if the (n-th) previous value of an indicator does not exist, i.e. if the (n-th) previous is below the first available index. 
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
@@ -75,7 +75,6 @@ public class DPOIndicator extends CachedIndicator<Num> {
         final SMAIndicator simpleMovingAverage = new SMAIndicator(price, barCount);
         final PreviousValueIndicator previousSimpleMovingAverage = new PreviousValueIndicator(simpleMovingAverage,
                 timeFrame);
-
         this.indicatorMinusPreviousSMAIndicator = CombineIndicator.minus(price, previousSimpleMovingAverage);
         this.name = String.format("%s barCount: %s", getClass().getSimpleName(), barCount);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
@@ -25,10 +25,14 @@ package org.ta4j.core.indicators.helpers;
 
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.CachedIndicator;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 /**
- * Returns the previous (n-th) value of an indicator.
+ * Returns the (n-th) previous value of an indicator.
+ *
+ * If the (n-th) previous index is below the first index from the bar series,
+ * then {@link NaN#NaN} is returned.
  */
 public class PreviousValueIndicator extends CachedIndicator<Num> {
 
@@ -61,8 +65,8 @@ public class PreviousValueIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
-        int previousValue = Math.max(0, (index - n));
-        return this.indicator.getValue(previousValue);
+        int previousIndex = index - n;
+        return previousIndex < 0 ? NaN.NaN : indicator.getValue(previousIndex);
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
@@ -34,6 +34,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 public class DPOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -64,7 +65,8 @@ public class DPOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
         // compare results to alternative calculation for each index
         for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertEquals(dpo.getValue(i), cp.getValue(i).minus(sma.getValue(i - timeShift)));
+            assertEquals(dpo.getValue(i),
+                    i - timeShift < 0 ? NaN.NaN : cp.getValue(i).minus(sma.getValue(i - timeShift)));
         }
 
         assertNumEquals(0.111999, dpo.getValue(9));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.indicators.EMAIndicator;
+import org.ta4j.core.num.NaN;
 
 public class PreviousValueIndicatorTest {
 
@@ -74,21 +75,22 @@ public class PreviousValueIndicatorTest {
 
         // test 1 with openPrice-indicator
         prevValueIndicator = new PreviousValueIndicator(openPriceIndicator);
-        assertEquals(prevValueIndicator.getValue(0), openPriceIndicator.getValue(0));
+        assertEquals(prevValueIndicator.getValue(0), NaN.NaN);
+
         for (int i = 1; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), openPriceIndicator.getValue(i - 1));
         }
 
         // test 2 with lowPrice-indicator
         prevValueIndicator = new PreviousValueIndicator(lowPriceIndicator);
-        assertEquals(prevValueIndicator.getValue(0), lowPriceIndicator.getValue(0));
+        assertEquals(prevValueIndicator.getValue(0), NaN.NaN);
         for (int i = 1; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), lowPriceIndicator.getValue(i - 1));
         }
 
         // test 3 with highPrice-indicator
         prevValueIndicator = new PreviousValueIndicator(highPriceIndicator);
-        assertEquals(prevValueIndicator.getValue(0), highPriceIndicator.getValue(0));
+        assertEquals(prevValueIndicator.getValue(0), NaN.NaN);
         for (int i = 1; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), highPriceIndicator.getValue(i - 1));
         }
@@ -105,8 +107,8 @@ public class PreviousValueIndicatorTest {
 
         // test 1 with volume-indicator
         prevValueIndicator = new PreviousValueIndicator(volumeIndicator, n);
-        for (int i = 0; i < n; i++) {
-            assertEquals(prevValueIndicator.getValue(i), volumeIndicator.getValue(0));
+        for (int i = 1; i < n; i++) {
+            assertEquals(prevValueIndicator.getValue(i), i - n < 0 ? NaN.NaN : volumeIndicator.getValue(0));
         }
         for (int i = n; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), volumeIndicator.getValue(i - n));
@@ -114,8 +116,8 @@ public class PreviousValueIndicatorTest {
 
         // test 2 with ema-indicator
         prevValueIndicator = new PreviousValueIndicator(emaIndicator, n);
-        for (int i = 0; i < n; i++) {
-            assertEquals(prevValueIndicator.getValue(i), emaIndicator.getValue(0));
+        for (int i = 1; i < n; i++) {
+            assertEquals(prevValueIndicator.getValue(i), i - n < 0 ? NaN.NaN : emaIndicator.getValue(0));
         }
         for (int i = n; i < this.series.getBarCount(); i++) {
             assertEquals(prevValueIndicator.getValue(i), emaIndicator.getValue(i - n));


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/1064

Changes proposed in this pull request:
- **PreviousValueIndicator** returns `NaN` if the (n-th) previous value of an indicator does not exist, i.e. if the (n-th) previous is below the first available index. 

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
