### PR TITLE
Use `Predicate` instead of enum in `BooleanTransformIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - **Added signal line and histogram to MACDIndicator**
 - **Implemented inner cache for SMAIndicator**
 - Added getTransactionCostModel, getHoldingCostModel, getTrades in TradingRecord
-
+- **BooleanTransformIndicator** remove enum constraint in favor of more flexible `Predicate`
 
 ## 0.16 (released May 15, 2024)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -34,36 +34,36 @@ import java.util.function.Predicate;
  */
 public class BooleanTransformIndicator<T> extends CachedIndicator<Boolean> {
 
-    public static BooleanTransformIndicator<Num> equals(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.equals(coefficient));
+    public static BooleanTransformIndicator<Num> equals(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.equals(constant));
     }
 
-    public static BooleanTransformIndicator<Num> notEquals(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> !num.equals(coefficient));
+    public static BooleanTransformIndicator<Num> notEquals(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> !num.equals(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isEqual(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.isEqual(coefficient));
+    public static BooleanTransformIndicator<Num> isEqual(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isEqual(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isNotEqual(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> !num.isEqual(coefficient));
+    public static BooleanTransformIndicator<Num> isNotEqual(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> !num.isEqual(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isGreaterThan(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThan(coefficient));
+    public static BooleanTransformIndicator<Num> isGreaterThan(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThan(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isGreaterThanOrEqual(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThanOrEqual(coefficient));
+    public static BooleanTransformIndicator<Num> isGreaterThanOrEqual(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThanOrEqual(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isLessThan(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThan(coefficient));
+    public static BooleanTransformIndicator<Num> isLessThan(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThan(constant));
     }
 
-    public static BooleanTransformIndicator<Num> isLessThanOrEqual(Indicator<Num> indicator, Num coefficient) {
-        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThanOrEqual(coefficient));
+    public static BooleanTransformIndicator<Num> isLessThanOrEqual(Indicator<Num> indicator, Num constant) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThanOrEqual(constant));
     }
 
     public static BooleanTransformIndicator<Num> isZero(Indicator<Num> indicator) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -27,180 +27,94 @@ import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.CachedIndicator;
 import org.ta4j.core.num.Num;
 
+import java.util.function.Predicate;
+
 /**
- * Simple boolean transform indicator.
- *
- * <p>
- * Transforms any decimal indicator to a boolean indicator by using common
- * logical operators.
+ * Transforms any indicator to a boolean indicator.
  */
-public class BooleanTransformIndicator extends CachedIndicator<Boolean> {
+public class BooleanTransformIndicator<T> extends CachedIndicator<Boolean> {
 
-    /**
-     * Select the type for transformation.
-     */
-    public enum BooleanTransformType {
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.equals(coefficient).
-         */
-        equals,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isGreaterThan(coefficient).
-         */
-        isGreaterThan,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isGreaterThanOrEqual(coefficient).
-         */
-        isGreaterThanOrEqual,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isLessThan(coefficient).
-         */
-        isLessThan,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isLessThanOrEqual(coefficient).
-         */
-        isLessThanOrEqual
+    public static BooleanTransformIndicator<Num> equals(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.equals(coefficient));
     }
 
-    /**
-     * Select the type for transformation.
-     */
-    public enum BooleanTransformSimpleType {
-        /**
-         * Transforms the decimal indicator to a boolean indicator by indicator.isNaN().
-         */
-        isNaN,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isNegative().
-         */
-        isNegative,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isNegativeOrZero().
-         */
-        isNegativeOrZero,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isPositive().
-         */
-        isPositive,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isPositiveOrZero().
-         */
-        isPositiveOrZero,
-
-        /**
-         * Transforms the decimal indicator to a boolean indicator by
-         * indicator.isZero().
-         */
-        isZero
+    public static BooleanTransformIndicator<Num> notEquals(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> !num.equals(coefficient));
     }
 
-    private final Indicator<Num> indicator;
-    private final Num coefficient;
-    private final BooleanTransformType type;
-    private final BooleanTransformSimpleType simpleType;
-
-    /**
-     * Constructor.
-     *
-     * @param indicator   the indicator
-     * @param coefficient the value for transformation
-     * @param type        the type of the transformation
-     */
-    public BooleanTransformIndicator(Indicator<Num> indicator, Num coefficient, BooleanTransformType type) {
-        super(indicator);
-        this.indicator = indicator;
-        this.coefficient = coefficient;
-        this.type = type;
-        this.simpleType = null;
+    public static BooleanTransformIndicator<Num> isEqual(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isEqual(coefficient));
     }
+
+    public static BooleanTransformIndicator<Num> isNotEqual(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> !num.isEqual(coefficient));
+    }
+
+    public static BooleanTransformIndicator<Num> isGreaterThan(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThan(coefficient));
+    }
+
+    public static BooleanTransformIndicator<Num> isGreaterThanOrEqual(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isGreaterThanOrEqual(coefficient));
+    }
+
+    public static BooleanTransformIndicator<Num> isLessThan(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThan(coefficient));
+    }
+
+    public static BooleanTransformIndicator<Num> isLessThanOrEqual(Indicator<Num> indicator, Num coefficient) {
+        return new BooleanTransformIndicator<>(indicator, num -> num.isLessThanOrEqual(coefficient));
+    }
+
+    public static BooleanTransformIndicator<Num> isZero(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isZero);
+    }
+
+    public static BooleanTransformIndicator<Num> isNaN(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isNaN);
+    }
+
+    public static BooleanTransformIndicator<Num> isPositive(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isPositive);
+    }
+
+    public static BooleanTransformIndicator<Num> isPositiveOrZero(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isPositiveOrZero);
+    }
+
+    public static BooleanTransformIndicator<Num> isNegative(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isNegative);
+    }
+
+    public static BooleanTransformIndicator<Num> isNegativeOrZero(Indicator<Num> indicator) {
+        return new BooleanTransformIndicator<>(indicator, Num::isNegativeOrZero);
+    }
+
+    private final Indicator<T> indicator;
+    private final Predicate<T> transform;
 
     /**
      * Constructor.
      *
      * @param indicator the indicator
-     * @param type      the type of the transformation
+     * @param transform the transform {@link Predicate} to apply
      */
-    public BooleanTransformIndicator(Indicator<Num> indicator, BooleanTransformSimpleType type) {
+    public BooleanTransformIndicator(Indicator<T> indicator, Predicate<T> transform) {
         super(indicator);
         this.indicator = indicator;
-        this.simpleType = type;
-        this.coefficient = null;
-        this.type = null;
+        this.transform = transform;
     }
 
     @Override
     protected Boolean calculate(int index) {
-
-        Num val = indicator.getValue(index);
-
-        if (type != null) {
-            switch (type) {
-            case equals:
-                return val.equals(coefficient);
-            case isGreaterThan:
-                return val.isGreaterThan(coefficient);
-            case isGreaterThanOrEqual:
-                return val.isGreaterThanOrEqual(coefficient);
-            case isLessThan:
-                return val.isLessThan(coefficient);
-            case isLessThanOrEqual:
-                return val.isLessThanOrEqual(coefficient);
-            default:
-                break;
-            }
-        }
-
-        else if (simpleType != null) {
-            switch (simpleType) {
-            case isNaN:
-                return val.isNaN();
-            case isNegative:
-                return val.isNegative();
-            case isNegativeOrZero:
-                return val.isNegativeOrZero();
-            case isPositive:
-                return val.isPositive();
-            case isPositiveOrZero:
-                return val.isPositiveOrZero();
-            case isZero:
-                return val.isZero();
-            default:
-                break;
-            }
-        }
-
-        return false;
+        return transform.test(indicator.getValue(index));
     }
 
-    /** @return {@code 0} */
+    /**
+     * @return {@code 0}
+     */
     @Override
     public int getUnstableBars() {
         return 0;
-    }
-
-    @Override
-    public String toString() {
-        if (type != null) {
-            return getClass().getSimpleName() + " Coefficient: " + coefficient + " Transform(" + type.name() + ")";
-        }
-        return getClass().getSimpleName() + "Transform(" + simpleType.name() + ")";
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
@@ -23,35 +23,34 @@
  */
 package org.ta4j.core.indicators.helpers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.function.Function;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
-import org.ta4j.core.indicators.helpers.BooleanTransformIndicator.BooleanTransformSimpleType;
-import org.ta4j.core.indicators.helpers.BooleanTransformIndicator.BooleanTransformType;
 import org.ta4j.core.num.Num;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BooleanTransformIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean>, Num> {
 
-    private BooleanTransformIndicator transEquals;
-    private BooleanTransformIndicator transIsGreaterThan;
-    private BooleanTransformIndicator transIsGreaterThanOrEqual;
-    private BooleanTransformIndicator transIsLessThan;
-    private BooleanTransformIndicator transIsLessThanOrEqual;
-
-    private BooleanTransformIndicator transIsNaN;
-    private BooleanTransformIndicator transIsNegative;
-    private BooleanTransformIndicator transIsNegativeOrZero;
-    private BooleanTransformIndicator transIsPositive;
-    private BooleanTransformIndicator transIsPositiveOrZero;
-    private BooleanTransformIndicator transIsZero;
+    private BooleanTransformIndicator<Num> equals;
+    private BooleanTransformIndicator<Num> notEquals;
+    private BooleanTransformIndicator<Num> isEqual;
+    private BooleanTransformIndicator<Num> isNotEqual;
+    private BooleanTransformIndicator<Num> isGreaterThan;
+    private BooleanTransformIndicator<Num> isGreaterThanOrEqual;
+    private BooleanTransformIndicator<Num> isLessThan;
+    private BooleanTransformIndicator<Num> isLessThanOrEqual;
+    private BooleanTransformIndicator<Num> isZero;
+    private BooleanTransformIndicator<Num> isNaN;
+    private BooleanTransformIndicator<Num> isPositive;
+    private BooleanTransformIndicator<Num> isPositiveOrZero;
+    private BooleanTransformIndicator<Num> isNegative;
+    private BooleanTransformIndicator<Num> isNegativeOrZero;
 
     public BooleanTransformIndicatorTest(Function<Number, Num> numFunction) {
         super(numFunction);
@@ -59,46 +58,40 @@ public class BooleanTransformIndicatorTest extends AbstractIndicatorTest<Indicat
 
     @Before
     public void setUp() {
-        Num FOUR = numFunction.apply(4);
-        Num minusFOUR = numFunction.apply(-4);
-        BarSeries series = new BaseBarSeries();
-        ConstantIndicator<Num> constantIndicator = new ConstantIndicator<Num>(series, FOUR);
+        final Num four = numFunction.apply(4);
+        final ConstantIndicator<Num> constantIndicator = new ConstantIndicator<>(new BaseBarSeries(), four);
 
-        transEquals = new BooleanTransformIndicator(constantIndicator, FOUR, BooleanTransformType.equals);
-        transIsGreaterThan = new BooleanTransformIndicator(constantIndicator, numFunction.apply(3),
-                BooleanTransformType.isGreaterThan);
-        transIsGreaterThanOrEqual = new BooleanTransformIndicator(constantIndicator, FOUR,
-                BooleanTransformType.isGreaterThanOrEqual);
-        transIsLessThan = new BooleanTransformIndicator(constantIndicator, numFunction.apply(10),
-                BooleanTransformType.isLessThan);
-        transIsLessThanOrEqual = new BooleanTransformIndicator(constantIndicator, FOUR,
-                BooleanTransformType.isLessThanOrEqual);
-
-        transIsNaN = new BooleanTransformIndicator(constantIndicator, BooleanTransformSimpleType.isNaN);
-        transIsNegative = new BooleanTransformIndicator(new ConstantIndicator<Num>(series, minusFOUR),
-                BooleanTransformSimpleType.isNegative);
-        transIsNegativeOrZero = new BooleanTransformIndicator(constantIndicator,
-                BooleanTransformSimpleType.isNegativeOrZero);
-        transIsPositive = new BooleanTransformIndicator(constantIndicator, BooleanTransformSimpleType.isPositive);
-        transIsPositiveOrZero = new BooleanTransformIndicator(constantIndicator,
-                BooleanTransformSimpleType.isPositiveOrZero);
-        transIsZero = new BooleanTransformIndicator(new ConstantIndicator<Num>(series, numFunction.apply(0)),
-                BooleanTransformSimpleType.isZero);
+        equals = BooleanTransformIndicator.equals(constantIndicator, four);
+        notEquals = BooleanTransformIndicator.notEquals(constantIndicator, four);
+        isEqual = BooleanTransformIndicator.isEqual(constantIndicator, four);
+        isNotEqual = BooleanTransformIndicator.isNotEqual(constantIndicator, four);
+        isGreaterThan = BooleanTransformIndicator.isGreaterThan(constantIndicator, four);
+        isGreaterThanOrEqual = BooleanTransformIndicator.isGreaterThanOrEqual(constantIndicator, four);
+        isLessThan = BooleanTransformIndicator.isLessThan(constantIndicator, four);
+        isLessThanOrEqual = BooleanTransformIndicator.isLessThanOrEqual(constantIndicator, four);
+        isZero = BooleanTransformIndicator.isZero(constantIndicator);
+        isNaN = BooleanTransformIndicator.isNaN(constantIndicator);
+        isPositive = BooleanTransformIndicator.isPositive(constantIndicator);
+        isPositiveOrZero = BooleanTransformIndicator.isPositiveOrZero(constantIndicator);
+        isNegative = BooleanTransformIndicator.isNegative(constantIndicator);
+        isNegativeOrZero = BooleanTransformIndicator.isNegativeOrZero(constantIndicator);
     }
 
     @Test
     public void getValue() {
-        assertTrue(transEquals.getValue(0));
-        assertTrue(transIsGreaterThan.getValue(0));
-        assertTrue(transIsGreaterThanOrEqual.getValue(0));
-        assertTrue(transIsLessThan.getValue(0));
-        assertTrue(transIsLessThanOrEqual.getValue(0));
-
-        assertFalse(transIsNaN.getValue(0));
-        assertTrue(transIsNegative.getValue(0));
-        assertFalse(transIsNegativeOrZero.getValue(0));
-        assertTrue(transIsPositive.getValue(0));
-        assertTrue(transIsPositiveOrZero.getValue(0));
-        assertTrue(transIsZero.getValue(0));
+        assertTrue(equals.getValue(0));
+        assertFalse(notEquals.getValue(0));
+        assertTrue(isEqual.getValue(0));
+        assertFalse(isNotEqual.getValue(0));
+        assertFalse(isGreaterThan.getValue(0));
+        assertTrue(isGreaterThanOrEqual.getValue(0));
+        assertFalse(isLessThan.getValue(0));
+        assertTrue(isLessThanOrEqual.getValue(0));
+        assertFalse(isZero.getValue(0));
+        assertFalse(isNaN.getValue(0));
+        assertTrue(isPositive.getValue(0));
+        assertTrue(isPositiveOrZero.getValue(0));
+        assertFalse(isNegative.getValue(0));
+        assertFalse(isNegativeOrZero.getValue(0));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove enum constraint in favor of more flexible `Predicate` (see #1162).

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
