### PR TITLE
Update ta4jexamples dependency version and fix SMAIndicatorMovingSerieTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangelog.com/en/1.0.0/) from version 0.9 onwards.
 
 ## 0.17
-- **Added signal line and histogram to MACDIndicator**
-- **Implemented inner cache for SMAIndicator**
-- Added getTransactionCostModel, getHoldingCostModel, getTrades in TradingRecord
+- Added signal line and histogram to **MACDIndicator**
+- Implemented inner cache for **SMAIndicator**
+- Added getTransactionCostModel, getHoldingCostModel, getTrades in **TradingRecord**
+- Fixed **ta4jexamples** project still pointing to old (0.16) version of **ta4j-core**
+- Renamed **SMAIndicatorMovingSerieTest** to **SMAIndicatorMovingSeriesTest**
+- Fixed **SMAIndicatorMovingSeriesTest** test flakiness where on fast enough build machines the mock bars are created with the exact same end time
 
 
 ## 0.16 (released May 15, 2024)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -61,7 +61,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
         randomAccessAfterFourAdditions();
     }
 
-    private void firstAddition() {        
+    private void firstAddition() {
         data.addBar(new MockBar(ZonedDateTime.now(), 5., numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
@@ -78,7 +78,8 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void secondAddition() {
-        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 10., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 10.,
+                numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -94,7 +95,8 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void thirdAddition() {
-        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 20., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 20.,
+                numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -110,7 +112,8 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void fourthAddition() {
-        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 30., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 30.,
+                numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -142,8 +145,10 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void whenBarCountIs1ResultShouldBeIndicatorValue() {
-        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5., numFunction));
-        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5.,
+                numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5.,
+                numFunction));
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 1);
         for (int i = 0; i < data.getBarCount(); i++) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -23,6 +23,7 @@
  */
 package org.ta4j.core.indicators;
 
+import java.time.ZonedDateTime;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -37,9 +38,9 @@ import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.Num;
 
-public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
-    public SMAIndicatorMovingSerieTest(Function<Number, Num> numFunction) {
+    public SMAIndicatorMovingSeriesTest(Function<Number, Num> numFunction) {
         super((data, params) -> new SMAIndicator(data, (int) params[0]), numFunction);
     }
 
@@ -60,8 +61,8 @@ public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator
         randomAccessAfterFourAdditions();
     }
 
-    private void firstAddition() {
-        data.addBar(new MockBar(5., numFunction));
+    private void firstAddition() {        
+        data.addBar(new MockBar(ZonedDateTime.now(), 5., numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -77,7 +78,7 @@ public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator
     }
 
     private void secondAddition() {
-        data.addBar(new MockBar(10., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 10., numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -93,7 +94,7 @@ public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator
     }
 
     private void thirdAddition() {
-        data.addBar(new MockBar(20., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 20., numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -109,7 +110,7 @@ public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator
     }
 
     private void fourthAddition() {
-        data.addBar(new MockBar(30., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 30., numFunction));
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -141,8 +142,8 @@ public class SMAIndicatorMovingSerieTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void whenBarCountIs1ResultShouldBeIndicatorValue() {
-        data.addBar(new MockBar(5., numFunction));
-        data.addBar(new MockBar(5., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5., numFunction));
+        data.addBar(new MockBar(data.isEmpty() ? ZonedDateTime.now() : data.getLastBar().getEndTime().plusHours(1), 5., numFunction));
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 1);
         for (int i = 0; i < data.getBarCount(); i++) {

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.ta4j</groupId>
             <artifactId>ta4j-core</artifactId>
-            <version>0.16</version>
+            <version>0.17-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes ##1164, #1165

Changes proposed in this pull request:
- Bump ta4j-core version in ta4jexamples pom
- Renamed SMAIndicatorMovingSerieTest to SMAIndicatorMovingSerie**s**Test
- Fixed SMAIndicatorMovingSeriesTest test flakiness where on fast enough build machines the mock bars are created with the exact same end time

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
