### PR TITLE
Fixes `CrossIndicator#calculator` function

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
@@ -62,13 +62,10 @@ public class CrossIndicator extends CachedIndicator<Boolean> {
             return false;
         }
 
-        i--;
-        if (up.getValue(i).isGreaterThan(low.getValue(i))) {
-            return true;
-        }
-        while (i > 0 && up.getValue(i).isEqual(low.getValue(i))) {
+        do {
             i--;
-        }
+        } while (i > 0 && up.getValue(i).isEqual(low.getValue(i)));
+
         return (i != 0) && (up.getValue(i).isGreaterThan(low.getValue(i)));
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
@@ -66,7 +66,7 @@ public class CrossIndicator extends CachedIndicator<Boolean> {
             i--;
         } while (i > 0 && up.getValue(i).isEqual(low.getValue(i)));
 
-        return (i != 0) && (up.getValue(i).isGreaterThan(low.getValue(i)));
+        return up.getValue(i).isGreaterThan(low.getValue(i));
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
@@ -36,17 +36,18 @@ import org.ta4j.core.num.Num;
 
 public class CrossedDownIndicatorRuleTest {
 
-    private CrossedDownIndicatorRule rule;
+    private BarSeries series;
 
     @Before
     public void setUp() {
-        BarSeries series = new BaseBarSeries();
-        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 12, 11, 10, 9, 11, 8, 7, 6);
-        rule = new CrossedDownIndicatorRule(evaluatedIndicator, 10);
+        series = new BaseBarSeries();
     }
 
     @Test
     public void isSatisfied() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 12, 11, 10, 9, 11, 8, 7, 6);
+        CrossedDownIndicatorRule rule = new CrossedDownIndicatorRule(evaluatedIndicator, 10);
+
         assertFalse(rule.isSatisfied(0));
         assertFalse(rule.isSatisfied(1));
         assertFalse(rule.isSatisfied(2));
@@ -55,5 +56,30 @@ public class CrossedDownIndicatorRuleTest {
         assertTrue(rule.isSatisfied(5));
         assertFalse(rule.isSatisfied(6));
         assertFalse(rule.isSatisfied(7));
+    }
+
+    @Test
+    public void onlyThresholdBetweenFirstBarAndLastBar() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 11, 10, 10, 9);
+        CrossedDownIndicatorRule rule = new CrossedDownIndicatorRule(evaluatedIndicator, 10);
+
+        assertFalse(rule.isSatisfied(0));
+        assertFalse(rule.isSatisfied(1));
+        assertFalse(rule.isSatisfied(2));
+        assertTrue(rule.isSatisfied(3));
+    }
+
+    @Test
+    public void repeatedlyHittingThresholdAfterCrossDown() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 11, 10, 9, 10, 9, 10, 9);
+        CrossedDownIndicatorRule rule = new CrossedDownIndicatorRule(evaluatedIndicator, 10);
+
+        assertFalse(rule.isSatisfied(0));
+        assertFalse(rule.isSatisfied(1));
+        assertTrue("first cross down", rule.isSatisfied(2));
+        assertFalse(rule.isSatisfied(3));
+        assertFalse(rule.isSatisfied(4));
+        assertFalse(rule.isSatisfied(5));
+        assertFalse(rule.isSatisfied(6));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.FixedDecimalIndicator;
@@ -35,17 +36,18 @@ import org.ta4j.core.num.Num;
 
 public class CrossedUpIndicatorRuleTest {
 
-    private CrossedUpIndicatorRule rule;
+    private BarSeries series;
 
     @Before
     public void setUp() {
-        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(new BaseBarSeries(), 8d, 9d, 10d, 12d, 9d, 11d,
-                12d, 13d);
-        rule = new CrossedUpIndicatorRule(evaluatedIndicator, 10);
+        series = new BaseBarSeries();
     }
 
     @Test
     public void isSatisfied() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 8, 9, 10, 12, 9, 11, 12, 13);
+        CrossedUpIndicatorRule rule = new CrossedUpIndicatorRule(evaluatedIndicator, 10);
+
         assertFalse(rule.isSatisfied(0));
         assertFalse(rule.isSatisfied(1));
         assertFalse(rule.isSatisfied(2));
@@ -54,5 +56,31 @@ public class CrossedUpIndicatorRuleTest {
         assertTrue(rule.isSatisfied(5));
         assertFalse(rule.isSatisfied(6));
         assertFalse(rule.isSatisfied(7));
+    }
+
+    @Test
+    public void onlyThresholdBetweenFirstBarAndLastBar() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 9, 10, 10, 10, 11);
+        CrossedUpIndicatorRule rule = new CrossedUpIndicatorRule(evaluatedIndicator, 10);
+
+        assertFalse(rule.isSatisfied(0));
+        assertFalse(rule.isSatisfied(1));
+        assertFalse(rule.isSatisfied(2));
+        assertFalse(rule.isSatisfied(3));
+        assertTrue(rule.isSatisfied(4));
+    }
+
+    @Test
+    public void repeatedlyHittingThresholdAfterCrossUp() {
+        Indicator<Num> evaluatedIndicator = new FixedDecimalIndicator(series, 9, 10, 11, 10, 11, 10, 11);
+        CrossedUpIndicatorRule rule = new CrossedUpIndicatorRule(evaluatedIndicator, 10);
+
+        assertFalse(rule.isSatisfied(0));
+        assertFalse(rule.isSatisfied(1));
+        assertTrue("first cross up", rule.isSatisfied(2));
+        assertFalse(rule.isSatisfied(3));
+        assertFalse(rule.isSatisfied(4));
+        assertFalse(rule.isSatisfied(5));
+        assertFalse(rule.isSatisfied(6));
     }
 }


### PR DESCRIPTION
Fixes `CrossIndicator#calculator` function

Changes proposed in this pull request:
- Fixed `CrossIndicator#calculator` function not working when there is only a threshold between the first and last value.
- Added a test case for the `CrossUp(Down)IndicatorRule` class for when the threshold is repeatedly reached after a cross-up(down) cross.

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
