### PR TITLE
Fixes erroneous SuperTrend calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **BarSeries#getBeginIndex()** methode returns correct begin index for bar series with max bar count
 
 ### Fixed
--  **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices
+- **Fixed** **SuperTrendIndicator** fixed calculation when close price is the same as the previous Super Trend indicator value
+- **Fixed** **ParabolicSarIndicator** fixed calculation for sporadic indices
 - **ExpectancyCriterion** fixed calculation
 - catch NumberFormatException if `DecimalNum.valueOf(Number)` is `NaN`
 - **ProfitCriterion** fixed excludeCosts functionality as it was reversed

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
@@ -76,7 +76,7 @@ public class SuperTrendIndicator extends RecursiveCachedIndicator<Num> {
         Num upperBand = superTrendUpperBandIndicator.getValue(i);
 
         if (previousValue.isEqual(superTrendUpperBandIndicator.getValue(i - 1))) {
-            if (closePrice.isLessThan(upperBand)) {
+            if (closePrice.isLessThanOrEqual(upperBand)) {
                 value = upperBand;
             } else if (closePrice.isGreaterThan(upperBand)) {
                 value = lowerBand;
@@ -84,7 +84,7 @@ public class SuperTrendIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         if (previousValue.isEqual(superTrendLowerBandIndicator.getValue(i - 1))) {
-            if (closePrice.isGreaterThan(lowerBand)) {
+            if (closePrice.isGreaterThanOrEqual(lowerBand)) {
                 value = lowerBand;
             } else if (closePrice.isLessThan(lowerBand)) {
                 value = upperBand;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -67,12 +67,11 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
         bars.add(new MockBar(19.89, 6.36, 20.22, 6.21, numFunction));
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
-        // new bar creating the problem (close price == previous Super Trend value)
+        // this mock bar exemplify an edge case, the close price is the same as the previous Super Trend value
         bars.add(new MockBar(19.28, 22.78938583966133, 23.58, 10.11, numFunction));
-        // more values to show that Super Trend value stay 0 even after
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
-        bars.add(new MockBar(21.56, 18.83, 21.80, 18.83, numFunction));
-        bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
+        bars.add(new MockBar(10.34, 9.83, 12.80, 8.83, numFunction));
+        bars.add(new MockBar(11.83, 7.35, 11.41, 5.01, numFunction));
 
         data = new MockBarSeries(bars);
     }
@@ -83,12 +82,21 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
         assertNumEquals(this.numOf(15.730621000000003), superTrendIndicator.getValue(4));
         assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(9));
+        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(10));
+        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(11));
+        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(12));
+    }
+
+    @Test
+    public void regressionTestOnZeroSuperTrendValueWhenClosePriceIsEqualToPreviousSuperTrendValue() {
+        // bug: https://github.com/ta4j/ta4j/issues/1120
+        SuperTrendIndicator superTrendIndicator = new SuperTrendIndicator(data);
+
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(13));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(14));
-        // now the Super Trend value goes to 0
-        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(15));
-        // no matter what happens after, it stays 0
-        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(16));
-        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(17));
-        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(18));
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(15));
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(16));
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(17));
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(18));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -67,6 +67,7 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
         bars.add(new MockBar(19.89, 6.36, 20.22, 6.21, numFunction));
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
+        bars.add(new MockBar(19.28, 22.78938583966133, 23.58, 10.11, numFunction));
 
         data = new MockBarSeries(bars);
     }
@@ -78,6 +79,6 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         assertNumEquals(this.numOf(15.730621000000003), superTrendIndicator.getValue(4));
         assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(9));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(14));
-
+        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(15));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -67,7 +67,12 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
         bars.add(new MockBar(19.89, 6.36, 20.22, 6.21, numFunction));
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
+        // new bar creating the problem (close price == previous Super Trend value)
         bars.add(new MockBar(19.28, 22.78938583966133, 23.58, 10.11, numFunction));
+        // more values to show that Super Trend value stay 0 even after
+        bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
+        bars.add(new MockBar(21.56, 18.83, 21.80, 18.83, numFunction));
+        bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
 
         data = new MockBarSeries(bars);
     }
@@ -79,6 +84,11 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         assertNumEquals(this.numOf(15.730621000000003), superTrendIndicator.getValue(4));
         assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(9));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(14));
+        // now the Super Trend value goes to 0
         assertNumEquals(this.numOf(0), superTrendIndicator.getValue(15));
+        // no matter what happens after, it stays 0
+        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(16));
+        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(17));
+        assertNumEquals(this.numOf(0), superTrendIndicator.getValue(18));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -82,7 +82,7 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
         assertNumEquals(this.numOf(15.730621000000003), superTrendIndicator.getValue(4));
         assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(9));
-        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(14));
+        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(14));
     }
 
     @Test
@@ -90,7 +90,6 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         // bug: https://github.com/ta4j/ta4j/issues/1120
         SuperTrendIndicator superTrendIndicator = new SuperTrendIndicator(data);
 
-        assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(13));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(14));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(15));
         assertNumEquals(this.numOf(22.78938583966133), superTrendIndicator.getValue(16));

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -82,9 +82,7 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
         assertNumEquals(this.numOf(15.730621000000003), superTrendIndicator.getValue(4));
         assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(9));
-        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(10));
-        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(11));
-        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(12));
+        assertNumEquals(this.numOf(17.602360938100002), superTrendIndicator.getValue(14));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -67,7 +67,8 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         bars.add(new MockBar(19.00, 18.35, 19.41, 18.01, numFunction));
         bars.add(new MockBar(19.89, 6.36, 20.22, 6.21, numFunction));
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
-        // this mock bar exemplify an edge case, the close price is the same as the previous Super Trend value
+        // this mock bar exemplify an edge case, the close price is the same as the
+        // previous Super Trend value
         bars.add(new MockBar(19.28, 22.78938583966133, 23.58, 10.11, numFunction));
         bars.add(new MockBar(19.28, 10.34, 20.58, 10.11, numFunction));
         bars.add(new MockBar(10.34, 9.83, 12.80, 8.83, numFunction));


### PR DESCRIPTION
Fixes #1120 .

Changes proposed in this pull request:
- On SuperTrendIndicator fixed calculation when close price is the same as the previous Super Trend indicator value

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
