### PR TITLE
#1087 Fixing ParabolicSarIndicator & BarSeries#getBeginIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
       - `BarSeriesManager manager = new BarSeriesManager(barSeries, new TradeOnCurrentCloseModel())`
       - `BarSeriesManager manager = new BarSeriesManager(barSeries, transactionCostModel, holdingCostModel, tradeExecutionModel)`
 - **BarSeriesManager** and **BacktestExecutor** moved to packge **`backtest`**
+- **BarSeries#getBeginIndex()** methode returns correct begin index for bar series with max bar count
 
 ### Fixed
 -  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -228,7 +228,7 @@ public class BaseBarSeries implements BarSeries {
                     String.format("the endIndex: %s must be greater than startIndex: %s", endIndex, startIndex));
         }
         if (!bars.isEmpty()) {
-            int start = Math.max(startIndex - getRemovedBarsCount(), this.getBeginIndex());
+            int start = startIndex - getRemovedBarsCount();
             int end = Math.min(endIndex - getRemovedBarsCount(), this.getEndIndex() + 1);
             return new BaseBarSeries(getName(), cut(bars, start, end), num);
         }
@@ -452,6 +452,7 @@ public class BaseBarSeries implements BarSeries {
             }
             // Updating removed bars count
             removedBarsCount += nbBarsToRemove;
+            seriesBeginIndex = Math.max(seriesBeginIndex, removedBarsCount);
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -112,6 +112,10 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         // the internal calculations until the previous index will fill the
         // required maps for the acceleration factor, the trend direction and the
         // last extreme value
+        if (index < getBarSeries().getBeginIndex()) {
+            return NaN;
+        }
+
         for (int i = getBarSeries().getBeginIndex(); i < index; i++) {
             calculateInternal(i);
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -121,7 +121,7 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         if (index < getBarSeries().getBeginIndex()) {
             return NaN;
         }
-        
+
         seriesStartIndex = getBarSeries().getRemovedBarsCount();
         if (index < seriesStartIndex) {
             index = seriesStartIndex;

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -255,7 +255,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
         defaultSeries.setMaximumBarCount(3);
 
         // After
-        assertEquals(0, defaultSeries.getBeginIndex());
+        assertEquals(3, defaultSeries.getBeginIndex());
         assertEquals(5, defaultSeries.getEndIndex());
         assertEquals(3, defaultSeries.getBarCount());
     }
@@ -357,7 +357,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         IntStream.range(0, 100).forEach(i -> {
             series.addBar(ZonedDateTime.now(ZoneId.systemDefault()).plusMinutes(i), 5, 7, 1, 5, i);
-            int startIndex = Math.max(0, series.getEndIndex() - timespan + 1);
+            int startIndex = Math.max(series.getBeginIndex(), series.getEndIndex() - timespan + 1);
             int endIndex = i + 1;
             final BarSeries subSeries = series.getSubSeries(startIndex, endIndex);
             assertEquals(subSeries.getBarCount(), endIndex - startIndex);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -57,11 +57,11 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
         MockBarSeries mockBarSeries = new MockBarSeries(bars);
         mockBarSeries.setMaximumBarCount(3);
 
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(1),75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(2),79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(3),75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(4),75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(5),74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(1), 75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(2), 79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(3), 75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(4), 75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(5), 74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -24,6 +24,7 @@
 package org.ta4j.core.indicators;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.time.ZonedDateTime;
@@ -38,6 +39,7 @@ import org.ta4j.core.Bar;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -48,25 +50,26 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void growingBarSeriesTest() {
+        ZonedDateTime now = ZonedDateTime.now();
         List<Bar> bars = new ArrayList<>();
-        bars.add(new MockBar(4120.98, 4086.29, 4211.08, 4032.62, numFunction));
+        bars.add(new MockBar(now, 74.5, 75.1, 75.11, 74.06, 0, 0, 0, numFunction));
 
         MockBarSeries mockBarSeries = new MockBarSeries(bars);
-        mockBarSeries.setMaximumBarCount(4);
+        mockBarSeries.setMaximumBarCount(3);
 
-        ZonedDateTime now = ZonedDateTime.now();
-        mockBarSeries.addBar(new MockBar(now, 4069.13, 4016.00, 4119.62, 3911.79, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(1), 4016.00, 4040.00, 4104.82, 3400.00, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(2), 4040.00, 4114.01, 4265.80, 4013.89, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(3), 4147.00, 4316.01, 4371.68, 4085.01, 0, 0, 0, numFunction));
-        mockBarSeries.addBar(new MockBar(now.plusSeconds(4), 4316.01, 4280.68, 4453.91, 4247.48, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(1),75.09, 75.9, 76.030000, 74.640000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(2),79.99, 75.24, 76.269900, 75.060000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(3),75.30, 75.17, 75.280000, 74.500000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(4),75.16, 74.6, 75.310000, 74.540000, 0, 0, 0, numFunction));
+        mockBarSeries.addBar(new MockBar(now.plusSeconds(5),74.58, 74.1, 75.467000, 74.010000, 0, 0, 0, numFunction));
 
         ParabolicSarIndicator sar = new ParabolicSarIndicator(mockBarSeries);
 
-        sar.getValue(0);
-        sar.getValue(1);
-        sar.getValue(2);
-        sar.getValue(3);
+        assertEquals(NaN.NaN, sar.getValue(mockBarSeries.getBeginIndex()));
+        assertEquals(NaN.NaN, sar.getValue(mockBarSeries.getRemovedBarsCount()));
+
+        assertNotEquals(NaN.NaN, sar.getValue(mockBarSeries.getRemovedBarsCount() + 1));
+        assertNotEquals(NaN.NaN, sar.getValue(mockBarSeries.getEndIndex()));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1087 .

Changes proposed in this pull request:
- According to #1087 and PR #1088 this PR suggests a solution with fixing the getBeginIndex method of bar series with a maximum bar count
- A bar series with a maximum bar count of `n` can hold up to `n` bars. Further bars can be added by removing the oldest bar ensuring that there are only `n` bars stored. The `endIndex` is growing with each added bar and represents the index of the last bar. With this PR the `startIndex` is also growing by adding new bars and represents the index of the first valid bar (instead of 0 or whatever the startIndex was before setting the max bar count)

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
