### PR TITLE
RecentSwing*Indicator fixed look ahead bias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Fixed
 - Fixed **ta4jexamples** project still pointing to old (0.16) version of **ta4j-core**
 - Fixed **SMAIndicatorMovingSeriesTest** test flakiness where on fast enough build machines the mock bars are created with the exact same end time
+- Fixed look ahead bias in **RecentSwingHighIndicator** and **RecentSwingLowIndicator**
 
 ### Changed
 - Implemented inner cache for **SMAIndicator**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
@@ -24,8 +24,11 @@
 package org.ta4j.core.indicators;
 
 import org.ta4j.core.BarSeries;
-import static org.ta4j.core.num.NaN.NaN;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.num.Num;
+
+import static org.ta4j.core.num.NaN.NaN;
 
 /**
  * Recent Swing High Indicator.
@@ -34,25 +37,26 @@ public class RecentSwingHighIndicator extends CachedIndicator<Num> {
 
     private final int surroundingLowerBars;
     private final int allowedEqualBars;
+    Indicator<Num> indicator;
 
     /**
      * Constructs a RecentSwingHighIndicator
      *
-     * @param series               The BarSeries to be analyzed.
+     * @param indicator            The Indicator to be analyzed.
      * @param surroundingLowerBars For a bar to be identified as a swing high, it
      *                             must have a higher high than this number of bars
      *                             both immediately preceding and immediately
      *                             following
-     * @param allowedEqualBars     For a looser definition of peak, instead of
+     * @param allowedEqualBars     For a looser definition of swing high, instead of
      *                             requiring the surrounding bars to be strictly
      *                             lower highs we allow this number of equal highs
-     *                             to either side (i.e. flat-ish peak or plateau)
+     *                             to either side (i.e. flat-ish valley)
      * @throws IllegalArgumentException if surroundingLowerBars is less than or
      *                                  equal to 0.
      * @throws IllegalArgumentException if allowedEqualBars is less than 0.
      */
-    public RecentSwingHighIndicator(BarSeries series, int surroundingLowerBars, int allowedEqualBars) {
-        super(series);
+    public RecentSwingHighIndicator(Indicator<Num> indicator, int surroundingLowerBars, int allowedEqualBars) {
+        super(indicator);
 
         if (surroundingLowerBars <= 0) {
             throw new IllegalArgumentException("surroundingLowerBars must be greater than 0");
@@ -62,95 +66,111 @@ public class RecentSwingHighIndicator extends CachedIndicator<Num> {
         }
         this.surroundingLowerBars = surroundingLowerBars;
         this.allowedEqualBars = allowedEqualBars;
+        this.indicator = indicator;
     }
 
     /**
-     * * Constructs a RecentSwingHighIndicator with the specified BarSeries and
-     * surrounding lower bars count and a default allowed equal bars count of 0
+     * Constructs a RecentSwingHighIndicator with the specified BarSeries (and
+     * defaulting to use HighPriceIndicator) and surrounding higher bars count and a
+     * default allowed equal bars of 0
      *
-     * @param series
-     * @param surroundingLowerBars
+     * @param series               The BarSeries to be analyzed.
+     * @param surroundingLowerBars The number of bars to consider on each side that
+     *                             must have lower highs to identify a swing high.
      */
     public RecentSwingHighIndicator(BarSeries series, int surroundingLowerBars) {
-        this(series, surroundingLowerBars, 0);
+        this(new HighPriceIndicator(series), surroundingLowerBars, 0);
     }
 
     /**
-     * Constructs a RecentSwingHighIndicator with the specified BarSeries, a default
-     * surrounding lower bars count of 2, and a default allowed equal bars count of
-     * 0
+     * Constructs a RecentSwingHighIndicator with the specified BarSeries (and
+     * defaulting to use HighPriceIndicator) and surrounding higher bars count
+     * defaulted to 2, and a default allowed equal bars of 0
      *
-     * @param series The BarSeries to be analyzed.
+     * @param series The BarSeries to be analyzed. must have lower highs to identify
+     *               a swing high.
      */
     public RecentSwingHighIndicator(BarSeries series) {
-        this(series, 2, 0);
+        this(new HighPriceIndicator(series), 2, 0);
     }
 
-    /**
-     * Validates if the specified bar at currentIndex, considering the direction,
-     * meets the criteria for being a swing high.
-     *
-     * @param currentIndex The index of the current bar.
-     * @param direction    The direction for comparison (-1 for previous bars, 1 for
-     *                     following bars).
-     * @return true if the bar at currentIndex is a swing high considering the
-     *         specified direction; false otherwise.
-     */
-    private boolean validateBars(int currentIndex, int direction) {
-        Num currentHighPrice = getBarSeries().getBar(currentIndex).getHighPrice();
+    private boolean isSwingHigh(int index) {
+        if (index < surroundingLowerBars || index >= getBarSeries().getBarCount()) {
+            return false;
+        }
+
+        Num currentPrice = this.indicator.getValue(index);
+
+        // Check bars before
+        if (!checkPrecedingBars(index, currentPrice)) {
+            return false;
+        }
+
+        // Check bars after (up to the current calculation index)
+        return checkFollowingBars(index, currentPrice);
+    }
+
+    private boolean checkPrecedingBars(int index, Num currentPrice) {
         int lowerBarsCount = 0;
         int equalBarsCount = 0;
 
-        for (int i = currentIndex + direction; i >= getBarSeries().getBeginIndex()
-                && i <= getBarSeries().getEndIndex(); i += direction) {
-            Num comparisonHighPrice = getBarSeries().getBar(i).getHighPrice();
+        for (int i = index - 1; i >= index - surroundingLowerBars - allowedEqualBars && i >= 0; i--) {
+            Num comparisonPrice = this.indicator.getValue(i);
 
-            if (currentHighPrice.isEqual(comparisonHighPrice)) {
+            if (currentPrice.isEqual(comparisonPrice)) {
                 equalBarsCount++;
-
                 if (equalBarsCount > allowedEqualBars) {
                     return false;
                 }
-            } else if (currentHighPrice.isGreaterThan(comparisonHighPrice)) {
+            } else if (currentPrice.isLessThan(comparisonPrice)) {
+                return false;
+            } else {
                 lowerBarsCount++;
                 if (lowerBarsCount == surroundingLowerBars) {
                     return true;
                 }
-            } else {
-                break;
             }
         }
-        return false;
+
+        return lowerBarsCount == surroundingLowerBars;
     }
 
-    /**
-     * Calculates the most recent swing high value up to the specified index.
-     *
-     * @param index The bar index up to which the calculation is done.
-     * @return The value of the most recent swing high if it exists; NaN otherwise.
-     */
-    @Override
-    protected Num calculate(int index) {
-        if (index < surroundingLowerBars) {
-            return NaN;
-        }
+    private boolean checkFollowingBars(int index, Num currentPrice) {
+        int lowerBarsCount = 0;
+        int equalBarsCount = 0;
 
-        for (int i = index; i >= getBarSeries().getBeginIndex(); i--) {
-            if (validateBars(i, -1) && validateBars(i, 1)) {
-                return getBarSeries().getBar(i).getHighPrice();
+        for (int i = index + 1; i < index + surroundingLowerBars + allowedEqualBars + 1
+                && i < getBarSeries().getBarCount(); i++) {
+            Num comparisonPrice = this.indicator.getValue(i);
+
+            if (currentPrice.isEqual(comparisonPrice)) {
+                equalBarsCount++;
+                if (equalBarsCount > allowedEqualBars) {
+                    return false;
+                }
+            } else if (currentPrice.isLessThan(comparisonPrice)) {
+                return false;
+            } else {
+                lowerBarsCount++;
+                if (lowerBarsCount == surroundingLowerBars) {
+                    return true;
+                }
             }
         }
 
+        return lowerBarsCount == surroundingLowerBars;
+    }
+
+    @Override
+    protected Num calculate(int index) {
+        for (int i = index; i >= getBarSeries().getBeginIndex(); i--) {
+            if (isSwingHigh(i)) {
+                return this.indicator.getValue(i);
+            }
+        }
         return NaN;
     }
 
-    /**
-     * Returns the number of unstable bars as defined by the surroundingBars
-     * parameter.
-     *
-     * @return The number of unstable bars.
-     */
-    @Override
     public int getUnstableBars() {
         return surroundingLowerBars;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- * <p>
+ *
  * Copyright (c) 2017-2023 Ta4j Organization & respective
  * authors (see AUTHORS)
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -44,22 +44,23 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
      * Constructs a RecentSwingLowIndicator
      *
      * @param indicator           The Indicator to be analyzed.
-     * @param precedingHigherBars For a bar to be identified as a swing low, it
-     *                            must have a lower low than this number of bars
-     *                            both immediately preceding
-     * @param followingHigherBars For a bar to be identified as a swing low, it
-     *                            must have a lower low than this number of bars
-     *                            both immediately following
+     * @param precedingHigherBars For a bar to be identified as a swing low, it must
+     *                            have a lower low than this number of bars
+     *                            immediately preceding it.
+     * @param followingHigherBars For a bar to be identified as a swing low, it must
+     *                            have a lower low than this number of bars
+     *                            immediately following it.
      * @param allowedEqualBars    For a looser definition of swing low, instead of
      *                            requiring the surrounding bars to be strictly
-     *                            higher lows we allow this number of equal lows
-     *                            to either side (i.e. flat-ish valley)
-     * @throws IllegalArgumentException if precedingHigherBars is less than or
-     *                                  equal to 0.
+     *                            higher lows we allow this number of equal lows to
+     *                            either side (i.e. flat-ish valley)
+     * @throws IllegalArgumentException if precedingHigherBars is less than or equal
+     *                                  to 0.
      * @throws IllegalArgumentException if followingHigherBars is less 0.
      * @throws IllegalArgumentException if allowedEqualBars is less than 0.
      */
-    public RecentSwingLowIndicator(Indicator<Num> indicator, int precedingHigherBars, int followingHigherBars, int allowedEqualBars) {
+    public RecentSwingLowIndicator(Indicator<Num> indicator, int precedingHigherBars, int followingHigherBars,
+            int allowedEqualBars) {
         super(indicator);
 
         if (precedingHigherBars <= 0) {
@@ -102,10 +103,6 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
     }
 
     private boolean isSwingLow(int index) {
-        if (index < getUnstableBars() || index >= getBarSeries().getBarCount()) {
-            return false;
-        }
-
         Num currentPrice = this.indicator.getValue(index);
 
         // Check bars before
@@ -146,7 +143,8 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
         int higherBarsCount = 0;
         int equalBarsCount = 0;
 
-        for (int i = index + 1; i < index + followingHigherBars + allowedEqualBars + 1 && i < getBarSeries().getBarCount(); i++) {
+        for (int i = index + 1; i < index + followingHigherBars + allowedEqualBars + 1
+                && i < getBarSeries().getBarCount(); i++) {
             Num comparisonPrice = this.indicator.getValue(i);
 
             if (currentPrice.isEqual(comparisonPrice)) {
@@ -169,6 +167,10 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
 
     @Override
     protected Num calculate(int index) {
+        if (index < getUnstableBars() || index >= getBarSeries().getBarCount()) {
+            return NaN;
+        }
+
         for (int i = index; i >= getBarSeries().getBeginIndex(); i--) {
             if (isSwingLow(i)) {
                 return this.indicator.getValue(i);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- *
+ * <p>
  * Copyright (c) 2017-2023 Ta4j Organization & respective
  * authors (see AUTHORS)
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -35,36 +35,44 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class RecentSwingLowIndicator extends CachedIndicator<Num> {
 
-    private final int surroundingHigherBars;
+    private final int precedingHigherBars;
+    private final int followingHigherBars;
     private final int allowedEqualBars;
     Indicator<Num> indicator;
 
     /**
      * Constructs a RecentSwingLowIndicator
      *
-     * @param indicator             The Indicator to be analyzed.
-     * @param surroundingHigherBars For a bar to be identified as a swing low, it
-     *                              must have a lower low than this number of bars
-     *                              both immediately preceding and immediately
-     *                              following
-     * @param allowedEqualBars      For a looser definition of swing low, instead of
-     *                              requiring the surrounding bars to be strictly
-     *                              higher lows we allow this number of equal lows
-     *                              to either side (i.e. flat-ish valley)
-     * @throws IllegalArgumentException if surroundingLowerBars is less than or
+     * @param indicator           The Indicator to be analyzed.
+     * @param precedingHigherBars For a bar to be identified as a swing low, it
+     *                            must have a lower low than this number of bars
+     *                            both immediately preceding
+     * @param followingHigherBars For a bar to be identified as a swing low, it
+     *                            must have a lower low than this number of bars
+     *                            both immediately following
+     * @param allowedEqualBars    For a looser definition of swing low, instead of
+     *                            requiring the surrounding bars to be strictly
+     *                            higher lows we allow this number of equal lows
+     *                            to either side (i.e. flat-ish valley)
+     * @throws IllegalArgumentException if precedingHigherBars is less than or
      *                                  equal to 0.
+     * @throws IllegalArgumentException if followingHigherBars is less 0.
      * @throws IllegalArgumentException if allowedEqualBars is less than 0.
      */
-    public RecentSwingLowIndicator(Indicator<Num> indicator, int surroundingHigherBars, int allowedEqualBars) {
+    public RecentSwingLowIndicator(Indicator<Num> indicator, int precedingHigherBars, int followingHigherBars, int allowedEqualBars) {
         super(indicator);
 
-        if (surroundingHigherBars <= 0) {
-            throw new IllegalArgumentException("surroundingHigherBars must be greater than 0");
+        if (precedingHigherBars <= 0) {
+            throw new IllegalArgumentException("precedingHigherBars must be greater than 0");
+        }
+        if (followingHigherBars < 0) {
+            throw new IllegalArgumentException("followingHigherBars must be 0 or greater");
         }
         if (allowedEqualBars < 0) {
             throw new IllegalArgumentException("allowedEqualBars must be 0 or greater");
         }
-        this.surroundingHigherBars = surroundingHigherBars;
+        this.precedingHigherBars = precedingHigherBars;
+        this.followingHigherBars = followingHigherBars;
         this.allowedEqualBars = allowedEqualBars;
         this.indicator = indicator;
     }
@@ -79,22 +87,22 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
      *                              must have higher lows to identify a swing low.
      */
     public RecentSwingLowIndicator(BarSeries series, int surroundingHigherBars) {
-        this(new LowPriceIndicator(series), surroundingHigherBars, 0);
+        this(new LowPriceIndicator(series), surroundingHigherBars, surroundingHigherBars, 0);
     }
 
     /**
      * Constructs a RecentSwingLowIndicator with the specified BarSeries (and
      * defaulting to use LowPriceIndicator), a default surrounding higher bars count
-     * of 2, and a default allowed equal bars of 0
+     * of 3, and a default allowed equal bars of 0
      *
      * @param series The BarSeries to be analyzed.
      */
     public RecentSwingLowIndicator(BarSeries series) {
-        this(new LowPriceIndicator(series), 2, 0);
+        this(new LowPriceIndicator(series), 3, 0, 0);
     }
 
     private boolean isSwingLow(int index) {
-        if (index < surroundingHigherBars || index >= getBarSeries().getBarCount()) {
+        if (index < getUnstableBars() || index >= getBarSeries().getBarCount()) {
             return false;
         }
 
@@ -113,7 +121,7 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
         int higherBarsCount = 0;
         int equalBarsCount = 0;
 
-        for (int i = index - 1; i >= index - surroundingHigherBars - allowedEqualBars && i >= 0; i--) {
+        for (int i = index - 1; i >= index - precedingHigherBars - allowedEqualBars && i >= 0; i--) {
             Num comparisonPrice = this.indicator.getValue(i);
 
             if (currentPrice.isEqual(comparisonPrice)) {
@@ -125,21 +133,20 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
                 return false;
             } else {
                 higherBarsCount++;
-                if (higherBarsCount == surroundingHigherBars) {
+                if (higherBarsCount == precedingHigherBars) {
                     return true;
                 }
             }
         }
 
-        return higherBarsCount == surroundingHigherBars;
+        return higherBarsCount == precedingHigherBars;
     }
 
     private boolean checkFollowingBars(int index, Num currentPrice) {
         int higherBarsCount = 0;
         int equalBarsCount = 0;
 
-        for (int i = index + 1; i < index + surroundingHigherBars + allowedEqualBars + 1
-                && i < getBarSeries().getBarCount(); i++) {
+        for (int i = index + 1; i < index + followingHigherBars + allowedEqualBars + 1 && i < getBarSeries().getBarCount(); i++) {
             Num comparisonPrice = this.indicator.getValue(i);
 
             if (currentPrice.isEqual(comparisonPrice)) {
@@ -151,13 +158,13 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
                 return false;
             } else {
                 higherBarsCount++;
-                if (higherBarsCount == surroundingHigherBars) {
+                if (higherBarsCount == followingHigherBars) {
                     return true;
                 }
             }
         }
 
-        return higherBarsCount == surroundingHigherBars;
+        return higherBarsCount == followingHigherBars;
     }
 
     @Override
@@ -178,6 +185,6 @@ public class RecentSwingLowIndicator extends CachedIndicator<Num> {
      */
     @Override
     public int getUnstableBars() {
-        return surroundingHigherBars;
+        return precedingHigherBars + followingHigherBars;
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
@@ -23,28 +23,24 @@
  */
 package org.ta4j.core.indicators;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
+import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
+import org.ta4j.core.mocks.MockBar;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
-
-import org.ta4j.core.Bar;
-
 import static org.ta4j.core.TestUtils.assertNumEquals;
-
-import org.ta4j.core.mocks.MockBar;
 
 public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
@@ -82,13 +78,13 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_Using2SurroundingBarsAnd2EqualBars_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2,
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2, 2,
                 2);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(1));
-        assertNumEquals(12, swingHighIndicator.getValue(2));
-        assertNumEquals(12, swingHighIndicator.getValue(3));
+        assertNumEquals(NaN.NaN, swingHighIndicator.getValue(2));
+        assertNumEquals(NaN.NaN, swingHighIndicator.getValue(3));
         assertNumEquals(12, swingHighIndicator.getValue(4));
         assertNumEquals(12, swingHighIndicator.getValue(5));
         assertNumEquals(12, swingHighIndicator.getValue(6));
@@ -108,13 +104,13 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_Using2SurroundingBarsAnd1EqualBars_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2,
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2, 2,
                 1);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(1));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(2));
-        assertNumEquals(12, swingHighIndicator.getValue(3));
+        assertNumEquals(NaN.NaN, swingHighIndicator.getValue(3));
         assertNumEquals(12, swingHighIndicator.getValue(4));
         assertNumEquals(12, swingHighIndicator.getValue(5));
         assertNumEquals(12, swingHighIndicator.getValue(6));
@@ -162,12 +158,12 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
         int surroundingBars = 2;
         RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, surroundingBars);
 
-        assertEquals(surroundingBars, swingHighIndicator.getUnstableBars());
+        assertEquals(surroundingBars * 2, swingHighIndicator.getUnstableBars());
     }
 
     @Test
     public void testCalculate_Using1SurroundingBar_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1,
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1, 1,
                 2);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
@@ -188,20 +184,20 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
     public void testCalculate_OnMovingBarSeries_ReturnsValue() {
         BarSeries movingSeries = new MockBarSeries(numFunction, 1); // movingSeries: [1]
         ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(closePrice, 1, 0);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(closePrice, 1, 1, 0);
 
         movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 2, numFunction)); // movingSeries:
-                                                                                                              // [1, 2]
+        // [1, 2]
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
 
         movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 3, numFunction)); // movingSeries:
-                                                                                                              // [1, 2,
-                                                                                                              // 3]
+        // [1, 2,
+        // 3]
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
 
         movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 2, numFunction)); // movingSeries:
-                                                                                                              // [1, 2,
-                                                                                                              // 3, 2]
+        // [1, 2,
+        // 3, 2]
         assertNumEquals(3, swingHighIndicator.getValue(movingSeries.getEndIndex()));
     }
 
@@ -212,7 +208,7 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1,
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1, 1,
                 -1);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
@@ -25,19 +25,25 @@ package org.ta4j.core.indicators;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 import java.util.function.Function;
+
 import static org.junit.Assert.assertEquals;
 
 import org.ta4j.core.Bar;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
+
 import org.ta4j.core.mocks.MockBar;
 
 public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -76,7 +82,8 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_Using2SurroundingBarsAnd2EqualBars_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 2, 2);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2,
+                2);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(1));
@@ -101,7 +108,8 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_Using2SurroundingBarsAnd1EqualBars_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 2, 1);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 2,
+                1);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(1));
@@ -159,7 +167,8 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_Using1SurroundingBar_ReturnsValue() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 1, 2);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1,
+                2);
 
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(0));
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(1));
@@ -175,6 +184,27 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
         assertNumEquals(14, swingHighIndicator.getValue(11));
     }
 
+    @Test
+    public void testCalculate_OnMovingBarSeries_ReturnsValue() {
+        BarSeries movingSeries = new MockBarSeries(numFunction, 1); // movingSeries: [1]
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(closePrice, 1, 0);
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 2, numFunction)); // movingSeries:
+                                                                                                              // [1, 2]
+        assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 3, numFunction)); // movingSeries:
+                                                                                                              // [1, 2,
+                                                                                                              // 3]
+        assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 2, numFunction)); // movingSeries:
+                                                                                                              // [1, 2,
+                                                                                                              // 3, 2]
+        assertNumEquals(3, swingHighIndicator.getValue(movingSeries.getEndIndex()));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_SurroundingBarsZero() {
         RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 0);
@@ -182,6 +212,7 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
-        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 1, -1);
+        RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1,
+                -1);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -221,7 +221,8 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, 1, -1);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, 1,
+                -1);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -86,7 +86,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
         int surroundingBars = 2;
         RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, surroundingBars);
 
-        assertEquals(surroundingBars, swingLowIndicator.getUnstableBars());
+        assertEquals(surroundingBars * 2, swingLowIndicator.getUnstableBars());
     }
 
     @Test
@@ -99,10 +99,10 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void testCalculate_With2SurroundingBarsAnd2AllowedEqualBars_ReturnsValue() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 2);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 2, 2);
 
-        assertNumEquals(8, swingLowIndicator.getValue(2));
-        assertNumEquals(8, swingLowIndicator.getValue(3));
+        assertNumEquals(NaN.NaN, swingLowIndicator.getValue(2));
+        assertNumEquals(NaN.NaN, swingLowIndicator.getValue(3));
         assertNumEquals(8, swingLowIndicator.getValue(4));
         assertNumEquals(8, swingLowIndicator.getValue(5));
         assertNumEquals(8, swingLowIndicator.getValue(6));
@@ -123,10 +123,10 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void testCalculate_With2SurroundingBarsAnd1AllowedEqualBars_ReturnsValue() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 1);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 2, 3);
 
         assertNumEquals(NaN.NaN, swingLowIndicator.getValue(2));
-        assertNumEquals(8, swingLowIndicator.getValue(3));
+        assertNumEquals(NaN.NaN, swingLowIndicator.getValue(3));
         assertNumEquals(8, swingLowIndicator.getValue(4));
         assertNumEquals(8, swingLowIndicator.getValue(5));
         assertNumEquals(8, swingLowIndicator.getValue(6));
@@ -135,14 +135,14 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
         assertNumEquals(6, swingLowIndicator.getValue(9));
         assertNumEquals(6, swingLowIndicator.getValue(10));
         assertNumEquals(6, swingLowIndicator.getValue(11));
-        assertNumEquals(6, swingLowIndicator.getValue(12));
-        assertNumEquals(6, swingLowIndicator.getValue(13));
-        assertNumEquals(6, swingLowIndicator.getValue(14));
-        assertNumEquals(6, swingLowIndicator.getValue(15));
-        assertNumEquals(6, swingLowIndicator.getValue(16));
-        assertNumEquals(6, swingLowIndicator.getValue(17));
-        assertNumEquals(6, swingLowIndicator.getValue(18));
-        assertNumEquals(6, swingLowIndicator.getValue(19));
+        assertNumEquals(5, swingLowIndicator.getValue(12));
+        assertNumEquals(5, swingLowIndicator.getValue(13));
+        assertNumEquals(5, swingLowIndicator.getValue(14));
+        assertNumEquals(5, swingLowIndicator.getValue(15));
+        assertNumEquals(5, swingLowIndicator.getValue(16));
+        assertNumEquals(5, swingLowIndicator.getValue(17));
+        assertNumEquals(5, swingLowIndicator.getValue(18));
+        assertNumEquals(5, swingLowIndicator.getValue(19));
     }
 
     @Test
@@ -197,7 +197,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
     public void testCalculate_OnMovingBarSeries_ReturnsValue() {
         BarSeries movingSeries = new MockBarSeries(numFunction, 10); // movingSeries: [10]
         ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(closePrice, 1, 0);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(closePrice, 1, 1, 0);
 
         movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 8, numFunction)); // movingSeries:
                                                                                                               // [10, 8]
@@ -221,7 +221,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, -1);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, 1, -1);
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -25,19 +25,25 @@ package org.ta4j.core.indicators;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.LowPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeries;
 import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 
 import java.util.function.Function;
+
 import static org.junit.Assert.assertEquals;
 
 import org.ta4j.core.Bar;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
+
 import org.ta4j.core.mocks.MockBar;
 
 public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
@@ -93,7 +99,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void testCalculate_With2SurroundingBarsAnd2AllowedEqualBars_ReturnsValue() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, 2, 2);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 2);
 
         assertNumEquals(8, swingLowIndicator.getValue(2));
         assertNumEquals(8, swingLowIndicator.getValue(3));
@@ -117,7 +123,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void testCalculate_With2SurroundingBarsAnd1AllowedEqualBars_ReturnsValue() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, 2, 1);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 2, 1);
 
         assertNumEquals(NaN.NaN, swingLowIndicator.getValue(2));
         assertNumEquals(8, swingLowIndicator.getValue(3));
@@ -187,6 +193,27 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
         assertNumEquals(5, swingLowIndicator.getValue(19));
     }
 
+    @Test
+    public void testCalculate_OnMovingBarSeries_ReturnsValue() {
+        BarSeries movingSeries = new MockBarSeries(numFunction, 10); // movingSeries: [10]
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(closePrice, 1, 0);
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 8, numFunction)); // movingSeries:
+                                                                                                              // [10, 8]
+        assertNumEquals(NaN.NaN, swingLowIndicator.getValue(movingSeries.getEndIndex()));
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 5, numFunction)); // movingSeries:
+                                                                                                              // [10, 8,
+                                                                                                              // 5]
+        assertNumEquals(NaN.NaN, swingLowIndicator.getValue(movingSeries.getEndIndex()));
+
+        movingSeries.addBar(new MockBar(movingSeries.getLastBar().getEndTime().plusDays(1), 7, numFunction)); // movingSeries:
+                                                                                                              // [10, 8,
+                                                                                                              // 5, 7]
+        assertNumEquals(5, swingLowIndicator.getValue(movingSeries.getEndIndex()));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_SurroundingBarsZero() {
         RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, 0);
@@ -194,7 +221,7 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
-        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, 1, -1);
+        RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, -1);
     }
 
 }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Fixed look ahead bias in **RecentSwingHighIndicator** and **RecentSwingLowIndicator**


- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
