### PR TITLE
0.16.8 (unreleased) downgrade to java 8,works on any JVM8+

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: '11'
+        java-version: '8'
     - name: Build with Maven
       run: xvfb-run mvn -B license:check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '8'
       - name: Build with Maven
         run: xvfb-run mvn -B test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: '11'
+        java-version: '8'
     - name: Build with Maven
       run: xvfb-run mvn -B formatter:validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangelog.com/en/1.0.0/) from version 0.9 onwards.
 
+## 0.16.8 (unreleased)
+- **downgrade to java 8,works on any Java Platform version 8 or later**
+- **ta4j-0.16.8 supports the Java EE edition whereas  ta4j-0.16 supports Jakarta EE, otherwise the two versions are feature identical.**
+
 ## 0.16 (unreleased)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ta4j is an open source Java library for [technical analysis](http://en.wikipedia
 
 ### Features
 
- * [x] 100% Pure Java - works on any Java Platform version 11 or later
+ * [x] 100% Pure Java - works on any Java Platform version 8 or later
  * [x] More than 130 technical indicators (Aroon, ATR, moving averages, parabolic SAR, RSI, etc.)
  * [x] A powerful engine for building custom trading strategies
  * [x] Utilities to run and compare strategies

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.ta4j</groupId>
 	<artifactId>ta4j-parent</artifactId>
-	<version>0.16-SNAPSHOT</version>
+	<version>0.16.8-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Ta4j Parent</name>
@@ -71,7 +71,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.4.4</version>
+				<version>1.3.11</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -143,9 +143,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
-					<release>11</release>
+					<source>1.8</source>
+					<target>1.8</target>
+<!--					<release>11</release>-->
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 				</configuration>

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.ta4j</groupId>
 		<artifactId>ta4j-parent</artifactId>
-		<version>0.16-SNAPSHOT</version>
+		<version>0.16.8-SNAPSHOT</version>
 	</parent>
 	<artifactId>ta4j-core</artifactId>
 

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
@@ -98,7 +99,7 @@ public class BarSeriesTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void createWithUnmodifiableCollectionTest() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withBars(List.copyOf(bars)).build();
+        BarSeries series = new BaseBarSeriesBuilder().withNumTypeOf(numFunction).withBars( new ArrayList<>(bars)).build();
         series.addBar(new MockBar(ZonedDateTime.of(2014, 7, 1, 0, 0, 0, 0, ZoneId.systemDefault()), 7d, numFunction));
         assertEquals(7, series.getBarCount());
         assertEquals(0, series.getBeginIndex());

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.16-SNAPSHOT</version>
+        <version>0.16.8-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.ta4j</groupId>
             <artifactId>ta4j-core</artifactId>
-            <version>0.16-SNAPSHOT</version>
+            <version>0.16.8-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
0.16.8 (unreleased) downgrade to java 8,works on any Java Platform version 8 or later

ta4j-0.16.8 supports the Java EE edition whereas  ta4j-0.16 supports Jakarta EE, otherwise the two versions are feature identical.

https://github.com/ta4j/ta4j/issues/1099


Fixes #.

Changes proposed in this pull request:
- 
- 
- 

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
