### PR TITLE
add-Num#bigDecimalValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,24 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ## 0.17
 
-- Added signal line and histogram to **MACDIndicator**
-- Implemented inner cache for **SMAIndicator**
-- Added getTransactionCostModel, getHoldingCostModel, getTrades in **TradingRecord**
-- **BooleanTransformIndicator** remove enum constraint in favor of more flexible `Predicate`
-- Fixed **ta4jexamples** project still pointing to old (0.16) version of **ta4j-core**
+### Breaking
 - Renamed **SMAIndicatorMovingSerieTest** to **SMAIndicatorMovingSeriesTest**
+
+### Fixed
+- Fixed **ta4jexamples** project still pointing to old (0.16) version of **ta4j-core**
 - Fixed **SMAIndicatorMovingSeriesTest** test flakiness where on fast enough build machines the mock bars are created with the exact same end time
+
+### Changed
+- Implemented inner cache for **SMAIndicator**
+- **BooleanTransformIndicator** remove enum constraint in favor of more flexible `Predicate`
 - **EnterAndHoldReturnCriterion** replaced by `EnterAndHoldCriterion` to calculate the "enter and hold"-strategy of any criteria.
+
+### Removed/Deprecated
+
+### Added
+- Added signal line and histogram to **MACDIndicator**
+- Added getTransactionCostModel, getHoldingCostModel, getTrades in **TradingRecord**
+- Added `Num.bigDecimalValue(DoubleNum)` to convert Num to a BigDecimal
 
 
 ## 0.16 (released May 15, 2024)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
@@ -23,13 +23,12 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.num.NaN.NaN;
+
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.indicators.helpers.ClosePriceDifferenceIndicator;
-import org.ta4j.core.indicators.helpers.VolumeIndicator;
 import org.ta4j.core.num.Num;
-
-import static org.ta4j.core.num.NaN.NaN;
 
 /**
  * Time Segmented Volume (TSV) indicator.

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -304,6 +304,11 @@ public final class DecimalNum implements Num {
         return (number -> DecimalNum.valueOf(number.toString(), mathContext.getPrecision()));
     }
 
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
     /**
      * Returns the underlying {@link BigDecimal} delegate.
      *
@@ -324,8 +329,8 @@ public final class DecimalNum implements Num {
     }
 
     @Override
-    public String getName() {
-        return this.getClass().getSimpleName();
+    public BigDecimal bigDecimalValue() {
+        return delegate;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -25,6 +25,7 @@ package org.ta4j.core.num;
 
 import static org.ta4j.core.num.NaN.NaN;
 
+import java.math.BigDecimal;
 import java.util.function.Function;
 
 /**
@@ -147,13 +148,18 @@ public class DoubleNum implements Num {
     }
 
     @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
     public Double getDelegate() {
         return delegate;
     }
 
     @Override
-    public String getName() {
-        return this.getClass().getSimpleName();
+    public BigDecimal bigDecimalValue() {
+        return Double.isNaN(delegate) || Double.isInfinite(delegate) ? null : BigDecimal.valueOf(delegate);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.num;
 
+import java.math.BigDecimal;
 import java.util.function.Function;
 
 /**
@@ -89,6 +90,11 @@ public class NaN implements Num {
     @Override
     public double doubleValue() {
         return Double.NaN;
+    }
+
+    @Override
+    public BigDecimal bigDecimalValue() {
+        return null;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -319,15 +319,6 @@ public interface Num extends Comparable<Num>, Serializable {
     }
 
     /**
-     * Converts this {@code Num} to a {@code double}.
-     *
-     * @return this {@code Num} converted to a {@code double}
-     */
-    default double doubleValue() {
-        return getDelegate().doubleValue();
-    }
-
-    /**
      * Converts this {@code Num} to an {@code integer}.
      *
      * @return this {@code Num} converted to an {@code integer}
@@ -353,6 +344,22 @@ public interface Num extends Comparable<Num>, Serializable {
     default float floatValue() {
         return getDelegate().floatValue();
     }
+
+    /**
+     * Converts this {@code Num} to a {@code double}.
+     *
+     * @return this {@code Num} converted to a {@code double}
+     */
+    default double doubleValue() {
+        return getDelegate().doubleValue();
+    }
+
+    /**
+     * Converts this {@code Num} to a {@code BigDecimal}.
+     *
+     * @return this {@code Num} converted to a {@code BigDecimal}
+     */
+    BigDecimal bigDecimalValue();
 
     @Override
     int hashCode();

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
@@ -23,26 +23,22 @@
  */
 package org.ta4j.core.indicators.volume;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.ta4j.core.Bar;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
-import org.ta4j.core.Indicator;
-import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.mocks.MockBar;
-import org.ta4j.core.mocks.MockBarSeries;
-import org.ta4j.core.num.NaN;
-import org.ta4j.core.num.Num;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.junit.Assert.*;
-import static org.ta4j.core.TestUtils.assertNumEquals;
-import static org.ta4j.core.num.NaN.NaN;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.mocks.MockBar;
+import org.ta4j.core.mocks.MockBarSeries;
+import org.ta4j.core.num.Num;
 
 public class MoneyFlowIndexIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- added `Num.bigDecimalValue()` to convert the `Num` to a `BigDecimal`
    - For `DecimalNum` it returns its `delegate`
    - For `DoubleNum` it converts by `BigDecimal.valueOf(delegate)` (if delegate is `NaN` or `Infinity`, then it simply returns `null`)
    - For `NaN` it simply returns `null`.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

_Actually, it's not easy to get the `BigDecimal`-representation of a `Num`. We have `intValue()`, `longValue()`, `doubleValue()`, etc. so it also makes sense to add `bigDecimalValue()`._