### PR TITLE
Update DecimalNum: `valueOf(DoubleNum)`

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -187,7 +187,7 @@ public final class DecimalNum implements Num {
      * @throws NumberFormatException if {@code val} is {@code "NaN"}
      */
     public static DecimalNum valueOf(DoubleNum val) {
-        return valueOf(val.toString());
+        return valueOf(val.doubleValue());
     }
 
     /**


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- `DecimalNum#valueOf(DoubleNum)`: Use doubleValue instead of converting to String.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` (already added by `added DecimalNum.valueOf(DoubleNum) to convert a DoubleNum to a DecimalNum.`)
