### PR TITLE
Use copy of bar data in a modifiable collection in base bar series creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **ThreeWhiteSoldiersIndicator** fixed eliminated instance variable holding possible wrong value
 - **ThreeBlackCrowsIndicator** fixed eliminated instance variable holding possible wrong value
 - **TrailingStopLossRule** removed instance variable `currentStopLossLimitActivation` because it may not be alway the correct (last) value
+- **BaseBarSeries** fixed `UnsupportedOperationException` when creating a bar series that is based on an unmodifiable collection
 
 ### Changed
 - **BarSeriesManager** consider finishIndex when running backtest

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -166,7 +166,7 @@ public class BaseBarSeries implements BarSeries {
     BaseBarSeries(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained, Num num) {
         this.name = name;
 
-        this.bars = bars;
+        this.bars = new ArrayList<>(bars);
         if (bars.isEmpty()) {
             // Bar list empty
             this.seriesBeginIndex = -1;


### PR DESCRIPTION

Changes proposed in this pull request:
- With this PR we use a copy of the provided bar data, that is a mofifiable list  in the `BaseBarSeries` constructor. This avoids `UnsupportedOperation` Exception when trying to add further bars to the series . This also avoids further side effects: changes in the original bar data list are not affecting the behaviour of the created bar series

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
