### PR TITLE
feature/update-dependencies-9-18-2024

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
-        java-version: '11'
+        distribution: 'temurin'
+        java-version: '21'
     - name: Build with Maven
       run: xvfb-run mvn -B license:check

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'zulu'
+          java-version: 21
+          distribution: 'temurin'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '21'
       - name: Build with Maven
         run: xvfb-run mvn -B test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
-        java-version: '11'
+        distribution: 'temurin'
+        java-version: '21'
     - name: Build with Maven
       run: xvfb-run mvn -B formatter:validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ## 0.18
 
 ### Breaking
-
+- Updated project Java JDK from 11 > 21
+- Updated Github workflows to use JDK 21
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 ### Changed
 - Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
-
+- Updated **logback-classic** 1.4.12 > 1.5.6 to resolve [CVE-2023-6481](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
 
 ### Removed/Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Changed
+- Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
 
 
 ### Removed/Deprecated

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2023 Ta4j Organization & respective
+Copyright (c) 2017-2024 Ta4j Organization & respective
 authors (see AUTHORS)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,14 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <version>4.5</version>
                 <configuration>
-                    <header>LICENSE</header>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>LICENSE</header>
+                            <includes>
+                                <include>**/*.java</include>
+                            </includes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.4.12</version>
+				<version>1.5.6</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
+                    <release>21</release>
                     <source>21</source>
                     <target>21</target>
-                    <release>21</release>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,211 +1,214 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.ta4j</groupId>
-	<artifactId>ta4j-parent</artifactId>
-	<version>0.18-SNAPSHOT</version>
-	<packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.ta4j</groupId>
+    <artifactId>ta4j-parent</artifactId>
+    <version>0.18-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-	<name>Ta4j Parent</name>
-	<description>ta4j is a Java library providing a simple API for technical analysis.</description>
-	<url>http://github.com/ta4j/ta4j</url>
-	<inceptionYear>2014</inceptionYear>
+    <name>Ta4j Parent</name>
+    <description>ta4j is a Java library providing a simple API for technical analysis.</description>
+    <url>http://github.com/ta4j/ta4j</url>
+    <inceptionYear>2014</inceptionYear>
 
-	<developers>
-		<developer>
-			<name>Marc de Verdelhan</name>
-		</developer>
-		<developer>
-			<name>Simon-Justus Wimmer</name>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>mdeverdelhan</id>
+            <name>Marc de Verdelhan</name>
+        </developer>
+        <developer>
+            <id>team172011</id>
+            <name>Simon-Justus Wimmer</name>
+        </developer>
+    </developers>
 
-	<licenses>
-		<license>
-			<name>MIT License</name>
-			<comments>All source code is under the MIT license.</comments>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <comments>All source code is under the MIT license.</comments>
+        </license>
+    </licenses>
 
-	<issueManagement>
-		<system>GitHub</system>
-		<url>http://github.com/ta4j/ta4j/issues</url>
-	</issueManagement>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>http://github.com/ta4j/ta4j/issues</url>
+    </issueManagement>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>sonatype-nexus-snapshots</id>
-			<name>Sonatype Nexus snapshot repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>sonatype-nexus-staging</id>
-			<name>Sonatype Nexus release repository</name>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Sonatype Nexus release repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
-	<ciManagement>
-		<url>http://travis-ci.org/ta4j/ta4j</url>
-	</ciManagement>
+    <ciManagement>
+        <url>http://travis-ci.org/ta4j/ta4j</url>
+    </ciManagement>
 
-	<scm>
-		<connection>scm:git:git://github.com/ta4j/ta4j.git</connection>
-		<developerConnection>scm:git:git@github.com:ta4j/ta4j.git</developerConnection>
-		<url>http://github.com/ta4j/ta4j</url>
-		<tag>0.17</tag>
-	</scm>
+    <scm>
+        <connection>scm:git:git://github.com/ta4j/ta4j.git</connection>
+        <developerConnection>scm:git:git@github.com:ta4j/ta4j.git</developerConnection>
+        <url>http://github.com/ta4j/ta4j</url>
+        <tag>0.17</tag>
+    </scm>
 
-	<modules>
-		<module>ta4j-core</module>
-		<module>ta4j-examples</module>
-	</modules>
+    <modules>
+        <module>ta4j-core</module>
+        <module>ta4j-examples</module>
+    </modules>
 
-	<properties>
-		<!-- Encoding -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-	</properties>
+    <properties>
+        <!-- Encoding -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>ch.qos.logback</groupId>
-				<artifactId>logback-classic</artifactId>
-				<version>1.5.6</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.5.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<profiles>
+    <profiles>
 
-		<!-- Only when performing a release (i.e. not for snapshots) -->
-		<profile>
-			<id>sonatype-oss-release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.7.0</version>
-						<extensions>true</extensions>
-						<configuration>
-							<!-- The Base URL of Nexus instance where we want to stage -->
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<!-- The server "id" element from settings to use authentication from -->
-							<serverId>sonatype-nexus-staging</serverId>
-						</configuration>
-					</plugin>
+        <!-- Only when performing a release (i.e. not for snapshots) -->
+        <profile>
+            <id>sonatype-oss-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!-- The Base URL of Nexus instance where we want to stage -->
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <!-- The server "id" element from settings to use authentication from -->
+                            <serverId>sonatype-nexus-staging</serverId>
+                        </configuration>
+                    </plugin>
 
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.8.0</version>
-						<configuration>
-							<doclint>none</doclint>
-						</configuration>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <configuration>
+                            <doclint>none</doclint>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-					<!-- Artifact signing -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.2.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+                    <!-- Artifact signing -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-	</profiles>
+    </profiles>
 
-	<build>
-		<plugins>
+    <build>
+        <plugins>
 
-			<!-- Build source and target -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
-				<configuration>
-					<source>11</source>
-					<target>11</target>
-					<release>11</release>
-					<showDeprecation>true</showDeprecation>
-					<showWarnings>true</showWarnings>
-				</configuration>
-			</plugin>
-			<!-- Package sources -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <!-- Build source and target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <release>11</release>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+            <!-- Package sources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<!-- License headers -->
-			<plugin>
-				<groupId>com.mycila</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>4.5</version>
-				<configuration>
-					<header>LICENSE</header>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
-				</configuration>
-			</plugin>
+            <!-- License headers -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>4.5</version>
+                <configuration>
+                    <header>LICENSE</header>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
 
-			<!-- Source formatter -->
-			<plugin>
-				<groupId>net.revelc.code.formatter</groupId>
-				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.10.0</version>
-					<configuration>
-						<configFile>${project.basedir}/code-formatter.xml</configFile>
-					</configuration>
-			</plugin>
+            <!-- Source formatter -->
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>2.10.0</version>
+                <configuration>
+                    <configFile>${project.basedir}/code-formatter.xml</configFile>
+                </configuration>
+            </plugin>
 
-			<!-- Releases -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>3.1.1</version>
-				<configuration>
-					<tagNameFormat>@{project.version}</tagNameFormat>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.shared</groupId>
-						<artifactId>maven-invoker</artifactId>
-						<version>3.3.0</version>
-					</dependency>
-				</dependencies>
-			</plugin>
+            <!-- Releases -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.shared</groupId>
+                        <artifactId>maven-invoker</artifactId>
+                        <version>3.3.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
 
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.13</version>
+						<version>1.7.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<!-- The Base URL of Nexus instance where we want to stage -->
@@ -99,7 +99,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>3.8.0</version>
 						<configuration>
 							<doclint>none</doclint>
 						</configuration>
@@ -117,7 +117,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
+						<version>3.2.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -141,7 +141,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.13.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>
@@ -154,7 +154,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.2.1</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -169,7 +169,7 @@
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
-				<version>3.0</version>
+				<version>4.5</version>
 				<configuration>
 					<header>LICENSE</header>
 					<includes>
@@ -192,7 +192,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>3.1.1</version>
 				<configuration>
 					<tagNameFormat>@{project.version}</tagNameFormat>
 				</configuration>
@@ -200,7 +200,7 @@
 					<dependency>
 						<groupId>org.apache.maven.shared</groupId>
 						<artifactId>maven-invoker</artifactId>
-						<version>2.2</version>
+						<version>3.3.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                    <release>11</release>
+                    <source>21</source>
+                    <target>21</target>
+                    <release>21</release>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.10.0</version>
+                <version>2.24.1</version>
                 <configuration>
                     <configFile>${project.basedir}/code-formatter.xml</configFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <name>Ta4j Parent</name>
     <description>ta4j is a Java library providing a simple API for technical analysis.</description>
-    <url>http://github.com/ta4j/ta4j</url>
+    <url>https://github.com/ta4j/ta4j</url>
     <inceptionYear>2014</inceptionYear>
 
     <developers>
@@ -31,7 +31,7 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>http://github.com/ta4j/ta4j/issues</url>
+        <url>https://github.com/ta4j/ta4j/issues</url>
     </issueManagement>
 
     <distributionManagement>
@@ -48,13 +48,13 @@
     </distributionManagement>
 
     <ciManagement>
-        <url>http://travis-ci.org/ta4j/ta4j</url>
+        <url>https://travis-ci.org/ta4j/ta4j</url>
     </ciManagement>
 
     <scm>
         <connection>scm:git:git://github.com/ta4j/ta4j.git</connection>
         <developerConnection>scm:git:git@github.com:ta4j/ta4j.git</developerConnection>
-        <url>http://github.com/ta4j/ta4j</url>
+        <url>https://github.com/ta4j/ta4j</url>
         <tag>0.17</tag>
     </scm>
 

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.13</version>
         </dependency>
 
         <dependency>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.2.3</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>7.0.0</version>
                 <executions>
                     <execution>
                         <id>default-bnd-process</id>

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>7.0.0</version>
+                <version>6.4.0</version>
                 <executions>
                     <execution>
                         <id>default-bnd-process</id>

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>6.4.0</version>
+                <version>7.0.0</version>
                 <executions>
                     <execution>
                         <id>default-bnd-process</id>

--- a/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * An analysis criterion. It can be used to:
- * 
+ *
  * <ul>
  * <li>analyze the performance of a {@link Strategy strategy}
  * <li>compare several {@link Strategy strategies} together

--- a/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/AnalysisCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -140,7 +140,7 @@ public interface Bar extends Serializable {
     /**
      * Updates the close price at the end of the bar period. The open, high and low
      * prices are also updated as needed.
-     * 
+     *
      * @param price       the actual price per asset
      * @param numFunction the numbers precision
      */
@@ -151,7 +151,7 @@ public interface Bar extends Serializable {
     /**
      * Updates the close price at the end of the bar period. The open, high and low
      * prices are also updated as needed.
-     * 
+     *
      * @param price       the actual price per asset
      * @param numFunction the numbers precision
      */
@@ -162,7 +162,7 @@ public interface Bar extends Serializable {
     /**
      * Updates the close price at the end of the bar period. The open, high and low
      * prices are also updated as needed.
-     * 
+     *
      * @param price the actual price per asset
      */
     void addPrice(Num price);

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -36,9 +36,9 @@ import org.ta4j.core.num.Num;
 /**
  * A {@code BarSeries} is a sequence of {@link Bar bars} separated by a
  * predefined period (e.g. 15 minutes, 1 day, etc.).
- * 
+ *
  * Notably, it can be:
- * 
+ *
  * <ul>
  * <li>the base of {@link Indicator indicator} calculations
  * <li>constrained between beginning and ending indices (e.g. for some
@@ -102,7 +102,7 @@ public interface BarSeries extends Serializable {
 
     /**
      * Gets the bar from {@link #getBarData()} with index {@code i}.
-     * 
+     *
      * <p>
      * The given {@code i} can return the same bar within the first range of indices
      * due to {@link #setMaximumBarCount(int)}, for example: If you fill a BarSeries
@@ -110,7 +110,7 @@ public interface BarSeries extends Serializable {
      * 20 bars will be removed from the BarSeries. The indices going further from 0
      * to 29 remain but return the same bar from 0 to 20. The remaining 9 bars are
      * returned from index 21.
-     * 
+     *
      * @param i the index
      * @return the bar at the i-th position
      */
@@ -150,7 +150,7 @@ public interface BarSeries extends Serializable {
      * <li>a shortened bar list if a {@code maximumBarCount} has been set.
      * <li>an extended bar list if it is a constrained bar series.
      * </ul>
-     * 
+     *
      * <p>
      * <b>Warning:</b> This method should be used carefully!
      *
@@ -196,7 +196,7 @@ public interface BarSeries extends Serializable {
      * the maximum bar count, then the FIRST bar in the series is automatically
      * removed, ensuring that the maximum bar count is not exceeded. The indices of
      * the bar series do not change.
-     * 
+     *
      * @param maximumBarCount the maximum bar count
      */
     void setMaximumBarCount(int maximumBarCount);
@@ -245,7 +245,7 @@ public interface BarSeries extends Serializable {
 
     /**
      * Adds the {@code bar} at the end of the series.
-     * 
+     *
      * <p>
      * The {@code beginIndex} is set to {@code 0} if not already initialized.<br>
      * The {@code endIndex} is set to {@code 0} if not already initialized, or

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Indicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Indicator over a {@link BarSeries bar series}.
- * 
+ *
  * <p>
  * Returns a value of type <b>T</b> for each index of the bar series.
  *
@@ -47,7 +47,7 @@ public interface Indicator<T> {
     /**
      * Returns the number of bars up to which {@code this} Indicator calculates
      * wrong values.
-     * 
+     *
      * @return unstable bars
      */
     int getUnstableBars();

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Position.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Position.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Rule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Rule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Rule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Strategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/Trade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Trade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/Trade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Trade.java
@@ -32,7 +32,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * A {@code Trade} is defined by:
- * 
+ *
  * <ul>
  * <li>the index (in the {@link BarSeries bar series}) on which the trade is
  * executed
@@ -40,7 +40,7 @@ import org.ta4j.core.num.Num;
  * <li>a pricePerAsset (optional)
  * <li>a trade amount (optional)
  * </ul>
- * 
+ *
  * A {@link Position position} is a pair of complementary trades.
  */
 public class Trade implements Serializable {

--- a/ta4j-core/src/main/java/org/ta4j/core/Trade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Trade.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradingRecord.java
@@ -35,7 +35,7 @@ import org.ta4j.core.num.Num;
 /**
  * A {@code TradingRecord} holds the full history/record of a trading session
  * when running a {@link Strategy strategy}. It can be used to:
- * 
+ *
  * <ul>
  * <li>analyze the performance of a {@link Strategy strategy}
  * <li>check whether some {@link Rule rules} are satisfied (while running a

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarAggregator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BarSeriesAggregator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/BaseBarSeriesAggregator.java
@@ -39,7 +39,7 @@ public class BaseBarSeriesAggregator implements BarSeriesAggregator {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barAggregator the {@link BarAggregator}
      */
     public BaseBarSeriesAggregator(BarAggregator barAggregator) {

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/CashFlow.java
@@ -237,7 +237,7 @@ public class CashFlow implements Indicator<Num> {
 
     /**
      * Pads {@link #values} with its last value up until {@code endIndex}.
-     * 
+     *
      * @param endIndex the end index
      */
     private void fillToTheEnd(int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/Returns.java
@@ -218,7 +218,7 @@ public class Returns implements Indicator<Num> {
 
     /**
      * Pads {@link #values} with zeros up until {@code endIndex}.
-     * 
+     *
      * @param endIndex the end index
      */
     private void fillToTheEnd(int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/CostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/CostModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/CostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/CostModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/FixedTransactionCostModel.java
@@ -40,7 +40,7 @@ public class FixedTransactionCostModel implements CostModel {
      * Constructor for a fixed fee trading cost model.
      *
      * <pre>
-     * Cost of opened {@link Position position}: (fixedFeePerTrade * 1) 
+     * Cost of opened {@link Position position}: (fixedFeePerTrade * 1)
      * Cost of closed {@link Position position}: (fixedFeePerTrade * 2)
      * </pre>
      *

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearTransactionCostModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/ZeroCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/ZeroCostModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/ZeroCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/ZeroCostModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
@@ -64,7 +64,7 @@ public class BarSeriesManager {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries           the bar series to be managed
      * @param tradeExecutionModel the trade execution model to use
      */
@@ -74,7 +74,7 @@ public class BarSeriesManager {
 
     /**
      * Constructor with {@link #tradeExecutionModel} = {@link TradeOnNextOpenModel}.
-     * 
+     *
      * @param barSeries            the bar series to be managed
      * @param transactionCostModel the cost model for transactions of the asset
      * @param holdingCostModel     the cost model for holding the asset (e.g.
@@ -89,7 +89,7 @@ public class BarSeriesManager {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries            the bar series to be managed
      * @param transactionCostModel the cost model for transactions of the asset
      * @param holdingCostModel     the cost model for holding asset (e.g. borrowing)

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
@@ -37,7 +37,7 @@ public interface TradeExecutionModel {
 
     /**
      * Executes a trade in the given {@code tradingRecord}.
-     * 
+     *
      * @param index         the trade index from {@code barSeries}
      * @param tradingRecord the trading record to place the trade
      * @param barSeries     the bar series

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnCurrentCloseModel.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
  * An execution model for {@link BarSeriesManager} objects.
  *
  * Executes trades on the current bar being considered using the closing price.
- * 
+ *
  * This is used for strategies that explicitly trade just before the bar closes
  * at index `t`, in order to execute new or close existing trades as close as
  * possible to the closing price.

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeOnNextOpenModel.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
  * An execution model for {@link BarSeriesManager} objects.
  *
  * Executes trades on the next bar at the open price.
- * 
+ *
  * This is used for strategies that explicitly trade just after a new bar opens
  * at bar index `t + 1`, in order to execute new or close existing trades as
  * close as possible to the opening price.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AbstractAnalysisCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AbstractAnalysisCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AbstractAnalysisCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AbstractAnalysisCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Calculates the average return per bar criterion, returned in decimal format.
- * 
+ *
  * <p>
  * It uses the following formula to accurately capture the compounding effect of
  * returns over the specified number of bars:

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectancyCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ExpectedShortfallCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/LinearTransactionCostCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/MaximumDrawdownCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBarsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBarsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBarsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/PositionsRatioCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
 /**
  * Reward risk ratio criterion (also known as "RoMaD"), returned in decimal
  * format.
- * 
+ *
  * <pre>
  * RoMaD = {@link ReturnCriterion gross return (with base)} / {@link MaximumDrawdownCriterion maximum drawdown}
  * </pre>

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/SqnCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ValueAtRiskCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/AverageCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/StandardErrorCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/VarianceCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageLossCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AverageProfitCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/LossCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -54,7 +54,7 @@ public class ReturnCriterion extends AbstractAnalysisCriterion {
 
     /**
      * Constructor.
-     * 
+     *
      * @param addBase the {@link #addBase}
      */
     public ReturnCriterion(boolean addBase) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ReturnCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -37,7 +37,7 @@ public class ATRIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */
@@ -47,7 +47,7 @@ public class ATRIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param tr       the {@link TRIndicator}
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractEMAIndicator.java
@@ -37,7 +37,7 @@ public abstract class AbstractEMAIndicator extends RecursiveCachedIndicator<Num>
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator  the {@link Indicator}
      * @param barCount   the time frame
      * @param multiplier the multiplier

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
@@ -37,7 +37,7 @@ public class AccelerationDecelerationIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series       the bar series
      * @param barCountSma1 the bar count for {@link #awesome}
      * @param barCountSma2 the bar count for {@link #sma}
@@ -50,7 +50,7 @@ public class AccelerationDecelerationIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with {@code barCountSma1} = 5 and {@code barCountSma2} = 34.
-     * 
+     *
      * @param series the bar series
      */
     public AccelerationDecelerationIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
@@ -53,7 +53,7 @@ public class AwesomeOscillatorIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code barCountSma1} = 5
      * <li>{@code barCountSma2} = 34
@@ -67,7 +67,7 @@ public class AwesomeOscillatorIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code indicator} = {@link MedianPriceIndicator}
      * <li>{@code barCountSma1} = 5

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CCIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
@@ -43,7 +43,7 @@ public class ChandelierExitLongIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code barCount} = 22
      * <li>{@code k} = 3

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -43,7 +43,7 @@ public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code barCount} = 22
      * <li>{@code k} = 3

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -32,19 +32,19 @@ import org.ta4j.core.num.Num;
 
 /**
  * The "CHOP" index is used to indicate side-ways markets.
- * 
+ *
  * <pre>
  * 100++ * LOG10( SUM(ATR(1), n) / ( MaxHi(n) - MinLo(n) ) ) / LOG10(n),
- * with n = User defined period length. 
- * LOG10(n) = base-10 LOG of n 
+ * with n = User defined period length.
+ * LOG10(n) = base-10 LOG of n
  * ATR(1) = Average True
- * Range (Period of 1) SUM(ATR(1), n) = Sum of the Average True Range over past n bars 
+ * Range (Period of 1) SUM(ATR(1), n) = Sum of the Average True Range over past n bars
  * MaxHi(n) = The highest high over past n bars
  *
  * ++ usually this index is between 0 and 100, but could be scaled differently
  * by the 'scaleTo' arg of the constructor
  * </pre>
- * 
+ *
  * @see <a href=
  *      "https://www.tradingview.com/wiki/Choppiness_Index_(CHOP)">https://www.tradingview.com/wiki/Choppiness_Index_(CHOP)</a>
  *

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
@@ -40,7 +40,7 @@ public class CoppockCurveIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code longRoCBarCount} = 14
      * <li>{@code shortRoCBarCount} = 11

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DPOIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DistanceFromMAIndicator.java
@@ -34,7 +34,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Distance From Moving Average
- * 
+ *
  * <pre>
  * (close - MA) / MA
  * </pre>

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/DoubleEMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/EMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/EMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/EMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/EMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/HMAIndicator.java
@@ -41,7 +41,7 @@ public class HMAIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
@@ -59,7 +59,7 @@ public class KAMAIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code barCountEffectiveRatio} = 10
      * <li>{@code barCountFast} = 2

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KAMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
@@ -28,13 +28,13 @@ import org.ta4j.core.num.Num;
 
 /**
  * Know Sure Thing (KST) indicator.
- * 
+ *
  * <pre>
  * RCMA1 = X1-Period SMA of Y1-Period Rate-of-Change
  * RCMA2 = X2-Period SMA of Y2-Period Rate-of-Change
  * RCMA3 = X3-Period SMA of Y3-Period Rate-of-Change
  * RCMA4 = X4-Period SMA of Y4-Period Rate-of-Change
- * 
+ *
  * KST = (RCMA1 x 1) + (RCMA2 x 2) + (RCMA3 x 3) + (RCMA4 x 4)
  * </pre>
  *

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KalmanFilterIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KalmanFilterIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KalmanFilterIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KalmanFilterIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/LWMAIndicator.java
@@ -41,7 +41,7 @@ public class LWMAIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -42,7 +42,7 @@ public class MACDIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code shortBarCount} = 12
      * <li>{@code longBarCount} = 26

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MACDIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/MassIndexIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
@@ -40,7 +40,7 @@ public class PPOIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code shortBarCount} = 12
      * <li>{@code longBarCount} = 26

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PPOIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/PVOIndicator.java
@@ -28,7 +28,7 @@ import org.ta4j.core.indicators.helpers.VolumeIndicator;
 
 /**
  * Percentage Volume Oscillator (PVO) indicator.
- * 
+ *
  * <pre>
  * ((12-day EMA of Volume - 26-day EMA of Volume) / 26-day EMA of Volume) x 100
  * </pre>
@@ -42,12 +42,12 @@ public class PVOIndicator extends PPOIndicator {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code shortBarCount} = 12
      * <li>{@code longBarCount} = 26
      * </ul>
-     * 
+     *
      * @param series the bar series {@link BarSeries}
      */
     public PVOIndicator(BarSeries series) {
@@ -56,12 +56,12 @@ public class PVOIndicator extends PPOIndicator {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code shortBarCount} = 12
      * <li>{@code longBarCount} = 26
      * </ul>
-     * 
+     *
      * @param series         the bar series {@link BarSeries}.
      * @param volumeBarCount the bar count for the {@link VolumeIndicator}
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ROCIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
@@ -41,7 +41,7 @@ public class RSIIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingHighIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecentSwingLowIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
@@ -31,7 +31,7 @@ import org.ta4j.core.Indicator;
  *
  * <p>
  * Recursive indicators should extend this class.
- * 
+ *
  * <p>
  * This class is only here to avoid (OK, to postpone) the StackOverflowError
  * that may be thrown on the first getValue(int) call of a recursive indicator.
@@ -43,7 +43,7 @@ public abstract class RecursiveCachedIndicator<T> extends CachedIndicator<T> {
 
     /**
      * The recursion threshold for which an iterative calculation is executed.
-     * 
+     *
      * TODO: Should be variable (depending on the sub-indicators used in this
      * indicator, e.g. Indicator#getUnstableBars()).
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RecursiveCachedIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SMAIndicator.java
@@ -40,7 +40,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorDIndicator.java
@@ -35,7 +35,7 @@ public class StochasticOscillatorDIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with {@code indicator} = {@link SMAIndicator SMAIndicator(3)}.
-     * 
+     *
      * @param indicator the indicator for the {@link SMAIndicator}
      */
     public StochasticOscillatorDIndicator(StochasticOscillatorKIndicator k) {
@@ -44,7 +44,7 @@ public class StochasticOscillatorDIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      */
     public StochasticOscillatorDIndicator(Indicator<Num> indicator) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -44,13 +44,13 @@ public class StochasticOscillatorKIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with:
-     * 
+     *
      * <ul>
      * <li>{@code indicator} = {@link ClosePriceIndicator}
      * <li>{@code highPriceIndicator} = {@link HighPriceIndicator}
      * <li>{@code lowPriceIndicator} = {@link LowPriceIndicator}
      * </ul>
-     * 
+     *
      * @param barSeries the bar series
      * @param barCount  the time frame
      */
@@ -61,7 +61,7 @@ public class StochasticOscillatorKIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator          the {@link Indicator}
      * @param barCount           the time frame
      * @param highPriceIndicator the {@link HighPriceIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticOscillatorKIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
@@ -45,7 +45,7 @@ public class StochasticRSIIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * <p>
      * <b>Note:</b> In most cases, this constructor should be used to avoid
      * confusion about which indicator parameters to use.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/TripleEMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UlcerIndexIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
@@ -36,7 +36,7 @@ public class WMAIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
@@ -48,7 +48,7 @@ public class WilliamsRIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries the bar series
      * @param barCount  the time frame
      */
@@ -59,7 +59,7 @@ public class WilliamsRIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param closePriceIndicator the {@link ClosePriceIndicator}
      * @param barCount            the time frame for {@code highPriceIndicator} and
      *                            {@code lowPriceIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/WilliamsRIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
@@ -43,7 +43,7 @@ public class ZLEMAIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ZLEMAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * ADX indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  *
@@ -45,7 +45,7 @@ public class ADXIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series      the bar series
      * @param diBarCount  the bar count for {@link DXIndicator}
      * @param adxBarCount the bar count for {@link #averageDXIndicator}
@@ -59,7 +59,7 @@ public class ADXIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the bar count for {@link DXIndicator} and
      *                 {@link #averageDXIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * DX indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  */
@@ -41,7 +41,7 @@ public class DXIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the bar count for {@link #plusDIIndicator} and
      *                 {@link #minusDIIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * -DI indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  *
@@ -49,7 +49,7 @@ public class MinusDIIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the bar count for {@link #atrIndicator} and
      *                 {@link #avgMinusDMIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDMIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * -DM indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  */
@@ -38,7 +38,7 @@ public class MinusDMIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public MinusDMIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -31,7 +31,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * +DI indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  *
@@ -49,7 +49,7 @@ public class PlusDIIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the bar count for {@link #atrIndicator} and
      *                 {@link #avgPlusDMIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDMIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * +DM indicator.
- * 
+ *
  * <p>
  * Part of the Directional Movement System.
  */
@@ -38,7 +38,7 @@ public class PlusDMIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public PlusDMIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonFacade.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
@@ -42,7 +42,7 @@ public class AroonOscillatorIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the number of periods used for the indicators
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandFacade.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 /**
  * Buy - Occurs when the price line crosses from below to above the Lower
  * Bollinger Band.
- * 
+ *
  * <p>
  * Sell - Occurs when the price line crosses from above to below the Upper
  * Bollinger Band.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 /**
  * Buy - Occurs when the price line crosses from below to above the Lower
  * Bollinger Band.
- * 
+ *
  * <p>
  * Sell - Occurs when the price line crosses from above to below the Upper
  * Bollinger Band.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 /**
  * Buy - Occurs when the price line crosses from below to above the Lower
  * Bollinger Band.
- * 
+ *
  * <p>
  * Sell - Occurs when the price line crosses from above to below the Upper
  * Bollinger Band.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/PercentBIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishHaramiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishHaramiIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishHaramiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishHaramiIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishHaramiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishHaramiIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishHaramiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishHaramiIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/LowerShadowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/LowerShadowIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/LowerShadowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/LowerShadowIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/RealBodyIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/RealBodyIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/RealBodyIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/RealBodyIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/UpperShadowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/UpperShadowIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/UpperShadowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/UpperShadowIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
@@ -40,7 +40,7 @@ public class DonchianChannelLowerIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
@@ -38,7 +38,7 @@ public class DonchianChannelMiddleIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
@@ -40,7 +40,7 @@ public class DonchianChannelUpperIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Amount indicator.
- * 
+ *
  * <p>
  * Returns the amount of a bar.
  */
@@ -37,7 +37,7 @@ public class AmountIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public AmountIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/AmountIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicator.java
@@ -40,7 +40,7 @@ public class CloseLocationValueIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public CloseLocationValueIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Calculates the difference between the current and the previous close price.
- * 
+ *
  * <pre>
  * ClosePriceDifference = currentBarClosePrice - previousBarClosePrice
  * </pre>

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Close price indicator.
- * 
+ *
  * <p>
  * Returns the close price of a bar.
  */
@@ -37,7 +37,7 @@ public class ClosePriceIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public ClosePriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Calculates the ratio between the current and the previous close price.
- * 
+ *
  * <pre>
  * ClosePriceRatio = currentBarClosePrice / previousBarClosePrice
  * </pre>

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
@@ -32,7 +32,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Combine indicator.
- * 
+ *
  * <p>
  * Combines two Num indicators by using common math operations.
  */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CombineIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConstantIndicator.java
@@ -28,7 +28,7 @@ import org.ta4j.core.indicators.AbstractIndicator;
 
 /**
  * Constant indicator.
- * 
+ *
  * <p>
  * Returns a constant value for a bar.
  */
@@ -38,7 +38,7 @@ public class ConstantIndicator<T> extends AbstractIndicator<T> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      * @param t      the constant value
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -32,7 +32,7 @@ import org.ta4j.core.indicators.CachedIndicator;
 
 /**
  * DateTime indicator.
- * 
+ *
  * <p>
  * Returns a {@link ZonedDateTime} of (or for) a bar.
  */
@@ -42,7 +42,7 @@ public class DateTimeIndicator extends CachedIndicator<ZonedDateTime> {
 
     /**
      * Constructor to return {@link Bar#getBeginTime()} of a bar.
-     * 
+     *
      * @param barSeries the bar series
      */
     public DateTimeIndicator(BarSeries barSeries) {
@@ -51,7 +51,7 @@ public class DateTimeIndicator extends CachedIndicator<ZonedDateTime> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries the bar series
      * @param action    the action
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
@@ -65,7 +65,7 @@ public class DifferencePercentageIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator           the {@link Indicator}
      * @param percentageThreshold the threshold percentage
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
@@ -27,7 +27,7 @@ import org.ta4j.core.BarSeries;
 
 /**
  * A fixed boolean indicator.
- * 
+ *
  * <p>
  * Returns constant {@link Boolean} values for a bar.
  */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedBooleanIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedDecimalIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * A fixed {@code Num} indicator.
- * 
+ *
  * <p>
  * Returns constant {@link Num} values for a bar.
  */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/FixedIndicator.java
@@ -35,7 +35,7 @@ import org.ta4j.core.indicators.AbstractIndicator;
  *
  * <p>
  * Returns constant values for a bar.
- * 
+ *
  * @param <T> the type of returned constant values (Double, Boolean, etc.)
  */
 public class FixedIndicator<T> extends AbstractIndicator<T> {
@@ -56,7 +56,7 @@ public class FixedIndicator<T> extends AbstractIndicator<T> {
 
     /**
      * Adds the {@code value} to {@link #values}.
-     * 
+     *
      * @param value the value to add
      */
     public void addValue(T value) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/GainIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Gain indicator.
- * 
+ *
  * <p>
  * Returns the difference of the indicator value of a bar and its previous bar
  * if the indicator value of the current bar is greater than the indicator value
@@ -41,7 +41,7 @@ public class GainIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      */
     public GainIndicator(Indicator<Num> indicator) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighPriceIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * The high price indicator.
- * 
+ *
  * <p>
  * Returns the high price of a bar.
  */
@@ -37,7 +37,7 @@ public class HighPriceIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public HighPriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Highest value indicator.
- * 
+ *
  * <p>
  * Returns the highest indicator value from the bar series within the bar count.
  */
@@ -40,7 +40,7 @@ public class HighestValueIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/HighestValueIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Loss indicator.
- * 
+ *
  * <p>
  * Returns the difference of the indicator value of a bar and its previous bar
  * if the indicator value of the current bar is less than the indicator value of
@@ -41,7 +41,7 @@ public class LossIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      */
     public LossIndicator(Indicator<Num> indicator) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LossIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Low price indicator.
- * 
+ *
  * <p>
  * Returns the low price of a bar.
  */
@@ -37,7 +37,7 @@ public class LowPriceIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public LowPriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowPriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/LowestValueIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Lowest value indicator.
- * 
+ *
  * <p>
  * Returns the lowest indicator value from the bar series within the bar count.
  */
@@ -40,7 +40,7 @@ public class LowestValueIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator the {@link Indicator}
      * @param barCount  the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/MedianPriceIndicator.java
@@ -30,10 +30,10 @@ import org.ta4j.core.num.Num;
 
 /**
  * Average high-low indicator.
- * 
+ *
  * <p>
  * Returns the median price of a bar using the following formula:
- * 
+ *
  * <pre>
  * MedianPrice = (highPrice + lowPrice) / 2
  * </pre>
@@ -42,7 +42,7 @@ public class MedianPriceIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public MedianPriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
@@ -32,10 +32,10 @@ import org.ta4j.core.num.Num;
 
 /**
  * Num indicator.
- * 
+ *
  * <p>
  * Returns a {@link Num} of (or for) a bar.
- * 
+ *
  * <p>
  * <b>Hint:</b> It is recommended to use the {@code NumIndicator} with its
  * {@link #action} mainly for complex functions and not for simple get
@@ -51,7 +51,7 @@ public class NumIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries the bar series
      * @param action    the action to calculate or determine a num on the bar
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/NumIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Open price indicator.
- * 
+ *
  * <p>
  * Returns the open price of a bar.
  */
@@ -37,7 +37,7 @@ public class OpenPriceIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public OpenPriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/OpenPriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/PreviousValueIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/RunningTotalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/RunningTotalIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/RunningTotalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/RunningTotalIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Calculates the sum of all indicator values.
- * 
+ *
  * <pre>
  * Sum = summand0 + summand1 + ... + summandN
  * </pre>

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/SumIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TRIndicator.java
@@ -30,7 +30,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * True range indicator.
- * 
+ *
  * <pre>
  * TrueRange = MAX(high - low, high - previousClose, previousClose - low)
  * </pre>
@@ -39,7 +39,7 @@ public class TRIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public TRIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TradeCountIndicator.java
@@ -28,7 +28,7 @@ import org.ta4j.core.indicators.CachedIndicator;
 
 /**
  * Trade count indicator.
- * 
+ *
  * <p>
  * Returns the number of trades of a bar.
  */
@@ -36,7 +36,7 @@ public class TradeCountIndicator extends CachedIndicator<Long> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public TradeCountIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -32,7 +32,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Transform indicator.
- * 
+ *
  * <p>
  * Transforms the {@link Num} of any indicator by using common math operations.
  *

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TransformIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicator.java
@@ -30,10 +30,10 @@ import org.ta4j.core.num.Num;
 
 /**
  * Typical price indicator.
- * 
+ *
  * <p>
  * Returns the typcial price of a bar using the following formula:
- * 
+ *
  * <pre>
  * TypicalPrice = (highPrice + lowPrice + closePrice) / 3
  * </pre>
@@ -42,7 +42,7 @@ public class TypicalPriceIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public TypicalPriceIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/UnstableIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
@@ -29,7 +29,7 @@ import org.ta4j.core.num.Num;
 
 /**
  * Volume indicator.
- * 
+ *
  * <p>
  * Returns the sum of the total traded volumes from the bar series within the
  * bar count.
@@ -40,7 +40,7 @@ public class VolumeIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor with {@code barCount} = 1.
-     * 
+     *
      * @param series the bar series
      */
     public VolumeIndicator(BarSeries series) {
@@ -49,7 +49,7 @@ public class VolumeIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/VolumeIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
@@ -45,7 +45,7 @@ public class KeltnerChannelFacade {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param emaCount the bar count for the {@code EmaIndicator}
      * @param atrCount the bar count for the {@code ATRIndicator}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacade.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -42,7 +42,7 @@ public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param middle      the {@link #keltnerMiddleIndicator}
      * @param ratio       the {@link #ratio}
      * @param barCountATR the bar count for the {@link ATRIndicator}
@@ -53,7 +53,7 @@ public class KeltnerChannelLowerIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param middle the {@link #keltnerMiddleIndicator}
      * @param atr    the {@link ATRIndicator}
      * @param ratio  the {@link #ratio}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
@@ -43,7 +43,7 @@ public class KeltnerChannelMiddleIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series      the bar series
      * @param barCountEMA the bar count for the {@link EMAIndicator}
      */
@@ -53,7 +53,7 @@ public class KeltnerChannelMiddleIndicator extends AbstractIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param indicator   the {@link Indicator}
      * @param barCountEMA the bar count for the {@link EMAIndicator}
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -42,7 +42,7 @@ public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param middle      the {@link #keltnerMiddleIndicator}
      * @param ratio       the {@link #ratio}
      * @param barCountATR the bar count for the {@link ATRIndicator}
@@ -53,7 +53,7 @@ public class KeltnerChannelUpperIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param middle the {@link #keltnerMiddleIndicator}
      * @param atr    the {@link ATRIndicator}
      * @param ratio  the {@link #ratio}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/BinaryOperation.java
@@ -41,7 +41,7 @@ public class BinaryOperation implements Indicator<Num> {
 
     /**
      * Returns an {@code Indicator} whose value is {@code (left + right)}.
-     * 
+     *
      * @param left
      * @param right
      * @return {@code left + right}, rounded as necessary
@@ -53,7 +53,7 @@ public class BinaryOperation implements Indicator<Num> {
 
     /**
      * Returns an {@code Indicator} whose value is {@code (left - right)}.
-     * 
+     *
      * @param left
      * @param right
      * @return {@code left - right}, rounded as necessary
@@ -65,7 +65,7 @@ public class BinaryOperation implements Indicator<Num> {
 
     /**
      * Returns an {@code Indicator} whose value is {@code (left * right)}.
-     * 
+     *
      * @param left
      * @param right
      * @return {@code left * right}, rounded as necessary
@@ -77,7 +77,7 @@ public class BinaryOperation implements Indicator<Num> {
 
     /**
      * Returns an {@code Indicator} whose value is {@code (left / right)}.
-     * 
+     *
      * @param left
      * @param right
      * @return {@code left / right}, rounded as necessary
@@ -90,7 +90,7 @@ public class BinaryOperation implements Indicator<Num> {
     /**
      * Returns the minimum of {@code left} and {@code right} as an
      * {@code Indicator}.
-     * 
+     *
      * @param left
      * @param right
      * @return the {@code Indicator} whose value is the smaller of {@code left} and
@@ -104,7 +104,7 @@ public class BinaryOperation implements Indicator<Num> {
     /**
      * Returns the maximum of {@code left} and {@code right} as an
      * {@code Indicator}.
-     * 
+     *
      * @param left
      * @param right
      * @return the {@code Indicator} whose value is the greater of {@code left} and

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
@@ -45,18 +45,18 @@ import org.ta4j.core.rules.UnderIndicatorRule;
  * NumericIndicator is a "fluent decorator" for Indicator<Num>. It provides
  * methods to create rules and other "lightweight" indicators, using a
  * (hopefully) natural-looking and expressive series of method calls.
- * 
+ *
  * <p>
  * Methods like plus(), minus() and sqrt() correspond directly to methods in the
  * {@code Num} interface. These methods create "lightweight" (not cached)
  * indicators to add, subtract, etc. Many methods are overloaded to accept
  * either {@code Indicator<Num>} or {@code Number} arguments.
- * 
+ *
  * <p>
  * Methods like sma() and ema() simply create the corresponding indicator
  * objects, (SMAIndicator or EMAIndicator, for example) with "this" as the first
  * argument. These methods usually instantiate cached objects.
- * 
+ *
  * <p>
  * Another set of methods, like crossedOver() and isGreaterThan() create Rule
  * objects. These are also overloaded to accept both {@code Indicator<Num>} and
@@ -205,7 +205,7 @@ public class NumericIndicator implements Indicator<Num> {
 
     /**
      * Returns an Indicator whose values are the absolute values of {@code this}.
-     * 
+     *
      * @return {@code abs(this)}
      */
     public NumericIndicator abs() {
@@ -214,7 +214,7 @@ public class NumericIndicator implements Indicator<Num> {
 
     /**
      * Returns an Indicator whose values are √(this).
-     * 
+     *
      * @return {@code √(this)}
      */
     public NumericIndicator sqrt() {
@@ -223,7 +223,7 @@ public class NumericIndicator implements Indicator<Num> {
 
     /**
      * Returns an Indicator whose values are {@code this * this}.
-     * 
+     *
      * @return {@code this * this}
      */
     public NumericIndicator squared() {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/NumericIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
@@ -38,7 +38,7 @@ public class UnaryOperation implements Indicator<Num> {
 
     /**
      * Returns an {@code Indicator} whose value is {@code √(operand)}.
-     * 
+     *
      * @param operand
      * @return {@code √(operand)}
      * @see Num#sqrt
@@ -50,7 +50,7 @@ public class UnaryOperation implements Indicator<Num> {
     /**
      * Returns an {@code Indicator} whose value is the absolute value of
      * {@code operand}.
-     * 
+     *
      * @param operand
      * @return {@code abs(operand)}
      * @see Num#abs

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/UnaryOperation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotLevel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotLevel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotLevel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/TimeLevel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/TimeLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/TimeLevel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/TimeLevel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicator.java
@@ -51,7 +51,7 @@ import org.ta4j.core.num.Num;
  *
  * <p>
  * Further readings:
- * 
+ *
  * <ul>
  * <li>Good sumary on 'Rate of Return':
  * https://en.wikipedia.org/wiki/Rate_of_return Annual return

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SigmaIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicator.java
@@ -34,11 +34,11 @@ import org.ta4j.core.num.Num;
  *
  * <p>
  * A moving (i.e. over the time frame) simple linear regression (least squares).
- * 
+ *
  * <pre>
  * y = slope * x + intercept
  * </pre>
- * 
+ *
  * @see http://introcs.cs.princeton.edu/java/97data/LinearRegression.java.html
  */
 public class SimpleLinearRegressionIndicator extends CachedIndicator<Num> {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/VarianceIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
@@ -40,7 +40,7 @@ public class SuperTrendIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor with {@code barCount} = 10 and {@code multiplier} = 3.
-     * 
+     *
      * @param series the bar series
      */
     public SuperTrendIndicator(final BarSeries series) {
@@ -49,7 +49,7 @@ public class SuperTrendIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series     the bar series
      * @param barCount   the time frame for the {@code ATRIndicator}
      * @param multiplier the multiplier for the

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
@@ -41,7 +41,7 @@ public class SuperTrendLowerBandIndicator extends RecursiveCachedIndicator<Num> 
 
     /**
      * Constructor with {@code multiplier} = 3.
-     * 
+     *
      * @param barSeries the bar series
      */
     public SuperTrendLowerBandIndicator(final BarSeries barSeries) {
@@ -50,7 +50,7 @@ public class SuperTrendLowerBandIndicator extends RecursiveCachedIndicator<Num> 
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries    the bar series
      * @param atrIndicator the {@link ATRIndicator}
      * @param multiplier   the multiplier

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
@@ -41,7 +41,7 @@ public class SuperTrendUpperBandIndicator extends RecursiveCachedIndicator<Num> 
 
     /**
      * Constructor with {@code multiplier} = 3.
-     * 
+     *
      * @param barSeries the bar series
      */
     public SuperTrendUpperBandIndicator(final BarSeries barSeries) {
@@ -50,7 +50,7 @@ public class SuperTrendUpperBandIndicator extends RecursiveCachedIndicator<Num> 
 
     /**
      * Constructor.
-     * 
+     *
      * @param barSeries    the bar series
      * @param atrIndicator the {@link #ATRIndicator}
      * @param multiplier   the multiplier

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
@@ -37,7 +37,7 @@ public class AccumulationDistributionIndicator extends RecursiveCachedIndicator<
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public AccumulationDistributionIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
@@ -47,7 +47,7 @@ public class ChaikinMoneyFlowIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series   the bar series
      * @param barCount the time frame
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/IIIIndicator.java
@@ -47,7 +47,7 @@ public class IIIIndicator extends CachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public IIIIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/NVIIndicator.java
@@ -44,7 +44,7 @@ public class NVIIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public NVIIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
@@ -37,7 +37,7 @@ public class OnBalanceVolumeIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public OnBalanceVolumeIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/PVIIndicator.java
@@ -41,7 +41,7 @@ public class PVIIndicator extends RecursiveCachedIndicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series the bar series
      */
     public PVIIndicator(BarSeries series) {

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ROCVIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/VWAPIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DecimalNum.java
@@ -63,7 +63,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Constructor.
-     * 
+     *
      * <p>
      * Constructs the most precise {@code Num}, because it converts a {@code String}
      * to a {@code Num} with a precision of {@link #DEFAULT_PRECISION}; only a
@@ -79,7 +79,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Constructor.
-     * 
+     *
      * <p>
      * Constructs a more precise {@code Num} than from {@code double}, because it
      * converts a {@code String} to a {@code Num} with a precision of
@@ -125,7 +125,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Returns a {@code Num} version of the given {@code String}.
-     * 
+     *
      * <p>
      * Constructs the most precise {@code Num}, because it converts a {@code String}
      * to a {@code Num} with a precision of {@link #DEFAULT_PRECISION}; only a
@@ -160,7 +160,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Returns a {@code Num} version of the given {@code Number}.
-     * 
+     *
      * <p>
      * Returns the most precise {@code Num}, because it first converts {@code val}
      * to a {@code String} and then to a {@code Num} with a precision of
@@ -177,7 +177,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Returns a {@code DecimalNum} version of the given {@code DoubleNum}.
-     * 
+     *
      * <p>
      * Returns the most precise {@code Num}, because it first converts {@code val}
      * to a {@code String} and then to a {@code Num} with a precision of
@@ -260,7 +260,7 @@ public final class DecimalNum implements Num {
 
     /**
      * Returns a {@code Num} version of the given {@code BigDecimal}.
-     * 
+     *
      * <p>
      * <b>Warning:</b> The {@code Num} returned may have inaccuracies because it
      * only inherits the precision of {@code val}.
@@ -437,7 +437,7 @@ public final class DecimalNum implements Num {
     /**
      * Returns a {@code Num} whose value is {@code √(this)} with {@code precision} =
      * {@link #DEFAULT_PRECISION}.
-     * 
+     *
      * @see DecimalNum#sqrt(int)
      */
     @Override
@@ -680,7 +680,7 @@ public final class DecimalNum implements Num {
     /**
      * <b>Warning:</b> This method returns {@code true} if {@code this} and
      * {@code obj} are both {@link NaN#NaN}.
-     * 
+     *
      * @return true if {@code this} object is the same as the {@code obj} argument,
      *         as defined by the {@link #compareTo(Num) compareTo} method; false
      *         otherwise.

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -71,7 +71,7 @@ public class DoubleNum implements Num {
 
     /**
      * Returns a {@code DoubleNum} version of the given {@code DecimalNum}.
-     * 
+     *
      * <p>
      * <b>Warning:</b> The {@code Num} returned may have inaccuracies.
      *

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -28,10 +28,10 @@ import java.util.function.Function;
 
 /**
  * Representation of an undefined or unrepresentable value: NaN (not a number)
- * 
+ *
  * <p>
  * Special behavior in methods such as:
- * 
+ *
  * <ul>
  * <li>{@link NaN#plus(Num)} => NaN</li>
  * <li>{@link NaN#isEqual(Num)} => true</li>

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/Num.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/num/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/num/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
@@ -44,7 +44,7 @@ public class PerformanceReport {
 
     /**
      * Constructor.
-     * 
+     *
      * @param totalProfitLoss           the total PnL
      * @param totalProfitLossPercentage the total PnL in percent
      * @param totalProfit               the total profit

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReport.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PerformanceReportGenerator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReport.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReportGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/PositionStatsReportGenerator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/ReportGenerator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatement.java
@@ -37,7 +37,7 @@ public class TradingStatement {
 
     /**
      * Constructor.
-     * 
+     *
      * @param strategy            the {@link Strategy}
      * @param positionStatsReport the {@link PositionStatsReport}
      * @param performanceReport   the {@link PerformanceReport}

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/TradingStatementGenerator.java
@@ -46,7 +46,7 @@ public class TradingStatementGenerator implements ReportGenerator<TradingStateme
 
     /**
      * Constructor.
-     * 
+     *
      * @param performanceReportGenerator   the {@link PerformanceReportGenerator}
      * @param positionStatsReportGenerator the {@link PositionStatsReportGenerator}
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AbstractRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AndRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopGainRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopGainRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopLossRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeStopLossRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanIndicatorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/BooleanRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/ChainRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedDownIndicatorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/CrossedUpIndicatorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -43,7 +43,7 @@ public class DayOfWeekRule extends AbstractRule {
 
     /**
      * Constructor.
-     * 
+     *
      * @param timeIndicator the {@link DateTimeIndicator}
      * @param daysOfWeek    the days of the week
      */

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/FixedRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InPipeRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/InSlopeRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsEqualRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsFallingRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsHighestRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsLowestRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/IsRisingRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/JustOnceRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/JustOnceRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/JustOnceRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/JustOnceRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/NotRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
@@ -28,7 +28,7 @@ import org.ta4j.core.TradingRecord;
 /**
  * A rule for setting the minimum number of bars up to which an open position
  * should not be closed.
- * 
+ *
  * <p>
  * Using this rule only makes sense for exit rules. For entry rules,
  * {@link OpenedPositionMinimumBarCountRule#isSatisfied(int, TradingRecord)}
@@ -43,7 +43,7 @@ public class OpenedPositionMinimumBarCountRule extends AbstractRule {
 
     /**
      * Constructor.
-     * 
+     *
      * @param barCount the {@link #barCount}
      */
     public OpenedPositionMinimumBarCountRule(int barCount) {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OrRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OverIndicatorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/UnderIndicatorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/XorRule.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/helper/ChainLink.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/helper/ChainLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/helper/ChainLink.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/helper/ChainLink.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
@@ -28,7 +28,7 @@ public interface CriterionFactory {
 
     /**
      * Applies parameters to a CriterionFactory and returns the AnalysisCriterion.
-     * 
+     *
      * @param params criteria parameters
      * @return AnalysisCriterion with the parameters applied
      */

--- a/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/CriterionFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalCriterionTest.java
@@ -29,7 +29,7 @@ public interface ExternalCriterionTest {
 
     /**
      * Gets the BarSeries used by an external criterion calculator.
-     * 
+     *
      * @return BarSeries from the external criterion calculator
      * @throws Exception if the external calculator throws an Exception
      */
@@ -38,7 +38,7 @@ public interface ExternalCriterionTest {
     /**
      * Sends criterion parameters to an external criterion calculator and returns
      * the final value of the externally calculated criterion.
-     * 
+     *
      * @param params criterion parameters
      * @return Num final criterion value
      * @throws Exception if the external calculator throws an Exception
@@ -47,7 +47,7 @@ public interface ExternalCriterionTest {
 
     /**
      * Gets the trading record used by an external criterion calculator.
-     * 
+     *
      * @return TradingRecord from the external criterion calculator
      * @throws Exception if the external calculator throws an Exception
      */

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
@@ -29,7 +29,7 @@ public interface ExternalIndicatorTest {
 
     /**
      * Gets the BarSeries used by an external indicator calculator.
-     * 
+     *
      * @return BarSeries from the external indicator calculator
      * @throws Exception if the external calculator throws an Exception
      */
@@ -38,7 +38,7 @@ public interface ExternalIndicatorTest {
     /**
      * Sends indicator parameters to an external indicator calculator and returns
      * the externally calculated indicator.
-     * 
+     *
      * @param params indicator parameters
      * @return Indicator<Num> from the external indicator calculator
      * @throws Exception if the external calculator throws an Exception

--- a/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ExternalIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorFactory.java
@@ -28,7 +28,7 @@ public interface IndicatorFactory<D, I> {
 
     /**
      * Applies parameters and data to an IndicatorFactory and returns the Indicator.
-     * 
+     *
      * @param data   source data for building the indicator
      * @param params indicator parameters
      * @return Indicator<I> with the indicator parameters applied

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/IndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/PositionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtils.java
@@ -74,7 +74,7 @@ public class TestUtils {
      * Verifies that the actual {@code Num} value is equal to the given {@code int}
      * representation.
      *
-     * 
+     *
      * @param expected the given {@code int} representation to compare the actual
      *                 value to
      * @param actual   the actual {@code Num} value
@@ -118,7 +118,7 @@ public class TestUtils {
 
     /**
      * Verifies that two indicators have the same size and values to an offset
-     * 
+     *
      * @param expected indicator of expected values
      * @param actual   indicator of actual values
      */
@@ -134,7 +134,7 @@ public class TestUtils {
     /**
      * Verifies that two indicators have either different size or different values
      * to an offset
-     * 
+     *
      * @param expected indicator of expected values
      * @param actual   indicator of actual values
      */
@@ -192,7 +192,7 @@ public class TestUtils {
 
     /**
      * Verifies that two indicators have the same size and values
-     * 
+     *
      * @param expected indicator of expected values
      * @param actual   indicator of actual values
      */
@@ -225,7 +225,7 @@ public class TestUtils {
     /**
      * Verifies that two indicators have either different size or different values
      * to an offset
-     * 
+     *
      * @param expected indicator of expected values
      * @param actual   indicator of actual values
      * @param delta    num offset to which the indicators must be different

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TradingRecordTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/CashFlowTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/ReturnsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/FixedTransactionCostModelTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/ZeroCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/ZeroCostModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/ZeroCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/ZeroCostModelTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractAnalysisCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AbstractCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AverageReturnPerBarCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AverageReturnPerBarCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/AverageReturnPerBarCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/AverageReturnPerBarCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectancyCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectancyCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectancyCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectancyCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectedShortfallCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectedShortfallCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectedShortfallCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ExpectedShortfallCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/LinearTransactionCostCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/MaximumDrawdownCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBarsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBarsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBarsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBarsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfBreakEvenPositionsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfConsecutivePositionsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfLosingPositionsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfWinningPositionsCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/OpenedPositionUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/PositionsRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/PositionsRatioCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/PositionsRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/PositionsRatioCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/SqnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/SqnCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/SqnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/SqnCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ValueAtRiskCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ValueAtRiskCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ValueAtRiskCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ValueAtRiskCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/VersusEnterAndHoldCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
@@ -42,7 +42,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
 
     /**
      * Constructor.
-     * 
+     *
      * @param clazz           class containing the file resources
      * @param fileName        file name of the file containing the workbook
      * @param criterionColumn column number containing the calculated criterion
@@ -61,7 +61,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
     /**
      * Gets the BarSeries from the XLS file. The BarSeries is cached so that
      * subsequent calls do not execute getSeries.
-     * 
+     *
      * @return BarSeries from the file
      * @throws Exception if getSeries throws IOException or DataFormatException
      */
@@ -75,7 +75,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
 
     /**
      * Gets the final criterion value from the XLS file given the parameters.
-     * 
+     *
      * @param params criterion parameters
      * @return Num final criterion value
      * @throws Exception if getFinalCriterionValue throws IOException or
@@ -88,7 +88,7 @@ public class XLSCriterionTest implements ExternalCriterionTest {
 
     /**
      * Gets the trading record from the XLS file.
-     * 
+     *
      * @return TradingRecord from the file
      */
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/XLSCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/AverageCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/RelativeStandardDeviationCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardDeviationCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/StandardErrorCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/helpers/VarianceCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageLossCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageLossCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageProfitCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/AverageProfitCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/LossCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossRatioCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ReturnCriterionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AbstractIndicatorTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractIndicatorTest<D, I> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param factory     IndicatorFactory for building an Indicator given data and
      *                    parameters.
      * @param numFunction the function to convert a Number into a Num implementation
@@ -89,7 +89,7 @@ public abstract class AbstractIndicatorTest<D, I> {
 
     /**
      * Generates an Indicator from data and parameters.
-     * 
+     *
      * @param data   indicator data
      * @param params indicator parameters
      * @return Indicator<I> from data given parameters

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
@@ -46,7 +46,7 @@ public class CCIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
 
     /**
      * Constructor.
-     * 
+     *
      * @param function
      */
     public CCIIndicatorTest(Function<Number, Num> function) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CCIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -22,7 +22,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 /**
- * 
+ *
  */
 package org.ta4j.core.indicators;
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DPOIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DistanceFromMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DoubleEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DoubleEMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/DoubleEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/DoubleEMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/EMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/HMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/HMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/HMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/HMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KAMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KAMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KAMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KAMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KalmanFilterIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KalmanFilterIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KalmanFilterIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KalmanFilterIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/LWMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/LWMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/LWMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/LWMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MACDIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/MassIndexIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PPOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PPOIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PPOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PPOIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/PVOIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ROCIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ROCIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ROCIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ROCIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RSIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RWIHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RWIHighIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RWIHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RWIHighIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RWILowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RWILowIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RWILowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RWILowIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorKIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TripleEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TripleEMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TripleEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TripleEMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/UlcerIndexIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/WMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/WMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/WMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/WMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/WilliamsRIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -41,7 +41,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
 
     /**
      * Constructor.
-     * 
+     *
      * @param clazz    class containing the file resources
      * @param fileName file name of the file containing the workbook
      * @param column   column number containing the calculated indicator values
@@ -55,7 +55,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
 
     /**
      * Gets the BarSeries from the XLS file.
-     * 
+     *
      * @return BarSeries from the file
      * @throws Exception if getSeries throws IOException or DataFormatException
      */
@@ -69,7 +69,7 @@ public class XLSIndicatorTest implements ExternalIndicatorTest {
 
     /**
      * Gets the Indicator from the XLS file given the parameters.
-     * 
+     *
      * @param params indicator parameters
      * @return Indicator from the file given the parameters
      * @throws Exception if getIndicator throws IOException or DataFormatException

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ZLEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ZLEMAIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ZLEMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ZLEMAIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDMIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDMIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonDownIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonDownIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonDownIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonDownIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandWidthIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsLowerIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsMiddleIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandsUpperIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/PercentBIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/PercentBIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/PercentBIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/PercentBIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/LowerShadowIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/RealBodyIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/UpperShadowIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/AmountIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/AmountIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/AmountIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/AmountIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/BooleanTransformIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CloseLocationValueIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceDifferenceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ClosePriceRatioIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CombineIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CombineIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CombineIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CombineIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConstantIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConstantIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConstantIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConstantIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/ConvergenceDivergenceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DifferencePercentageIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/FixedIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/GainIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/GainIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/GainIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/GainIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighPriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighPriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LossIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LossIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LossIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LossIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowestValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowestValueIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowestValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowestValueIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/MedianPriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/NumndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/OpenPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/OpenPriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/OpenPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/OpenPriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/RunningTotalIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/RunningTotalIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/RunningTotalIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/RunningTotalIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SumIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SumIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SumIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/SumIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TRIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TradeCountIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TradeCountIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TradeCountIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TradeCountIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TransformIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/TypicalPriceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/UnstableIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/UnstableIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/UnstableIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/UnstableIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/VolumeIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/numeric/NumericIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/numeric/NumericIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/numeric/NumericIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/numeric/NumericIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/MeanDeviationIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PeriodicalGrowthRateIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SigmaIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SigmaIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SigmaIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SigmaIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/SimpleLinearRegressionIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/VarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/VarianceIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/VarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/VarianceIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinMoneyFlowIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/IIIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MoneyFlowIndexIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/NVIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/OnBalanceVolumeIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/PVIIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ROCVIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/RelativeVolumeStandardDeviationIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/TimeSegmentedVolumeIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
@@ -38,7 +38,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series BarSeries of the AnalysisCriterion
      * @param values AnalysisCriterion values
      */
@@ -49,7 +49,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
 
     /**
      * Gets the final criterion value.
-     * 
+     *
      * @param series   BarSeries is ignored
      * @param position is ignored
      */
@@ -60,7 +60,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
 
     /**
      * Gets the final criterion value.
-     * 
+     *
      * @param series        BarSeries is ignored
      * @param tradingRecord is ignored
      */
@@ -72,7 +72,7 @@ public class MockAnalysisCriterion implements AnalysisCriterion {
     /**
      * Compares two criterion values and returns true if first value is greater than
      * second value, false otherwise.
-     * 
+     *
      * @param criterionValue1 first value
      * @param criterionValue2 second value
      * @return boolean indicating first value is greater than second value

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockAnalysisCriterion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBar.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockIndicator.java
@@ -36,7 +36,7 @@ public class MockIndicator implements Indicator<Num> {
 
     /**
      * Constructor.
-     * 
+     *
      * @param series BarSeries of the Indicator
      * @param values Indicator values
      */
@@ -47,7 +47,7 @@ public class MockIndicator implements Indicator<Num> {
 
     /**
      * Gets a value from the Indicator
-     * 
+     *
      * @param index Indicator value to get
      * @return Num Indicator value at index
      */
@@ -63,7 +63,7 @@ public class MockIndicator implements Indicator<Num> {
 
     /**
      * Gets the Indicator TimeSeries.
-     * 
+     *
      * @return TimeSeries of the Indicator
      */
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockTradingRecord.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DoubleNumTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -315,7 +315,7 @@ public class NumTest extends AbstractIndicatorTest<Object, Num> {
             assertEquals("Infinity", sqrt.toString());
             /*
              * BigDecimalNum has been replaced by PrecisionNum
-             * 
+             *
              * } else if (numOf(0).getClass().equals(BigDecimalNum.class)) {
              * assertNumEquals("1.7976931348623157000000000000000E+308", sqrt);
              * assertNumNotEquals("1.7976931348623157000000000000001E+308", sqrt);

--- a/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/NumTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AndRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AndRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AndRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AndRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanIndicatorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanIndicatorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/BooleanRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/ChainRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedDownIndicatorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/CrossedUpIndicatorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/FixedRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/FixedRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/FixedRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/FixedRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InPipeRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/InSlopeRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsEqualRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsFallingRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsHighestRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsLowestRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/IsRisingRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/JustOnceRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/JustOnceRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/JustOnceRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/JustOnceRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/NotRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/NotRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/NotRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/NotRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OrRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OrRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OrRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OrRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OverIndicatorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/UnderIndicatorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/XorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/XorRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/XorRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/XorRuleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.jfree</groupId>
             <artifactId>jfreechart</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.5</version>
         </dependency>
 
         <dependency>

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.7.1</version>
+            <version>5.9</version>
         </dependency>
 
         <dependency>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10</version>
+            <version>2.10.1</version>
         </dependency>
     </dependencies>
 

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -94,7 +94,7 @@ public class BuyAndSellSignalsToChart {
             // Buy signal
             double buySignalBarTime = new Minute(
                     Date.from(series.getBar(position.getEntry().getIndex()).getEndTime().toInstant()))
-                            .getFirstMillisecond();
+                    .getFirstMillisecond();
             Marker buyMarker = new ValueMarker(buySignalBarTime);
             buyMarker.setPaint(Color.GREEN);
             buyMarker.setLabel("B");
@@ -102,7 +102,7 @@ public class BuyAndSellSignalsToChart {
             // Sell signal
             double sellSignalBarTime = new Minute(
                     Date.from(series.getBar(position.getExit().getIndex()).getEndTime().toInstant()))
-                            .getFirstMillisecond();
+                    .getFirstMillisecond();
             Marker sellMarker = new ValueMarker(sellSignalBarTime);
             sellMarker.setPaint(Color.RED);
             sellMarker.setLabel("S");

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/TradeCost.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/MovingAverageCrossOverRangeBacktest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToCsv.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -63,9 +63,6 @@ public class CsvBarsLoader {
 
         BarSeries series = new BaseBarSeries("apple_bars");
 
-        // new CSVReader(, ',', '"',
-        // 1)
-
         try {
             assert stream != null;
             try (CSVReader csvReader = new CSVReaderBuilder(new InputStreamReader(stream, StandardCharsets.UTF_8))

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/JsonBarsSerializer.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/JsonBarsSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/JsonBarsSerializer.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/JsonBarsSerializer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarSeries.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/logging/StrategyExecutionLogging.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/CCICorrectionStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/GlobalExtremaStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/MovingMomentumStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/QuickstartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/QuickstartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/QuickstartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/QuickstartTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/StrategyAnalysisTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/StrategyAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/StrategyAnalysisTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/StrategyAnalysisTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/TradeCostTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageBacktestTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktestTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktestTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktestTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/barSeries/BuildBarSeriesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/barSeries/BuildBarSeriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/barSeries/BuildBarSeriesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/barSeries/BuildBarSeriesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/bots/TradingBotOnMovingBarSeriesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/bots/TradingBotOnMovingBarSeriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/bots/TradingBotOnMovingBarSeriesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/bots/TradingBotOnMovingBarSeriesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToCsvTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToCsvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToCsvTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToCsvTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvBarsLoaderTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvBarsLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvBarsLoaderTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvBarsLoaderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvTradesLoaderTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvTradesLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvTradesLoaderTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/CsvTradesLoaderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/JsonBarsSerializerTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/JsonBarsSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/loaders/JsonBarsSerializerTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/loaders/JsonBarsSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/logging/StrategyExecutionLoggingTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/logging/StrategyExecutionLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/logging/StrategyExecutionLoggingTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/logging/StrategyExecutionLoggingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/num/CompareNumTypesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/num/CompareNumTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/num/CompareNumTypesTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/num/CompareNumTypesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/CCICorrectionStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/CCICorrectionStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/CCICorrectionStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/CCICorrectionStrategyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/GlobalExtremaStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/GlobalExtremaStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/GlobalExtremaStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/GlobalExtremaStrategyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/MovingMomentumStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/MovingMomentumStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/MovingMomentumStrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/MovingMomentumStrategyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/RSI2StrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/RSI2StrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/strategies/RSI2StrategyTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/strategies/RSI2StrategyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/ta4j-examples/src/test/java/ta4jexamples/walkforward/WalkForwardTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/walkforward/WalkForwardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2017-2023 Ta4j Organization & respective

--- a/ta4j-examples/src/test/java/ta4jexamples/walkforward/WalkForwardTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/walkforward/WalkForwardTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2017-2023 Ta4j Organization & respective
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
  * authors (see AUTHORS)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Fixes #1181

Changes proposed in this pull request:
- Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
- Updated **logback-classic** 1.4.12 > 1.5.6 to resolve [CVE-2023-6481](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
- Updated other **ta4j-parent** dependencies and reformatted all files
- Updated **ta4j-core** dependencies and added <id> element to **ta4j-parent** pom's developers section
- Updated all github URLs from http to https
- Updated project Java JDK from 11 > 21
- Updated Github workflows to use JDK 21

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
