### PR TITLE
Introduced live trading LiveIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangelog.com/en/1.0.0/) from version 0.9 onwards.
 
 ## 0.16 (unreleased)
+- **Added LiveIndicator for live trading side channels
 
 ### Breaking
 - **Upgraded to Java 11**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/LiveIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/LiveIndicator.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators;
+
+import java.util.function.Supplier;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.num.Num;
+
+/**
+ * This indicator is usable in live trading as side channel for data analysis.
+ *
+ * For example exchange may send profit calculations and we want base entry exit
+ * rules on that information.
+ */
+class LiveIndicator implements Indicator<Num> {
+
+    private final Supplier<Num> valueSupplier;
+    private final BarSeries series;
+
+    public LiveIndicator(final BarSeries series, final Supplier<Number> valueSupplier) {
+        this.series = series;
+        this.valueSupplier = () -> numOf(valueSupplier.get());
+    }
+
+    @Override
+    public Num getValue(final int index) {
+        return this.valueSupplier.get();
+    }
+
+    @Override
+    public int getUnstableBars() {
+        return 0;
+    }
+
+    @Override
+    public BarSeries getBarSeries() {
+        return this.series;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/LiveIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/LiveIndicatorTest.java
@@ -1,0 +1,29 @@
+package org.ta4j.core.indicators;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.num.Num;
+
+public class LiveIndicatorTest extends AbstractIndicatorTest {
+
+    public LiveIndicatorTest(final Function<Number, Num> function) {
+        super(function);
+    }
+
+    @Test
+    public void getValue() {
+        final var liveIndicator = new LiveIndicator(new BaseBarSeries() {
+            @Override
+            public Num numOf(final Number number) {
+                return LiveIndicatorTest.super.numOf(number);
+            }
+        }, () -> 37.5);
+
+        final var indicatorValue = liveIndicator.getValue(4534534);
+        assertEquals(numOf(37.5), indicatorValue);
+    }
+}


### PR DESCRIPTION
- which may fetch data from external source


Changes proposed in this pull request:
- ta4j may analyse external data sources and create rules from them

For example we may use CPU temperature, AI generated numeric advision, current profit from exchange API as stop loss source.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
