### PR TITLE
Add `notEquals` transform type to `BooleanTransformIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Added signal line and histogram to MACDIndicator**
 - **Implemented inner cache for SMAIndicator**
 - Added getTransactionCostModel, getHoldingCostModel, getTrades in TradingRecord
-
+- **BooleanTransformIndicator** added `notEquals` transform type
 
 ## 0.16 (released May 15, 2024)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -49,6 +49,12 @@ public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
 
         /**
          * Transforms the decimal indicator to a boolean indicator by
+         * !indicator.equals(coefficient).
+         */
+        notEquals,
+
+        /**
+         * Transforms the decimal indicator to a boolean indicator by
          * indicator.isGreaterThan(coefficient).
          */
         isGreaterThan,
@@ -155,6 +161,8 @@ public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
             switch (type) {
             case equals:
                 return val.equals(coefficient);
+            case notEquals:
+                return !val.equals(coefficient);
             case isGreaterThan:
                 return val.isGreaterThan(coefficient);
             case isGreaterThanOrEqual:

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
@@ -41,6 +41,7 @@ import org.ta4j.core.num.Num;
 public class BooleanTransformIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean>, Num> {
 
     private BooleanTransformIndicator transEquals;
+    private BooleanTransformIndicator transNotEquals;
     private BooleanTransformIndicator transIsGreaterThan;
     private BooleanTransformIndicator transIsGreaterThanOrEqual;
     private BooleanTransformIndicator transIsLessThan;
@@ -65,6 +66,7 @@ public class BooleanTransformIndicatorTest extends AbstractIndicatorTest<Indicat
         ConstantIndicator<Num> constantIndicator = new ConstantIndicator<Num>(series, FOUR);
 
         transEquals = new BooleanTransformIndicator(constantIndicator, FOUR, BooleanTransformType.equals);
+        transNotEquals = new BooleanTransformIndicator(constantIndicator, minusFOUR, BooleanTransformType.notEquals);
         transIsGreaterThan = new BooleanTransformIndicator(constantIndicator, numFunction.apply(3),
                 BooleanTransformType.isGreaterThan);
         transIsGreaterThanOrEqual = new BooleanTransformIndicator(constantIndicator, FOUR,
@@ -89,6 +91,7 @@ public class BooleanTransformIndicatorTest extends AbstractIndicatorTest<Indicat
     @Test
     public void getValue() {
         assertTrue(transEquals.getValue(0));
+        assertTrue(transNotEquals.getValue(0));
         assertTrue(transIsGreaterThan.getValue(0));
         assertTrue(transIsGreaterThanOrEqual.getValue(0));
         assertTrue(transIsLessThan.getValue(0));


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `notEquals` transform type to `BooleanTransformIndicator`.

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
