### PR TITLE
Added `TradingRecord#getTrade(index)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - added "TradeExecutionModel" to modify trade execution during backtesting
 - added **NumIndicator** to calculate any `Num`-value for a `Bar`
 - added **RunningTotalIndicator** to calculate a cumulative sum for a period.
+- added `TradingRecord.getTrade(barIndex)` to get the trade executed at the specified {@code barIndex}.
 
 ### Fixed
 - **Fixed** **CashFlow** fixed calculation with custom startIndex and endIndex

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -148,6 +148,27 @@ public interface TradingRecord extends Serializable {
     }
 
     /**
+     * Gets the trade executed at the specified {@code barIndex}.
+     * 
+     * @param barIndex the index the trade were executed
+     * @return the trade with {@link Trade#getIndex()} equals {@code barIndex}, null
+     *         otherwise
+     */
+    default Trade getTrade(int barIndex) {
+        for (Position p : getPositions()) {
+            Trade entry = p.getEntry();
+            if (entry != null && entry.getIndex() == barIndex) {
+                return entry;
+            }
+            Trade exit = p.getExit();
+            if (exit != null && exit.getIndex() == barIndex) {
+                return exit;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return the last trade recorded
      */
     Trade getLastTrade();


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- added `TradingRecord.getTrade(barIndex)` to get the trade executed at the specified index (= barIndex).

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

_A useful method to get the `Trade` from the `TradingRecord` executed on a specific `index`. Complements other query methods (like getLastTrade(), etc.)._
