### PR TITLE
Closes #1087

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -23,8 +23,9 @@
  */
 package org.ta4j.core.indicators;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
@@ -42,11 +43,12 @@ import org.ta4j.core.Indicator;
  */
 public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
 
-    private final Map<Integer, T> cachedResults;
+    /** List of cached results. */
+    private final List<T> results;
 
     /**
-     * Should always be the key (index) of the last (calculated) result in
-     * {@link #cachedResults}.
+     * Should always be the index of the last (calculated) result in
+     * {@link #results}.
      */
     protected int highestResultIndex = -1;
 
@@ -58,7 +60,7 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
     protected CachedIndicator(BarSeries series) {
         super(series);
         int limit = series.getMaximumBarCount();
-        this.cachedResults = limit == Integer.MAX_VALUE ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(limit);
+        this.results = limit == Integer.MAX_VALUE ? new ArrayList<>() : new ArrayList<>(limit);
     }
 
     /**
@@ -77,32 +79,109 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
     protected abstract T calculate(int index);
 
     @Override
-    public T getValue(final int index) {
+    public synchronized T getValue(int index) {
         BarSeries series = getBarSeries();
-        T result;
-
         if (series == null) {
-            // Indicator doesn't need cache without series (e.g. simple computation of the value).
-            result = calculate(index);
-        } else {
-            int actualIndex = Math.max(index, series.getRemovedBarsCount());
-            result = cachedResults.get(actualIndex);
-            if (result == null) {
-                if (index == series.getEndIndex()) { // Don't cache result if last bar
-                    result = calculate(index);
-                } else {
-                    int positiveIndex = Math.max(index, 0);
-                    result = calculate(positiveIndex);
-                    cachedResults.put(index, result);
-                    highestResultIndex = positiveIndex;
-                }
+            // Series is null; the indicator doesn't need cache.
+            // (e.g. simple computation of the value)
+            // --> Calculating the value
+            T result = calculate(index);
+            if (log.isTraceEnabled()) {
+                log.trace("{}({}): {}", this, index, result);
             }
+            return result;
         }
 
+        // Series is not null
+
+        final int removedBarsCount = series.getRemovedBarsCount();
+        final int maximumResultCount = series.getMaximumBarCount();
+
+        T result;
+        if (index < removedBarsCount) {
+            // Result already removed from cache
+            if (log.isTraceEnabled()) {
+                log.trace("{}: result from bar {} already removed from cache, use {}-th instead",
+                        getClass().getSimpleName(), index, removedBarsCount);
+            }
+            increaseLengthTo(removedBarsCount, maximumResultCount);
+            highestResultIndex = removedBarsCount;
+            result = results.get(0);
+            if (result == null) {
+                // It should be "result = calculate(removedBarsCount);".
+                // We use "result = calculate(0);" as a workaround
+                // to fix issue #120 (https://github.com/mdeverdelhan/ta4j/issues/120).
+                result = calculate(0);
+                results.set(0, result);
+            }
+        } else {
+            if (index == series.getEndIndex()) {
+                // Don't cache result if last bar
+                result = calculate(index);
+            } else {
+                increaseLengthTo(index, maximumResultCount);
+                if (index > highestResultIndex) {
+                    // Result not calculated yet
+                    highestResultIndex = index;
+                    result = calculate(index);
+                    results.set(results.size() - 1, result);
+                } else {
+                    // Result covered by current cache
+                    int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);
+                    result = results.get(resultInnerIndex);
+                    if (result == null) {
+                        result = calculate(index);
+                        results.set(resultInnerIndex, result);
+                    }
+                }
+            }
+
+        }
         if (log.isTraceEnabled()) {
             log.trace("{}({}): {}", this, index, result);
         }
-
         return result;
+    }
+
+    /**
+     * Increases the size of the cached results buffer.
+     *
+     * @param index     the index to increase length to
+     * @param maxLength the maximum length of the results buffer
+     */
+    private void increaseLengthTo(int index, int maxLength) {
+        if (highestResultIndex > -1) {
+            int newResultsCount = Math.min(index - highestResultIndex, maxLength);
+            if (newResultsCount == maxLength) {
+                results.clear();
+                results.addAll(Collections.nCopies(maxLength, null));
+            } else if (newResultsCount > 0) {
+                results.addAll(Collections.nCopies(newResultsCount, null));
+                removeExceedingResults(maxLength);
+            }
+        } else {
+            // First use of cache
+            assert results.isEmpty() : "Cache results list should be empty";
+            results.addAll(Collections.nCopies(Math.min(index + 1, maxLength), null));
+        }
+    }
+
+    /**
+     * Removes the N first results which exceed the maximum bar count. (i.e. keeps
+     * only the last maximumResultCount results)
+     *
+     * @param maximumResultCount the number of results to keep
+     */
+    private void removeExceedingResults(int maximumResultCount) {
+        int resultCount = results.size();
+        if (resultCount > maximumResultCount) {
+            // Removing old results
+            final int nbResultsToRemove = resultCount - maximumResultCount;
+            if (nbResultsToRemove == 1) {
+                results.remove(0);
+            } else {
+                results.subList(0, nbResultsToRemove).clear();
+            }
+        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -23,9 +23,8 @@
  */
 package org.ta4j.core.indicators;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
@@ -43,12 +42,11 @@ import org.ta4j.core.Indicator;
  */
 public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
 
-    /** List of cached results. */
-    private final List<T> results;
+    private final Map<Integer, T> cachedResults;
 
     /**
-     * Should always be the index of the last (calculated) result in
-     * {@link #results}.
+     * Should always be the key (index) of the last (calculated) result in
+     * {@link #cachedResults}.
      */
     protected int highestResultIndex = -1;
 
@@ -60,7 +58,7 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
     protected CachedIndicator(BarSeries series) {
         super(series);
         int limit = series.getMaximumBarCount();
-        this.results = limit == Integer.MAX_VALUE ? new ArrayList<>() : new ArrayList<>(limit);
+        this.cachedResults = limit == Integer.MAX_VALUE ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(limit);
     }
 
     /**
@@ -79,109 +77,32 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
     protected abstract T calculate(int index);
 
     @Override
-    public synchronized T getValue(int index) {
+    public T getValue(final int index) {
         BarSeries series = getBarSeries();
-        if (series == null) {
-            // Series is null; the indicator doesn't need cache.
-            // (e.g. simple computation of the value)
-            // --> Calculating the value
-            T result = calculate(index);
-            if (log.isTraceEnabled()) {
-                log.trace("{}({}): {}", this, index, result);
-            }
-            return result;
-        }
-
-        // Series is not null
-
-        final int removedBarsCount = series.getRemovedBarsCount();
-        final int maximumResultCount = series.getMaximumBarCount();
-
         T result;
-        if (index < removedBarsCount) {
-            // Result already removed from cache
-            if (log.isTraceEnabled()) {
-                log.trace("{}: result from bar {} already removed from cache, use {}-th instead",
-                        getClass().getSimpleName(), index, removedBarsCount);
-            }
-            increaseLengthTo(removedBarsCount, maximumResultCount);
-            highestResultIndex = removedBarsCount;
-            result = results.get(0);
-            if (result == null) {
-                // It should be "result = calculate(removedBarsCount);".
-                // We use "result = calculate(0);" as a workaround
-                // to fix issue #120 (https://github.com/mdeverdelhan/ta4j/issues/120).
-                result = calculate(0);
-                results.set(0, result);
-            }
+
+        if (series == null) {
+            // Indicator doesn't need cache without series (e.g. simple computation of the value).
+            result = calculate(index);
         } else {
-            if (index == series.getEndIndex()) {
-                // Don't cache result if last bar
-                result = calculate(index);
-            } else {
-                increaseLengthTo(index, maximumResultCount);
-                if (index > highestResultIndex) {
-                    // Result not calculated yet
-                    highestResultIndex = index;
+            int actualIndex = Math.max(index, series.getRemovedBarsCount());
+            result = cachedResults.get(actualIndex);
+            if (result == null) {
+                if (index == series.getEndIndex()) { // Don't cache result if last bar
                     result = calculate(index);
-                    results.set(results.size() - 1, result);
                 } else {
-                    // Result covered by current cache
-                    int resultInnerIndex = results.size() - 1 - (highestResultIndex - index);
-                    result = results.get(resultInnerIndex);
-                    if (result == null) {
-                        result = calculate(index);
-                        results.set(resultInnerIndex, result);
-                    }
+                    int positiveIndex = Math.max(index, 0);
+                    result = calculate(positiveIndex);
+                    cachedResults.put(index, result);
+                    highestResultIndex = positiveIndex;
                 }
             }
-
         }
+
         if (log.isTraceEnabled()) {
             log.trace("{}({}): {}", this, index, result);
         }
+
         return result;
-    }
-
-    /**
-     * Increases the size of the cached results buffer.
-     *
-     * @param index     the index to increase length to
-     * @param maxLength the maximum length of the results buffer
-     */
-    private void increaseLengthTo(int index, int maxLength) {
-        if (highestResultIndex > -1) {
-            int newResultsCount = Math.min(index - highestResultIndex, maxLength);
-            if (newResultsCount == maxLength) {
-                results.clear();
-                results.addAll(Collections.nCopies(maxLength, null));
-            } else if (newResultsCount > 0) {
-                results.addAll(Collections.nCopies(newResultsCount, null));
-                removeExceedingResults(maxLength);
-            }
-        } else {
-            // First use of cache
-            assert results.isEmpty() : "Cache results list should be empty";
-            results.addAll(Collections.nCopies(Math.min(index + 1, maxLength), null));
-        }
-    }
-
-    /**
-     * Removes the N first results which exceed the maximum bar count. (i.e. keeps
-     * only the last maximumResultCount results)
-     *
-     * @param maximumResultCount the number of results to keep
-     */
-    private void removeExceedingResults(int maximumResultCount) {
-        int resultCount = results.size();
-        if (resultCount > maximumResultCount) {
-            // Removing old results
-            final int nbResultsToRemove = resultCount - maximumResultCount;
-            if (nbResultsToRemove == 1) {
-                results.remove(0);
-            } else {
-                results.subList(0, nbResultsToRemove).clear();
-            }
-        }
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -225,7 +225,8 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         if (barIndex - 1 < seriesStartIndex) {
             return false;
         } else {
-            return getBarSeries().getBar(barIndex - 1).getClosePrice()
+            return getBarSeries().getBar(barIndex - 1)
+                    .getClosePrice()
                     .isLessThan(getBarSeries().getBar(barIndex).getClosePrice());
         }
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -58,6 +58,11 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
     private final Map<Integer, Num> lastAf = new HashMap<>();
 
     /**
+     * If series have removed bars, first actual bar won't have 0 index.
+     */
+    private int seriesStartIndex = getBarSeries().getBeginIndex();
+
+    /**
      * Constructor with:
      *
      * <ul>
@@ -111,31 +116,34 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         // clear the maps and recalculate the values for start to index
         // the internal calculations until the previous index will fill the
         // required maps for the acceleration factor, the trend direction and the
-        // last extreme value
-        for (int i = getBarSeries().getBeginIndex(); i < index; i++) {
+        // last extreme value.
+        // Cache doesn't require more than current and previous values.
+        seriesStartIndex = getBarSeries().getRemovedBarsCount();
+        if (index < seriesStartIndex) {
+            index = seriesStartIndex;
+        }
+
+        for (int i = seriesStartIndex; i < index; i++) {
             calculateInternal(i);
         }
 
         return calculateInternal(index);
-
     }
 
     private Num calculateInternal(int index) {
         Num sar = NaN;
         boolean is_up_trend;
 
-        if (index == getBarSeries().getBeginIndex()) {
+        if (index == seriesStartIndex) {
             lastExtreme.put(index, getBarSeries().getBar(index).getClosePrice());
             lastAf.put(index, zero());
             isUpTrendMap.put(index, false);
             return sar; // no trend detection possible for the first value
-        } else if (index == getBarSeries().getBeginIndex() + 1) {// start trend detection
-            is_up_trend = getBarSeries().getBar(index - 1)
-                    .getClosePrice()
-                    .isLessThan(getBarSeries().getBar(index).getClosePrice());
-
+        } else if (index == seriesStartIndex + 1) { // start trend detection
+            is_up_trend = defineUpTrend(index);
             lastAf.put(index, accelerationStart);
             isUpTrendMap.put(index, is_up_trend);
+
             if (is_up_trend) { // up trend
                 sar = new LowestValueIndicator(lowPriceIndicator, 2).getValue(index - 1); // put the lowest low value of
                 // two
@@ -211,6 +219,15 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
     @Override
     public int getUnstableBars() {
         return 0;
+    }
+
+    private boolean defineUpTrend(final int barIndex) {
+        if (barIndex - 1 < seriesStartIndex) {
+            return false;
+        } else {
+            return getBarSeries().getBar(barIndex - 1).getClosePrice()
+                    .isLessThan(getBarSeries().getBar(barIndex).getClosePrice());
+        }
     }
 
     /**

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -24,6 +24,7 @@
 package org.ta4j.core.indicators;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.time.ZonedDateTime;
@@ -38,6 +39,7 @@ import org.ta4j.core.Bar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -48,84 +50,93 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void growingBarSeriesTest() {
+        ZonedDateTime now = ZonedDateTime.now();
         List<Bar> bars = new ArrayList<>();
-        bars.add(new MockBar(4120.98, 4086.29, 4211.08, 4032.62, numFunction));
+        bars.add(new MockBar(now, 74.5, 75.1, 75.11, 74.06, 0, 0, 0, numFunction));
 
         MockBarSeries mockBarSeries = new MockBarSeries(bars);
-        mockBarSeries.setMaximumBarCount(4);
+        mockBarSeries.setMaximumBarCount(3);
 
-        ZonedDateTime now = ZonedDateTime.now();
-        mockBarSeries.addBar(new MockBar(now, 4069.13, 4016.00, 4119.62, 3911.79, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(1), 4016.00, 4040.00, 4104.82, 3400.00, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(2), 4040.00, 4114.01, 4265.80, 4013.89, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(3), 4147.00, 4316.01, 4371.68, 4085.01, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(4), 4316.01, 4280.68, 4453.91, 4247.48, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(1),75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(2),79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(3),75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(4),75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(5),74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
 
-        sar.getValue(0);
-        sar.getValue(1);
-        sar.getValue(2);
-        sar.getValue(3);
+        assertEquals(NaN.NaN, sar.getValue(mockBarSeries.getBeginIndex()));
+        assertEquals(NaN.NaN, sar.getValue(mockBarSeries.getRemovedBarsCount()));
+
+        assertNotEquals(NaN.NaN, sar.getValue(mockBarSeries.getRemovedBarsCount() + 1));
+        assertNotEquals(NaN.NaN, sar.getValue(mockBarSeries.getEndIndex()));
     }
 
     @Test
     public void startUpAndDownTrendTest() {
+        ZonedDateTime now = ZonedDateTime.now();
         List<Bar> bars = new ArrayList<>();
+        // values of removable bars are much higher to be sure that they will not affect the result.
+        bars.add(new MockBar(now.plusSeconds(1),165.5, 175.1, 180.10, 170.1, 0, 0, 0, numFunction));
+        bars.add(new MockBar(now.plusSeconds(2),175.1, 185.1, 190.20, 180.2, 0, 0, 0, numFunction));
+        bars.add(new MockBar(now.plusSeconds(3),185.1, 195.1, 200.30, 190.3, 0, 0, 0, numFunction));
 
-        bars.add(new MockBar(74.5, 75.1, 75.11, 74.06, numFunction));
-        bars.add(new MockBar(75.09, 75.9, 76.030000, 74.640000, numFunction));
-        bars.add(new MockBar(79.99, 75.24, 76.269900, 75.060000, numFunction));
-        bars.add(new MockBar(75.30, 75.17, 75.280000, 74.500000, numFunction));
-        bars.add(new MockBar(75.16, 74.6, 75.310000, 74.540000, numFunction));
-        bars.add(new MockBar(74.58, 74.1, 75.467000, 74.010000, numFunction));
-        bars.add(new MockBar(74.01, 73.740000, 74.700000, 73.546000, numFunction));
-        bars.add(new MockBar(73.71, 73.390000, 73.830000, 72.720000, numFunction));
-        bars.add(new MockBar(73.35, 73.25, 73.890000, 72.86, numFunction));
-        bars.add(new MockBar(73.24, 74.36, 74.410000, 73, 26, numFunction));
-        bars.add(new MockBar(74.36, 76.510000, 76.830000, 74.820000, numFunction));
-        bars.add(new MockBar(76.5, 75.590000, 76.850000, 74.540000, numFunction));
-        bars.add(new MockBar(75.60, 75.910000, 76.960000, 75.510000, numFunction));
-        bars.add(new MockBar(75.82, 74.610000, 77.070000, 74.560000, numFunction));
-        bars.add(new MockBar(74.75, 75.330000, 75.530000, 74.010000, numFunction));
-        bars.add(new MockBar(75.33, 75.010000, 75.500000, 74.510000, numFunction));
-        bars.add(new MockBar(75.0, 75.620000, 76.210000, 75.250000, numFunction));
-        bars.add(new MockBar(75.63, 76.040000, 76.460000, 75.092800, numFunction));
-        bars.add(new MockBar(76.0, 76.450000, 76.450000, 75.435000, numFunction));
-        bars.add(new MockBar(76.45, 76.260000, 76.470000, 75.840000, numFunction));
-        bars.add(new MockBar(76.30, 76.850000, 77.000000, 76.190000, numFunction));
+        MockBarSeries mockBarSeries = new MockBarSeries(bars);
+        mockBarSeries.setMaximumBarCount(21);
 
-        ParabolicSarIndicator sar = new ParabolicSarIndicator(new MockBarSeries(bars));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(4), 74.5, 75.1, 75.11, 74.06, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(5), 75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(6), 79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(7), 75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(8), 75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(9), 74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(10), 74.01, 73.740000, 74.700000, 73.546000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(11), 73.71, 73.390000, 73.830000, 72.720000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(12), 73.35, 73.25, 73.890000, 72.86, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(13), 73.24, 74.36, 74.410000, 73, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(14), 74.36, 76.510000, 76.830000, 74.820000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(15), 76.5, 75.590000, 76.850000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(16), 75.60, 75.910000, 76.960000, 75.510000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(17), 75.82, 74.610000, 77.070000, 74.560000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(18), 74.75, 75.330000, 75.530000, 74.010000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(19), 75.33, 75.010000, 75.500000, 74.510000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(20), 75.0, 75.620000, 76.210000, 75.250000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(21), 75.63, 76.040000, 76.460000, 75.092800, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(22), 76.0, 76.450000, 76.450000, 75.435000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(23), 76.45, 76.260000, 76.470000, 75.840000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(24), 76.30, 76.850000, 77.000000, 76.190000, 0, 0, 0, numFunction));
 
-        assertEquals("NaN", sar.getValue(0).toString());
-        assertNumEquals(74.06, sar.getValue(1));
-        assertNumEquals(74.06, sar.getValue(2)); // start with up trend
-        assertNumEquals(74.148396, sar.getValue(3)); // switch to downtrend
-        assertNumEquals(74.23325616000001, sar.getValue(4)); // hold trend...
-        assertNumEquals(76.2699, sar.getValue(5));
-        assertNumEquals(76.22470200000001, sar.getValue(6));
-        assertNumEquals(76.11755392, sar.getValue(7));
-        assertNumEquals(75.9137006848, sar.getValue(8));
-        assertNumEquals(75.72207864371201, sar.getValue(9)); // switch to up trend
-        assertNumEquals(72.72, sar.getValue(10));// hold trend
-        assertNumEquals(72.8022, sar.getValue(11));
-        assertNumEquals(72.964112, sar.getValue(12));
-        assertNumEquals(73.20386528, sar.getValue(13));
-        assertNumEquals(73.5131560576, sar.getValue(14));
-        assertNumEquals(73.797703572992, sar.getValue(15));
-        assertNumEquals(74.01, sar.getValue(16));
-        assertNumEquals(74.2548, sar.getValue(17));
-        assertNumEquals(74.480016, sar.getValue(18));
-        assertNumEquals(74.68721472, sar.getValue(19));
-        assertNumEquals(74.8778375424, sar.getValue(20));
+        ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
+
+        assertEquals(NaN.NaN, sar.getValue(mockBarSeries.getRemovedBarsCount())); // first bar in series
+        assertNumEquals(74.06, sar.getValue(mockBarSeries.getRemovedBarsCount() + 1));
+        assertNumEquals(74.06, sar.getValue(mockBarSeries.getRemovedBarsCount() + 2)); // start with up trend
+        assertNumEquals(74.148396, sar.getValue(mockBarSeries.getRemovedBarsCount() + 3)); // switch to downtrend
+        assertNumEquals(74.23325616000001, sar.getValue(mockBarSeries.getRemovedBarsCount() + 4)); // hold trend...
+        assertNumEquals(76.2699, sar.getValue(mockBarSeries.getRemovedBarsCount() + 5));
+        assertNumEquals(76.22470200000001, sar.getValue(mockBarSeries.getRemovedBarsCount() + 6));
+        assertNumEquals(76.11755392, sar.getValue(mockBarSeries.getRemovedBarsCount() + 7));
+        assertNumEquals(75.9137006848, sar.getValue(mockBarSeries.getRemovedBarsCount() + 8));
+        assertNumEquals(75.72207864371201, sar.getValue(mockBarSeries.getRemovedBarsCount() + 9)); // switch to up trend
+        assertNumEquals(72.72, sar.getValue(mockBarSeries.getRemovedBarsCount() + 10));// hold trend
+        assertNumEquals(72.8022, sar.getValue(mockBarSeries.getRemovedBarsCount() + 11)); // ??? trend changed?
+        assertNumEquals(72.964112, sar.getValue(mockBarSeries.getRemovedBarsCount() + 12));
+        assertNumEquals(73.20386528, sar.getValue(mockBarSeries.getRemovedBarsCount() + 13));
+        assertNumEquals(73.5131560576, sar.getValue(mockBarSeries.getRemovedBarsCount() + 14));
+        assertNumEquals(73.797703572992, sar.getValue(mockBarSeries.getRemovedBarsCount() + 15));
+        assertNumEquals(74.01, sar.getValue(mockBarSeries.getRemovedBarsCount() + 16));
+        assertNumEquals(74.2548, sar.getValue(mockBarSeries.getRemovedBarsCount() + 17));
+        assertNumEquals(74.480016, sar.getValue(mockBarSeries.getRemovedBarsCount() + 18));
+        assertNumEquals(74.68721472, sar.getValue(mockBarSeries.getRemovedBarsCount() + 19));
+        assertNumEquals(74.8778375424, sar.getValue(mockBarSeries.getRemovedBarsCount() + 20));
     }
 
     @Test
     public void startWithDownAndUpTrendTest() {
         List<Bar> bars = new ArrayList<>();
         bars.add(new MockBar(4261.48, 4285.08, 4485.39, 4200.74, numFunction)); // The first daily candle of BTCUSDT in
-                                                                                // the Binance cryptocurrency exchange.
-                                                                                // 17 Aug 2017
+        // the Binance cryptocurrency exchange.
+        // 17 Aug 2017
         bars.add(new MockBar(4285.08, 4108.37, 4371.52, 3938.77, numFunction)); // starting with down trend
         bars.add(new MockBar(4108.37, 4139.98, 4184.69, 3850.00, numFunction)); // hold trend...
         bars.add(new MockBar(4120.98, 4086.29, 4211.08, 4032.62, numFunction));
@@ -138,7 +149,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(new MockBarSeries(bars));
 
-        assertEquals("NaN", sar.getValue(0).toString());
+        assertEquals(NaN.NaN, sar.getValue(0));
         assertNumEquals(4485.39000000, sar.getValue(1));
         assertNumEquals(4485.39000000, sar.getValue(2));
         assertNumEquals(4459.97440000, sar.getValue(3));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -57,11 +57,11 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
         MockBarSeries mockBarSeries = new MockBarSeries(bars);
         mockBarSeries.setMaximumBarCount(3);
 
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(1),75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(2),79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(3),75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(4),75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(5),74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(1), 75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(2), 79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(3), 75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(4), 75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(5), 74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
 
@@ -76,10 +76,11 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
     public void startUpAndDownTrendTest() {
         ZonedDateTime now = ZonedDateTime.now();
         List<Bar> bars = new ArrayList<>();
-        // values of removable bars are much higher to be sure that they will not affect the result.
-        bars.add(new MockBar(now.plusSeconds(1),165.5, 175.1, 180.10, 170.1, 0, 0, 0, numFunction));
-        bars.add(new MockBar(now.plusSeconds(2),175.1, 185.1, 190.20, 180.2, 0, 0, 0, numFunction));
-        bars.add(new MockBar(now.plusSeconds(3),185.1, 195.1, 200.30, 190.3, 0, 0, 0, numFunction));
+        // values of removable bars are much higher to be sure that they will not affect
+        // the result.
+        bars.add(new MockBar(now.plusSeconds(1), 165.5, 175.1, 180.10, 170.1, 0, 0, 0, numFunction));
+        bars.add(new MockBar(now.plusSeconds(2), 175.1, 185.1, 190.20, 180.2, 0, 0, 0, numFunction));
+        bars.add(new MockBar(now.plusSeconds(3), 185.1, 195.1, 200.30, 190.3, 0, 0, 0, numFunction));
 
         MockBarSeries mockBarSeries = new MockBarSeries(bars);
         mockBarSeries.setMaximumBarCount(21);
@@ -90,21 +91,34 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
         mockBarSeries.addBar(new MockBar(now.plusSeconds(7), 75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
         mockBarSeries.addBar(new MockBar(now.plusSeconds(8), 75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
         mockBarSeries.addBar(new MockBar(now.plusSeconds(9), 74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(10), 74.01, 73.740000, 74.700000, 73.546000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(11), 73.71, 73.390000, 73.830000, 72.720000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(10), 74.01, 73.740000, 74.700000, 73.546000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(11), 73.71, 73.390000, 73.830000, 72.720000, 0, 0, 0, numFunction));
         mockBarSeries.addBar(new MockBar(now.plusSeconds(12), 73.35, 73.25, 73.890000, 72.86, 0, 0, 0, numFunction));
         mockBarSeries.addBar(new MockBar(now.plusSeconds(13), 73.24, 74.36, 74.410000, 73, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(14), 74.36, 76.510000, 76.830000, 74.820000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(15), 76.5, 75.590000, 76.850000, 74.540000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(16), 75.60, 75.910000, 76.960000, 75.510000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(17), 75.82, 74.610000, 77.070000, 74.560000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(18), 74.75, 75.330000, 75.530000, 74.010000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(19), 75.33, 75.010000, 75.500000, 74.510000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(20), 75.0, 75.620000, 76.210000, 75.250000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(21), 75.63, 76.040000, 76.460000, 75.092800, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(22), 76.0, 76.450000, 76.450000, 75.435000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(23), 76.45, 76.260000, 76.470000, 75.840000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(24), 76.30, 76.850000, 77.000000, 76.190000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(14), 74.36, 76.510000, 76.830000, 74.820000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(15), 76.5, 75.590000, 76.850000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(16), 75.60, 75.910000, 76.960000, 75.510000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(17), 75.82, 74.610000, 77.070000, 74.560000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(18), 74.75, 75.330000, 75.530000, 74.010000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(19), 75.33, 75.010000, 75.500000, 74.510000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(20), 75.0, 75.620000, 76.210000, 75.250000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(21), 75.63, 76.040000, 76.460000, 75.092800, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(22), 76.0, 76.450000, 76.450000, 75.435000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(23), 76.45, 76.260000, 76.470000, 75.840000, 0, 0, 0, numFunction));
+        mockBarSeries
+                .addBar(new MockBar(now.plusSeconds(24), 76.30, 76.850000, 77.000000, 76.190000, 0, 0, 0, numFunction));
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
 


### PR DESCRIPTION
Fixes ta4j/ta4j#1087.

Changes proposed in this pull request:
- Change [CachedIndicator](https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java) to simplify logic by using `Map` instead of `List`.
- Change [ParabolicSarIndicator](https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java) to not evaluate values from 0 index, and use removedBarsCount instead, because series with removed bars doesn't have values at indexes less then removed bars counter. When indicator get values from non-existent index, it actually receive value at removedBarsCount index instead, but using it like real values and produce fake values (for itself too) because of it.
- Change [ParabolicSarIndicatorTest](https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java) to test not only series without removed bars.
