### PR TITLE
reused tr in constructor instead of creating new instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Implemented inner cache for **SMAIndicator**
 - **BooleanTransformIndicator** remove enum constraint in favor of more flexible `Predicate`
 - **EnterAndHoldReturnCriterion** replaced by `EnterAndHoldCriterion` to calculate the "enter and hold"-strategy of any criteria.
+- **ATRIndicator** re-use tr by passing it as a constructor param when initializing averageTrueRangeIndicator
 
 ### Removed/Deprecated
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -54,7 +54,7 @@ public class ATRIndicator extends AbstractIndicator<Num> {
     public ATRIndicator(TRIndicator tr, int barCount) {
         super(tr.getBarSeries());
         this.trIndicator = tr;
-        this.averageTrueRangeIndicator = new MMAIndicator(new TRIndicator(tr.getBarSeries()), barCount);
+        this.averageTrueRangeIndicator = new MMAIndicator(tr, barCount);
     }
 
     @Override


### PR DESCRIPTION
Fixes #[Any reason tr isn't being passed to MMA instead of creating a new instance?](https://github.com/ta4j/ta4j/commit/594c4e464418e162c1b1dcdd1bbed3f218c740ee#r146073872)

Changes proposed in this pull request:
- re-use `tr `by passing it as a constructor param when initializing `averageTrueRangeIndicator`

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
