### PR TITLE
replaced ZonedDateTime with Instant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Updated project Java JDK from 11 > 21
 - Updated Github workflows to use JDK 21
 - Extracted NumFactory as source of numbers with defined precision
+- Replaced `ZonedDateTime` with `Instant`
 
 ### Fixed
-
+- Fixed `BaseBar.toString()` to avoid `NullPointerException` if any of its property is null
+- Fixed `SMAIndicatorTest` to set the endTime of the next bar correctly
+- Fixed `SMAIndicatorMovingSeriesTest` to set the endTime of the next bar correctly
 
 ### Changed
 - Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
@@ -18,7 +21,11 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Added
-
+- added `Bar.getZonedBeginTime`: the bar's begin time usable as ZonedDateTime
+- added `Bar.getZonedEndTime`: the bar's end time usable as ZonedDateTime
+- added `Bar.getSystemBeginTime`: the bar's begin time converted to system time zone
+- added `Bar.getSystemEndTime`: the bar's end time converted to system time zone
+- added `BarSeries.getSeriesPeriodDescriptionInDefaultTimeZone`: with times printed in system's default time zone
 
 ## 0.17 (released September 9, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Added
 - added `Bar.getZonedBeginTime`: the bar's begin time usable as ZonedDateTime
 - added `Bar.getZonedEndTime`: the bar's end time usable as ZonedDateTime
-- added `Bar.getSystemBeginTime`: the bar's begin time converted to system time zone
-- added `Bar.getSystemEndTime`: the bar's end time converted to system time zone
-- added `BarSeries.getSeriesPeriodDescriptionInDefaultTimeZone`: with times printed in system's default time zone
+- added `Bar.getSystemZonedBeginTime`: the bar's begin time converted to system time zone
+- added `Bar.getSystemZonedEndTime`: the bar's end time converted to system time zone
+- added `BarSeries.getSeriesPeriodDescriptionInSystemTimeZone`: with times printed in system's default time zone
 
 ## 0.17 (released September 9, 2024)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/Bar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/Bar.java
@@ -26,6 +26,9 @@ package org.ta4j.core;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
@@ -44,14 +47,14 @@ public interface Bar extends Serializable {
     Duration getTimePeriod();
 
     /**
-     * @return the begin timestamp of the bar period
+     * @return the begin timestamp of the bar period (in UTC).
      */
-    ZonedDateTime getBeginTime();
+    Instant getBeginTime();
 
     /**
-     * @return the end timestamp of the bar period
+     * @return the end timestamp of the bar period (in UTC).
      */
-    ZonedDateTime getEndTime();
+    Instant getEndTime();
 
     /**
      * @return the open price of the bar period
@@ -93,22 +96,70 @@ public interface Bar extends Serializable {
      * @return true if the provided timestamp is between the begin time and the end
      *         time of the current period, false otherwise
      */
-    default boolean inPeriod(ZonedDateTime timestamp) {
+    default boolean inPeriod(Instant timestamp) {
         return timestamp != null && !timestamp.isBefore(getBeginTime()) && timestamp.isBefore(getEndTime());
     }
 
     /**
-     * @return a human-friendly string of the end timestamp
+     * @return the bar's begin time in UTC as {@link ZonedDateTime}
      */
-    default String getDateName() {
-        return getEndTime().format(DateTimeFormatter.ISO_DATE_TIME);
+    default ZonedDateTime getZonedBeginTime() {
+        return getBeginTime().atZone(ZoneOffset.UTC);
     }
 
     /**
-     * @return a even more human-friendly string of the end timestamp
+     * @return the bar's end time in UTC as {@link ZonedDateTime}
+     */
+    default ZonedDateTime getZonedEndTime() {
+        return getEndTime().atZone(ZoneOffset.UTC);
+    }
+
+    /**
+     * Converts the begin time of the bar to a time in the system's time zone.
+     *
+     * <p>
+     * <b>Warning:</b> The use of {@link ZoneId#systemDefault()} may introduce
+     * variability based on the system's default time zone settings. This can result
+     * in inconsistencies in time calculations and comparisons, particularly due to
+     * daylight saving time (DST). It is recommended to always utilize either
+     * {@link #getBeginTime()} or {@link #getZonedBeginTime()} for accurate results.
+     *
+     * @return the bar's begin time converted to system time zone
+     */
+    default ZonedDateTime getSystemZonedBeginTime() {
+        return getBeginTime().atZone(ZoneId.systemDefault());
+    }
+
+    /**
+     * Converts the end time of the bar to a time in the system's time zone.
+     *
+     * <p>
+     * <b>Warning:</b> The use of {@link ZoneId#systemDefault()} may introduce
+     * variability based on the system's default time zone settings. This can result
+     * in inconsistencies in time calculations and comparisons, particularly due to
+     * daylight saving time (DST). It is recommended to always utilize either
+     * {@link #getEndTime()} or {@link #getZonedEndTime()} for accurate results.
+     *
+     * @return the bar's end time converted to system time zone
+     */
+    default ZonedDateTime getSystemZonedEndTime() {
+        return getEndTime().atZone(ZoneId.systemDefault());
+    }
+
+    /**
+     * @return a user-friendly representation of the end timestamp in the system's
+     *         time zone
+     */
+    default String getDateName() {
+        return getSystemZonedEndTime().format(DateTimeFormatter.ISO_DATE_TIME);
+    }
+
+    /**
+     * @return an even more user-friendly representation of the end timestamp in the
+     *         system's time zone
      */
     default String getSimpleDateName() {
-        return getEndTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return getSystemZonedEndTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -129,17 +129,31 @@ public interface BarSeries extends Serializable {
     int getEndIndex();
 
     /**
-     * @return the description of the series period (e.g. "from 12:00 21/01/2014 to
-     *         12:15 21/01/2014")
+     * @return the description of the series period (e.g. "from 2014-01-21T12:00:00Z
+     *         to 2014-01-21T12:15:00Z"); times are in UTC.
      */
     default String getSeriesPeriodDescription() {
         StringBuilder sb = new StringBuilder();
         if (!getBarData().isEmpty()) {
-            Bar firstBar = getFirstBar();
-            Bar lastBar = getLastBar();
-            sb.append(firstBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME))
-                    .append(" - ")
-                    .append(lastBar.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
+            var endTimeFirstBar = getFirstBar().getEndTime();
+            var endTimeLastBar = getLastBar().getEndTime();
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+            sb.append(formatter.format(endTimeFirstBar)).append(" - ").append(formatter.format(endTimeLastBar));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * @return the description of the series period (e.g. "from 12:00 21/01/2014 to
+     *         12:15 21/01/2014"); times are in system's default time zone.
+     */
+    default String getSeriesPeriodDescriptionInSystemTimeZone() {
+        StringBuilder sb = new StringBuilder();
+        if (!getBarData().isEmpty()) {
+            var endTimeFirstBar = getFirstBar().getSystemZonedEndTime();
+            var endTimeLastBar = getLastBar().getSystemZonedEndTime();
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+            sb.append(formatter.format(endTimeFirstBar)).append(" - ").append(formatter.format(endTimeLastBar));
         }
         return sb.toString();
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -24,8 +24,7 @@
 package org.ta4j.core;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 import org.ta4j.core.num.Num;
@@ -40,11 +39,11 @@ public class BaseBar implements Bar {
     /** The time period (e.g. 1 day, 15 min, etc.) of the bar. */
     private final Duration timePeriod;
 
-    /** The begin time of the bar period. */
-    private final ZonedDateTime beginTime;
+    /** The begin time of the bar period (in UTC). */
+    private final Instant beginTime;
 
-    /** The end time of the bar period. */
-    private final ZonedDateTime endTime;
+    /** The end time of the bar period (in UTC). */
+    private final Instant endTime;
 
     /** The open price of the bar period. */
     private Num openPrice;
@@ -71,7 +70,7 @@ public class BaseBar implements Bar {
      * Constructor.
      *
      * @param timePeriod the time period
-     * @param endTime    the end time of the bar period
+     * @param endTime    the end time of the bar period (in UTC)
      * @param openPrice  the open price of the bar period
      * @param highPrice  the highest price of the bar period
      * @param lowPrice   the lowest price of the bar period
@@ -80,7 +79,7 @@ public class BaseBar implements Bar {
      * @param amount     the total traded amount of the bar period
      * @param trades     the number of trades of the bar period
      */
-    BaseBar(Duration timePeriod, ZonedDateTime endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+    BaseBar(Duration timePeriod, Instant endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
             Num volume, Num amount, long trades) {
         checkTimeArguments(timePeriod, endTime);
         this.timePeriod = timePeriod;
@@ -109,12 +108,12 @@ public class BaseBar implements Bar {
      *         {@link #timePeriod})
      */
     @Override
-    public ZonedDateTime getBeginTime() {
+    public Instant getBeginTime() {
         return beginTime;
     }
 
     @Override
-    public ZonedDateTime getEndTime() {
+    public Instant getEndTime() {
         return endTime;
     }
 
@@ -176,12 +175,14 @@ public class BaseBar implements Bar {
         }
     }
 
+    /**
+     * @return {end time, close price, open price, low price, high price, volume}
+     */
     @Override
     public String toString() {
         return String.format(
-                "{end time: %1s, close price: %2$f, open price: %3$f, low price: %4$f, high price: %5$f, volume: %6$f}",
-                endTime.withZoneSameInstant(ZoneId.systemDefault()), closePrice.doubleValue(), openPrice.doubleValue(),
-                lowPrice.doubleValue(), highPrice.doubleValue(), volume.doubleValue());
+                "{end time: %1s, close price: %2s, open price: %3s, low price: %4s high price: %5s, volume: %6s}",
+                endTime, closePrice, openPrice, lowPrice, highPrice, volume);
     }
 
     /**
@@ -189,7 +190,7 @@ public class BaseBar implements Bar {
      * @param endTime    the end time of the bar
      * @throws NullPointerException if one of the arguments is null
      */
-    private static void checkTimeArguments(Duration timePeriod, ZonedDateTime endTime) {
+    private static void checkTimeArguments(Duration timePeriod, Instant endTime) {
         Objects.requireNonNull(timePeriod, "Time period cannot be null");
         Objects.requireNonNull(endTime, "End time cannot be null");
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarBuilder.java
@@ -24,7 +24,7 @@
 package org.ta4j.core;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 import org.ta4j.core.num.Num;
@@ -35,7 +35,7 @@ import org.ta4j.core.num.Num;
 public class BaseBarBuilder {
 
     private Duration timePeriod;
-    private ZonedDateTime endTime;
+    private Instant endTime;
     private Num openPrice;
     private Num highPrice;
     private Num lowPrice;
@@ -62,7 +62,7 @@ public class BaseBarBuilder {
      * @param endTime the end time of the bar period
      * @return {@code this}
      */
-    public BaseBarBuilder endTime(ZonedDateTime endTime) {
+    public BaseBarBuilder endTime(Instant endTime) {
         this.endTime = endTime;
         return this;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarConvertibleBuilder.java
@@ -24,7 +24,7 @@
 package org.ta4j.core;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
@@ -48,7 +48,7 @@ public class BaseBarConvertibleBuilder extends BaseBarBuilder {
     }
 
     @Override
-    public BaseBarConvertibleBuilder endTime(final ZonedDateTime endTime) {
+    public BaseBarConvertibleBuilder endTime(final Instant endTime) {
         super.endTime(endTime);
         return this;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -23,7 +23,7 @@
  */
 package org.ta4j.core;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -255,7 +255,7 @@ public class BaseBarSeries implements BarSeries {
                 return;
             }
             final int lastBarIndex = this.bars.size() - 1;
-            final ZonedDateTime seriesEndTime = this.bars.get(lastBarIndex).getEndTime();
+            final Instant seriesEndTime = this.bars.get(lastBarIndex).getEndTime();
             if (!bar.getEndTime().isAfter(seriesEndTime)) {
                 throw new IllegalArgumentException(
                         String.format("Cannot add a bar with end time:%s that is <= to series end time: %s",

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/DurationBarAggregator.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.aggregator;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,7 +94,7 @@ public class DurationBarAggregator implements BarAggregator {
         final Num zero = firstBar.getOpenPrice().getNumFactory().zero();
         while (i < bars.size()) {
             Bar bar = bars.get(i);
-            final ZonedDateTime beginTime = bar.getBeginTime();
+            final Instant beginTime = bar.getBeginTime();
             final Num open = bar.getOpenPrice();
             Num high = bar.getHighPrice();
             Num low = bar.getLowPrice();
@@ -152,7 +152,7 @@ public class DurationBarAggregator implements BarAggregator {
         return aggregated;
     }
 
-    private boolean beginTimesInDuration(ZonedDateTime startTime, ZonedDateTime endTime) {
+    private boolean beginTimesInDuration(Instant startTime, Instant endTime) {
         return Duration.between(startTime, endTime).compareTo(timePeriod) < 0;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/DateTimeIndicator.java
@@ -23,7 +23,7 @@
  */
 package org.ta4j.core.indicators.helpers;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.function.Function;
 
 import org.ta4j.core.Bar;
@@ -34,11 +34,11 @@ import org.ta4j.core.indicators.CachedIndicator;
  * DateTime indicator.
  *
  * <p>
- * Returns a {@link ZonedDateTime} of (or for) a bar.
+ * Returns a {@link Instant} of (or for) a bar.
  */
-public class DateTimeIndicator extends CachedIndicator<ZonedDateTime> {
+public class DateTimeIndicator extends CachedIndicator<Instant> {
 
-    private final Function<Bar, ZonedDateTime> action;
+    private final Function<Bar, Instant> action;
 
     /**
      * Constructor to return {@link Bar#getBeginTime()} of a bar.
@@ -55,13 +55,13 @@ public class DateTimeIndicator extends CachedIndicator<ZonedDateTime> {
      * @param barSeries the bar series
      * @param action    the action
      */
-    public DateTimeIndicator(BarSeries barSeries, Function<Bar, ZonedDateTime> action) {
+    public DateTimeIndicator(BarSeries barSeries, Function<Bar, Instant> action) {
         super(barSeries);
         this.action = action;
     }
 
     @Override
-    protected ZonedDateTime calculate(int index) {
+    protected Instant calculate(int index) {
         Bar bar = getBarSeries().getBar(index);
         return this.action.apply(bar);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkPivotPointIndicator.java
@@ -37,9 +37,15 @@ import org.ta4j.core.num.Num;
 /**
  * DeMark Pivot Point indicator.
  *
+ * <p>
+ * The {@link java.time.Instant UTC} represents a point in time on the
+ * time-line, typically measured in milliseconds. It is independent of time
+ * zones, days of the week, or months. However, this rule converts a UTC to a
+ * ZonedDateTime in UTC to get the day, week and month in that time zone.
+ *
  * @see <a href=
- *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points">
- *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points</a>
+ *      "https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points">
+ *      https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points</a>
  */
 public class DeMarkPivotPointIndicator extends RecursiveCachedIndicator<Num> {
 
@@ -157,34 +163,36 @@ public class DeMarkPivotPointIndicator extends RecursiveCachedIndicator<Num> {
     }
 
     private long getPreviousPeriod(Bar bar, int indexOfPreviousBar) {
+        var zonedEndTime = bar.getZonedEndTime();
         switch (timeLevel) {
         case DAY: // return previous day
-            int prevCalendarDay = bar.getEndTime().minusDays(1).getDayOfYear();
+            int prevCalendarDay = zonedEndTime.minusDays(1).getDayOfYear();
             // skip weekend and holidays:
-            while (getBarSeries().getBar(indexOfPreviousBar).getEndTime().getDayOfYear() != prevCalendarDay
-                    && indexOfPreviousBar > 0) {
+            var previousZonedEndTime = getBarSeries().getBar(indexOfPreviousBar).getZonedEndTime();
+            while (previousZonedEndTime.getDayOfYear() != prevCalendarDay && indexOfPreviousBar > 0) {
                 prevCalendarDay--;
             }
             return prevCalendarDay;
         case WEEK: // return previous week
-            return bar.getEndTime().minusWeeks(1).get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            return zonedEndTime.minusWeeks(1).get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         case MONTH: // return previous month
-            return bar.getEndTime().minusMonths(1).getMonthValue();
+            return zonedEndTime.minusMonths(1).getMonthValue();
         default: // return previous year
-            return bar.getEndTime().minusYears(1).getYear();
+            return zonedEndTime.minusYears(1).getYear();
         }
     }
 
     private long getPeriod(Bar bar) {
+        var zonedEndTime = bar.getZonedEndTime();
         switch (timeLevel) {
         case DAY: // return previous day
-            return bar.getEndTime().getDayOfYear();
+            return zonedEndTime.getDayOfYear();
         case WEEK: // return previous week
-            return bar.getEndTime().get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            return zonedEndTime.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         case MONTH: // return previous month
-            return bar.getEndTime().getMonthValue();
+            return zonedEndTime.getMonthValue();
         default: // return previous year
-            return bar.getEndTime().getYear();
+            return zonedEndTime.getYear();
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/DeMarkReversalIndicator.java
@@ -35,8 +35,8 @@ import org.ta4j.core.num.Num;
  * DeMark Reversal Indicator.
  *
  * @see <a href=
- *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points">
- *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points</a>
+ *      "https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points">
+ *      https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points</a>
  */
 public class DeMarkReversalIndicator extends RecursiveCachedIndicator<Num> {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/FibonacciReversalIndicator.java
@@ -35,8 +35,8 @@ import org.ta4j.core.num.Num;
  * Fibonacci Reversal Indicator.
  *
  * @see <a href=
- *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points">
- *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points</a>
+ *      "https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points">
+ *      https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points</a>
  */
 public class FibonacciReversalIndicator extends RecursiveCachedIndicator<Num> {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicator.java
@@ -37,9 +37,15 @@ import org.ta4j.core.num.Num;
 /**
  * Pivot Point indicator.
  *
+ * <p>
+ * The {@link java.time.Instant UTC} represents a point in time on the
+ * time-line, typically measured in milliseconds. It is independent of time
+ * zones, days of the week, or months. However, this rule converts a UTC to a
+ * ZonedDateTime in UTC to get the day, week and month in that time zone.
+ *
  * @see <a href=
- *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points">chart_school:
- *      pivotpoints</a>
+ *      "https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points">
+ *      https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points</a>
  */
 public class PivotPointIndicator extends RecursiveCachedIndicator<Num> {
 
@@ -141,34 +147,37 @@ public class PivotPointIndicator extends RecursiveCachedIndicator<Num> {
     }
 
     private long getPreviousPeriod(Bar bar, int indexOfPreviousBar) {
+        var zonedEndTime = bar.getZonedEndTime();
         switch (timeLevel) {
         case DAY: // return previous day
-            int prevCalendarDay = bar.getEndTime().minusDays(1).getDayOfYear();
+            int prevCalendarDay = zonedEndTime.minusDays(1).getDayOfYear();
             // skip weekend and holidays:
-            while (getBarSeries().getBar(indexOfPreviousBar).getEndTime().getDayOfYear() != prevCalendarDay
-                    && indexOfPreviousBar > 0 && prevCalendarDay >= 0) {
+            var previousZonedEndTime = getBarSeries().getBar(indexOfPreviousBar).getZonedEndTime();
+            while (previousZonedEndTime.getDayOfYear() != prevCalendarDay && indexOfPreviousBar > 0
+                    && prevCalendarDay >= 0) {
                 prevCalendarDay--;
             }
             return prevCalendarDay;
         case WEEK: // return previous week
-            return bar.getEndTime().minusWeeks(1).get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            return zonedEndTime.minusWeeks(1).get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         case MONTH: // return previous month
-            return bar.getEndTime().minusMonths(1).getMonthValue();
+            return zonedEndTime.minusMonths(1).getMonthValue();
         default: // return previous year
-            return bar.getEndTime().minusYears(1).getYear();
+            return zonedEndTime.minusYears(1).getYear();
         }
     }
 
     private long getPeriod(Bar bar) {
+        var zonedEndTime = bar.getZonedEndTime();
         switch (timeLevel) {
         case DAY: // return previous day
-            return bar.getEndTime().getDayOfYear();
+            return zonedEndTime.getDayOfYear();
         case WEEK: // return previous week
-            return bar.getEndTime().get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            return zonedEndTime.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
         case MONTH: // return previous month
-            return bar.getEndTime().getMonthValue();
+            return zonedEndTime.getMonthValue();
         default: // return previous year
-            return bar.getEndTime().getYear();
+            return zonedEndTime.getYear();
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/StandardReversalIndicator.java
@@ -35,8 +35,8 @@ import org.ta4j.core.num.Num;
  * Pivot Reversal Indicator.
  *
  * @see <a href=
- *      "http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points">
- *      http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:pivot_points</a>
+ *      "https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points">
+ *      https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/pivot-points</a>
  */
 public class StandardReversalIndicator extends RecursiveCachedIndicator<Num> {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/DoubleNum.java
@@ -26,7 +26,6 @@ package org.ta4j.core.num;
 import static org.ta4j.core.num.NaN.NaN;
 
 import java.math.BigDecimal;
-import java.util.function.Function;
 
 /**
  * Representation of {@link Double}. High performance, lower precision.

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NaN.java
@@ -24,7 +24,6 @@
 package org.ta4j.core.num;
 
 import java.math.BigDecimal;
-import java.util.function.Function;
 
 /**
  * Representation of an undefined or unrepresentable value: NaN (not a number)

--- a/ta4j-core/src/main/java/org/ta4j/core/num/NumFactory.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/num/NumFactory.java
@@ -79,7 +79,7 @@ public interface NumFactory {
     Num numOf(String number);
 
     /**
-     * Determines whether num instace has been produced by this factory
+     * Determines whether num instance has been produced by this factory
      *
      * @param num to test
      * @return true if made by this factory

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -24,7 +24,8 @@
 package org.ta4j.core.rules;
 
 import java.time.DayOfWeek;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -35,6 +36,12 @@ import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 /**
  * Satisfied when the "day of the week" value of the {@link DateTimeIndicator}
  * matches the specified set of {@link DayOfWeek}.
+ *
+ * <p>
+ * The {@link java.time.Instant UTC} represents a point in time on the
+ * time-line, typically measured in milliseconds. It is independent of time
+ * zones, days of the week, or months. However, this rule converts a UTC to a
+ * ZonedDateTime with UTC to get the day, week and month in that time zone.
  */
 public class DayOfWeekRule extends AbstractRule {
 
@@ -55,8 +62,8 @@ public class DayOfWeekRule extends AbstractRule {
     /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        ZonedDateTime dateTime = timeIndicator.getValue(index);
-        final boolean satisfied = daysOfWeekSet.contains(dateTime.getDayOfWeek());
+        Instant dateTime = timeIndicator.getValue(index);
+        final boolean satisfied = daysOfWeekSet.contains(dateTime.atZone(ZoneOffset.UTC).getDayOfWeek());
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TimeRangeRule.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.rules;
 
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.ta4j.core.TradingRecord;
@@ -33,8 +33,18 @@ import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 /**
  * Satisfied when the "local time" value of the {@link DateTimeIndicator} is
  * within the specified set of {@link TimeRange}.
+ *
+ * <p>
+ * An {@link java.time.Instant UTC} itself does not have a concept of a local
+ * time, as UTC is a time standard that does not include details such as days of
+ * the week. However, this rule converts a UTC to a ZonedDateTime in the
+ * system's default time zone and then to a LocalTime to get the local time in
+ * that time zone.
  */
 public class TimeRangeRule extends AbstractRule {
+
+    public record TimeRange(LocalTime from, LocalTime to) {
+    }
 
     private final List<TimeRange> timeRanges;
     private final DateTimeIndicator timeIndicator;
@@ -53,31 +63,12 @@ public class TimeRangeRule extends AbstractRule {
     /** This rule does not use the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        ZonedDateTime dateTime = timeIndicator.getValue(index);
-        LocalTime localTime = dateTime.toLocalTime();
-        final boolean satisfied = timeRanges.stream()
-                .anyMatch(
-                        timeRange -> !localTime.isBefore(timeRange.getFrom()) && !localTime.isAfter(timeRange.getTo()));
+        var localTime = LocalTime.ofInstant(timeIndicator.getValue(index), ZoneOffset.UTC);
+        final boolean satisfied = timeRanges.stream().anyMatch(range -> {
+            return !localTime.isBefore(range.from()) && !localTime.isAfter(range.to());
+        });
         traceIsSatisfied(index, satisfied);
         return satisfied;
     }
 
-    public static class TimeRange {
-
-        private final LocalTime from;
-        private final LocalTime to;
-
-        public TimeRange(LocalTime from, LocalTime to) {
-            this.from = from;
-            this.to = to;
-        }
-
-        public LocalTime getFrom() {
-            return from;
-        }
-
-        public LocalTime getTo() {
-            return to;
-        }
-    }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/BarSeriesUtils.java
@@ -24,7 +24,7 @@
 package org.ta4j.core.utils;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -90,8 +90,8 @@ public final class BarSeriesUtils {
             return null;
         for (int i = 0; i < bars.size(); i++) {
             Bar bar = bars.get(i);
-            boolean isSameBar = bar.getBeginTime().isEqual(newBar.getBeginTime())
-                    && bar.getEndTime().isEqual(newBar.getEndTime())
+            boolean isSameBar = bar.getBeginTime().equals(newBar.getBeginTime())
+                    && bar.getEndTime().equals(newBar.getEndTime())
                     && bar.getTimePeriod().equals(newBar.getTimePeriod());
             if (isSameBar && !bar.equals(newBar))
                 return bars.set(i, newBar);
@@ -112,12 +112,12 @@ public final class BarSeriesUtils {
      * @param findOnlyNaNBars find only bars with undefined prices
      * @return the list of possibly missing bars
      */
-    public static List<ZonedDateTime> findMissingBars(BarSeries barSeries, boolean findOnlyNaNBars) {
+    public static List<Instant> findMissingBars(BarSeries barSeries, boolean findOnlyNaNBars) {
         List<Bar> bars = barSeries.getBarData();
         if (bars == null || bars.isEmpty())
             return new ArrayList<>();
         Duration duration = bars.iterator().next().getTimePeriod();
-        List<ZonedDateTime> missingBars = new ArrayList<>();
+        List<Instant> missingBars = new ArrayList<>();
         for (int i = 0; i < bars.size(); i++) {
             Bar bar = bars.get(i);
             if (!findOnlyNaNBars) {

--- a/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
@@ -25,10 +25,12 @@ package org.ta4j.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
-import java.time.ZoneId;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import org.junit.Before;
@@ -41,9 +43,9 @@ public class BarTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     private Bar bar;
 
-    private ZonedDateTime beginTime;
+    private Instant beginTime;
 
-    private ZonedDateTime endTime;
+    private Instant endTime;
 
     public BarTest(NumFactory numFactory) {
         super(null, numFactory);
@@ -51,8 +53,8 @@ public class BarTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Before
     public void setUp() {
-        beginTime = ZonedDateTime.of(2014, 6, 25, 0, 0, 0, 0, ZoneId.systemDefault());
-        endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
+        beginTime = Instant.parse("2014-06-25T00:00:00Z");
+        endTime = Instant.parse("2014-06-25T01:00:00Z");
         bar = new BaseBarConvertibleBuilder(numFactory).timePeriod(Duration.ofHours(1))
                 .endTime(endTime)
                 .volume(0)
@@ -87,15 +89,33 @@ public class BarTest extends AbstractIndicatorTest<BarSeries, Num> {
     }
 
     @Test
+    public void getDateName() {
+        assertNotNull(bar.getDateName());
+    }
+
+    @Test
+    public void getSimpleDateName() {
+        assertNotNull(bar.getSimpleDateName());
+    }
+
+    @Test
     public void inPeriod() {
         assertFalse(bar.inPeriod(null));
 
-        assertFalse(bar.inPeriod(beginTime.withDayOfMonth(24)));
-        assertFalse(bar.inPeriod(beginTime.withDayOfMonth(26)));
-        assertTrue(bar.inPeriod(beginTime.withMinute(30)));
+        ZonedDateTime zonedBeginTime = beginTime.atZone(ZoneOffset.UTC);
+        assertFalse(bar.inPeriod(zonedBeginTime.withDayOfMonth(24).toInstant()));
+        assertFalse(bar.inPeriod(zonedBeginTime.withDayOfMonth(26).toInstant()));
+        assertTrue(bar.inPeriod(zonedBeginTime.withMinute(30).toInstant()));
 
         assertTrue(bar.inPeriod(beginTime));
         assertFalse(bar.inPeriod(endTime));
+    }
+
+    @Test
+    public void doesNotThrowNullPointerException() {
+        var bar = new BaseBarBuilder().timePeriod(Duration.ofHours(1)).endTime(endTime).build();
+        // TODO use Junit5: org.junit.jupiter.api.Assertions.assertDoesNotThrow instead:
+        assertNotNull(bar.toString());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarBuilderTest.java
@@ -26,9 +26,7 @@ package org.ta4j.core;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
+import java.time.Instant;
 import org.junit.Test;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.num.Num;
@@ -42,8 +40,9 @@ public class BaseBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void testBuildBar() {
-        final ZonedDateTime beginTime = ZonedDateTime.of(2014, 6, 25, 0, 0, 0, 0, ZoneId.systemDefault());
-        final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
+
+        final Instant beginTime = Instant.parse("2014-06-25T00:00:00Z");
+        final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
         final Duration duration = Duration.between(beginTime, endTime);
 
         final BaseBar bar = new BaseBarBuilder().timePeriod(duration)

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarConvertibleBuilderTest.java
@@ -28,9 +28,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
+import java.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -48,8 +46,8 @@ public class BaseBarConvertibleBuilderTest extends AbstractIndicatorTest<BarSeri
     @Test
     public void testBuildBigDecimal() {
 
-        final ZonedDateTime beginTime = ZonedDateTime.of(2014, 6, 25, 0, 0, 0, 0, ZoneId.systemDefault());
-        final ZonedDateTime endTime = ZonedDateTime.of(2014, 6, 25, 1, 0, 0, 0, ZoneId.systemDefault());
+        final Instant beginTime = Instant.parse("2014-06-25T00:00:00Z");
+        final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
         final Duration duration = Duration.between(beginTime, endTime);
 
         final var series = new BaseBarSeriesBuilder().withNumFactory(numFactory).build();

--- a/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/SeriesBuilderTest.java
@@ -27,7 +27,7 @@ import static junit.framework.TestCase.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Test;
 import org.ta4j.core.num.DecimalNum;
@@ -42,9 +42,13 @@ public class SeriesBuilderTest {
 
     @Test
     public void testBuilder() {
-        BarSeries defaultSeries = seriesBuilder.build(); // build a new empty unnamed bar series
-        BarSeries defaultSeriesName = seriesBuilder.withName("default").build(); // build a new empty bar series using
-                                                                                 // BigDecimal as delegate
+
+        // build a new empty unnamed bar series
+        BarSeries defaultSeries = seriesBuilder.build();
+
+        // build a new empty bar series using BigDecimal as delegate
+        BarSeries defaultSeriesName = seriesBuilder.withName("default").build();
+
         BarSeries doubleSeries = seriesBuilder.withMaxBarCount(100)
                 .withNumFactory(DoubleNumFactory.getInstance())
                 .withName("useDoubleNum")
@@ -54,10 +58,11 @@ public class SeriesBuilderTest {
                 .withName("usePrecisionNum")
                 .build();
 
+        var now = Instant.now();
         for (int i = 1000; i >= 0; i--) {
             defaultSeries.barBuilder()
                     .timePeriod(Duration.ofDays(1))
-                    .endTime(ZonedDateTime.now().minusSeconds(i))
+                    .endTime(now.minusSeconds(i))
                     .openPrice(i)
                     .closePrice(i)
                     .highPrice(i)
@@ -66,7 +71,7 @@ public class SeriesBuilderTest {
                     .add();
             defaultSeriesName.barBuilder()
                     .timePeriod(Duration.ofDays(1))
-                    .endTime(ZonedDateTime.now().minusSeconds(i))
+                    .endTime(now.minusSeconds(i))
                     .openPrice(i)
                     .closePrice(i)
                     .highPrice(i)
@@ -75,7 +80,7 @@ public class SeriesBuilderTest {
                     .add();
             doubleSeries.barBuilder()
                     .timePeriod(Duration.ofDays(1))
-                    .endTime(ZonedDateTime.now().minusSeconds(i))
+                    .endTime(now.minusSeconds(i))
                     .openPrice(i)
                     .closePrice(i)
                     .highPrice(i)
@@ -84,7 +89,7 @@ public class SeriesBuilderTest {
                     .add();
             precisionSeries.barBuilder()
                     .timePeriod(Duration.ofDays(1))
-                    .endTime(ZonedDateTime.now().minusSeconds(i))
+                    .endTime(now.minusSeconds(i))
                     .openPrice(i)
                     .closePrice(i)
                     .highPrice(i)

--- a/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/TestUtilsTest.java
@@ -30,9 +30,7 @@ import static org.ta4j.core.TestUtils.assertNumNotEquals;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
+import java.time.Instant;
 import org.junit.Test;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
@@ -73,12 +71,13 @@ public class TestUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     }
 
     private BarSeries randomSeries() {
-        BarSeries series = new BaseBarSeriesBuilder().withNumFactory(numFactory).build();
-        ZonedDateTime time = ZonedDateTime.of(1970, 1, 1, 1, 1, 1, 1, ZoneId.systemDefault());
+        var series = new BaseBarSeriesBuilder().withNumFactory(numFactory).build();
+
+        var time = Instant.parse("1970-01-01T01:01:01Z");
         double random;
         for (int i = 0; i < 1000; i++) {
             random = Math.random();
-            time = time.plusDays(i);
+            time = time.plus(Duration.ofDays(i));
             series.barBuilder()
                     .timePeriod(Duration.ofDays(1))
                     .endTime(time)

--- a/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/XlsTestsUtils.java
@@ -28,8 +28,6 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -168,8 +166,8 @@ public class XlsTestsUtils {
             }
             // add a bar to the series
             Date endDate = DateUtil.getJavaDate(cellValues[0].getNumberValue());
-            ZonedDateTime endDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDate.getTime()),
-                    ZoneId.systemDefault());
+            Instant endDateTime = Instant.ofEpochMilli(endDate.getTime());
+
             series.addBar(series.barBuilder()
                     .timePeriod(duration)
                     .endTime(endDateTime)

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/BaseBarSeriesAggregatorTest.java
@@ -26,10 +26,9 @@ package org.ta4j.core.aggregator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Test;
@@ -51,10 +50,8 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
 
     @Test
     public void testAggregateWithNewName() {
-        final List<Bar> bars = new LinkedList<>();
-
         final BarSeries barSeries = new MockBarSeriesBuilder().withName("name").build();
-        final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
+        final Instant time = Instant.parse("2019-06-12T04:01:00Z");
 
         var bar0 = barSeries.barBuilder()
                 .endTime(time)
@@ -67,7 +64,7 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
                 .trades(7)
                 .build();
         var bar1 = barSeries.barBuilder()
-                .endTime(time.plusDays(1))
+                .endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(2d)
                 .closePrice(3d)
                 .highPrice(3d)
@@ -77,7 +74,7 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
                 .trades(7)
                 .build();
         var bar2 = barSeries.barBuilder()
-                .endTime(time.plusDays(2))
+                .endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(3d)
                 .closePrice(4d)
                 .highPrice(4d)
@@ -101,7 +98,7 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
     @Test
     public void testAggregateWithTheSameName() {
         final BarSeries barSeries = new MockBarSeriesBuilder().withName("name").build();
-        final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
+        final Instant time = Instant.parse("2019-06-12T04:01:00Z");
 
         var bar0 = barSeries.barBuilder()
                 .endTime(time)
@@ -114,7 +111,7 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
                 .trades(7)
                 .build();
         var bar1 = barSeries.barBuilder()
-                .endTime(time.plusDays(1))
+                .endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(2d)
                 .closePrice(3d)
                 .highPrice(3d)
@@ -124,7 +121,7 @@ public class BaseBarSeriesAggregatorTest extends AbstractIndicatorTest<BarSeries
                 .trades(7)
                 .build();
         var bar2 = barSeries.barBuilder()
-                .endTime(time.plusDays(2))
+                .endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(3d)
                 .closePrice(4d)
                 .highPrice(4d)

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/DurationBarAggregatorTest.java
@@ -27,8 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -49,7 +48,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
 
     private List<Bar> getOneDayBars() {
         final List<Bar> bars = new LinkedList<>();
-        final ZonedDateTime time = ZonedDateTime.of(2019, 6, 12, 4, 1, 0, 0, ZoneId.systemDefault());
+        final Instant time = Instant.parse("2019-06-12T04:01:00Z");
 
         // days 1 - 5
         bars.add(new MockBarBuilder(numFactory).endTime(time)
@@ -61,7 +60,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(6d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(1))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(2d)
                 .closePrice(3d)
                 .highPrice(3d)
@@ -70,7 +69,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(6d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(2))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(3d)
                 .closePrice(4d)
                 .highPrice(4d)
@@ -79,7 +78,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(7d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(3))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(3)))
                 .openPrice(4d)
                 .closePrice(5d)
                 .highPrice(6d)
@@ -88,7 +87,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(8d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(4))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(4)))
                 .openPrice(5d)
                 .closePrice(9d)
                 .highPrice(3d)
@@ -99,7 +98,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .build());
 
         // days 6 - 10
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(5))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(5)))
                 .openPrice(6d)
                 .closePrice(10d)
                 .highPrice(9d)
@@ -108,7 +107,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(3d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(6))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(6)))
                 .openPrice(3d)
                 .closePrice(3d)
                 .highPrice(4d)
@@ -117,7 +116,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(74d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(7))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(7)))
                 .openPrice(4d)
                 .closePrice(7d)
                 .highPrice(63d)
@@ -126,7 +125,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(89d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(8))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(8)))
                 .openPrice(5d)
                 .closePrice(93d)
                 .highPrice(3d)
@@ -135,7 +134,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(62d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(9))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(9)))
                 .openPrice(6d)
                 .closePrice(10d)
                 .highPrice(91d)
@@ -146,7 +145,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .build());
 
         // days 11 - 15
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(10))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(10)))
                 .openPrice(4d)
                 .closePrice(10d)
                 .highPrice(943d)
@@ -155,7 +154,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(43d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(11))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(11)))
                 .openPrice(3d)
                 .closePrice(3d)
                 .highPrice(43d)
@@ -164,7 +163,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(784d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(12))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(12)))
                 .openPrice(4d)
                 .closePrice(74d)
                 .highPrice(53d)
@@ -173,7 +172,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(89d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(13))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(13)))
                 .openPrice(5d)
                 .closePrice(93d)
                 .highPrice(31d)
@@ -182,7 +181,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .volume(62d)
                 .trades(7)
                 .build());
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(14))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(14)))
                 .openPrice(6d)
                 .closePrice(10d)
                 .highPrice(991d)
@@ -193,7 +192,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .build());
 
         // day 16
-        bars.add(new MockBarBuilder(numFactory).endTime(time.plusDays(15))
+        bars.add(new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(15)))
                 .openPrice(6d)
                 .closePrice(108d)
                 .highPrice(1991d)
@@ -281,12 +280,12 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
 
     @Test
     public void testWithGapsInSeries() {
-        ZonedDateTime now = ZonedDateTime.now();
+        Instant now = Instant.now();
         BarSeries barSeries = new BaseBarSeriesBuilder().withNumFactory(numFactory).build();
 
         barSeries.barBuilder()
                 .timePeriod(Duration.ofMinutes(1))
-                .endTime(now.plusMinutes(1))
+                .endTime(now.plus(Duration.ofMinutes(1)))
                 .openPrice(1)
                 .highPrice(1)
                 .closePrice(2)
@@ -295,7 +294,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
                 .add();
         barSeries.barBuilder()
                 .timePeriod(Duration.ofMinutes(1))
-                .endTime(now.plusMinutes(2))
+                .endTime(now.plus(Duration.ofMinutes(2)))
                 .openPrice(1)
                 .highPrice(1)
                 .closePrice(3)
@@ -305,7 +304,7 @@ public class DurationBarAggregatorTest extends AbstractIndicatorTest<BarSeries, 
         ;
         barSeries.barBuilder()
                 .timePeriod(Duration.ofMinutes(1))
-                .endTime(now.plusMinutes(60))
+                .endTime(now.plus(Duration.ofMinutes(60)))
                 .openPrice(1)
                 .highPrice(1)
                 .closePrice(1)

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearTransactionCostModelTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.math.BigDecimal;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -138,7 +138,7 @@ public class LinearTransactionCostModelTest {
         BaseBarSeries series = new BaseBarSeriesBuilder().withName("CostModel test")
                 .withBarBuilderFactory(new MockBarBuilderFactory())
                 .build();
-        ZonedDateTime now = ZonedDateTime.now();
+        Instant now = Instant.now();
         Num one = series.numFactory().one();
         Num two = series.numFactory().numOf(2);
         Num three = series.numFactory().numOf(3);

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BarSeriesManagerTest.java
@@ -26,8 +26,7 @@ package org.ta4j.core.backtest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.Before;
@@ -61,19 +60,17 @@ public class BarSeriesManagerTest extends AbstractIndicatorTest<BarSeries, Num> 
 
     @Before
     public void setUp() {
-
-        final DateTimeFormatter dtf = DateTimeFormatter.ISO_ZONED_DATE_TIME;
         seriesForRun = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
 
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2013-01-01T00:00:00-05:00", dtf)).closePrice(1d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2013-08-01T00:00:00-05:00", dtf)).closePrice(2d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2013-10-01T00:00:00-05:00", dtf)).closePrice(3d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2013-12-01T00:00:00-05:00", dtf)).closePrice(4d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2014-02-01T00:00:00-05:00", dtf)).closePrice(5d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2015-01-01T00:00:00-05:00", dtf)).closePrice(6d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2015-08-01T00:00:00-05:00", dtf)).closePrice(7d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2015-10-01T00:00:00-05:00", dtf)).closePrice(8d).add();
-        seriesForRun.barBuilder().endTime(ZonedDateTime.parse("2015-12-01T00:00:00-05:00", dtf)).closePrice(7d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2013-01-01T05:00:00Z")).closePrice(1d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2013-08-01T05:00:00Z")).closePrice(2d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2013-10-01T05:00:00Z")).closePrice(3d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2013-12-01T05:00:00Z")).closePrice(4d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2014-02-01T05:00:00Z")).closePrice(5d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2015-01-01T05:00:00Z")).closePrice(6d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2015-08-01T05:00:00Z")).closePrice(7d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2015-10-01T05:00:00Z")).closePrice(8d).add();
+        seriesForRun.barBuilder().endTime(Instant.parse("2015-12-01T05:00:00Z")).closePrice(7d).add();
 
         manager = new BarSeriesManager(seriesForRun, new TradeOnCurrentCloseModel());
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ATRIndicatorTest.java
@@ -26,7 +26,7 @@ package org.ta4j.core.indicators;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertIndicatorEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -49,8 +49,9 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
     @Test
     public void testDummy() {
         var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        var now = Instant.now();
         series.addBar(series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(5))
+                .endTime(now.minusSeconds(5))
                 .openPrice(0)
                 .closePrice(12)
                 .highPrice(15)
@@ -59,7 +60,7 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .volume(0)
                 .build());
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(4))
+                .endTime(now.minusSeconds(4))
                 .openPrice(0)
                 .closePrice(8)
                 .highPrice(11)
@@ -69,7 +70,7 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(0)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(3))
+                .endTime(now.minusSeconds(3))
                 .openPrice(0)
                 .closePrice(15)
                 .highPrice(17)
@@ -79,7 +80,7 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(0)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(2))
+                .endTime(now.minusSeconds(2))
                 .openPrice(0)
                 .closePrice(15)
                 .highPrice(17)
@@ -89,7 +90,7 @@ public class ATRIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(0)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(1))
+                .endTime(now.minusSeconds(1))
                 .openPrice(0)
                 .closePrice(0)
                 .highPrice(0)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
@@ -59,7 +59,6 @@ public class ChandelierExitLongIndicatorTest extends AbstractIndicatorTest<Indic
         data.barBuilder().openPrice(45.58).closePrice(45.55).highPrice(45.61).lowPrice(45.39).add();
         data.barBuilder().openPrice(45.45).closePrice(45.01).highPrice(45.55).lowPrice(44.80).add();
         data.barBuilder().openPrice(45.03).closePrice(44.23).highPrice(45.04).lowPrice(44.17).add();
-
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
@@ -59,7 +59,6 @@ public class ChandelierExitShortIndicatorTest extends AbstractIndicatorTest<Indi
         data.barBuilder().openPrice(45.58).closePrice(45.55).highPrice(45.61).lowPrice(45.39).add();
         data.barBuilder().openPrice(45.45).closePrice(45.01).highPrice(45.55).lowPrice(44.80).add();
         data.barBuilder().openPrice(45.03).closePrice(44.23).highPrice(45.04).lowPrice(44.17).add();
-
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
@@ -25,7 +25,7 @@ package org.ta4j.core.indicators;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,142 +47,143 @@ public class FisherIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     public void setUp() {
 
         series = new MockBarSeriesBuilder().withNumFactory(numFactory).withName("NaN test").build();
+        var now = Instant.now();
         int i = 20;
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(44.98)
                 .closePrice(45.05)
                 .highPrice(45.17)
                 .lowPrice(44.96)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.05)
                 .closePrice(45.10)
                 .highPrice(45.15)
                 .lowPrice(44.99)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.11)
                 .closePrice(45.19)
                 .highPrice(45.32)
                 .lowPrice(45.11)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.19)
                 .closePrice(45.14)
                 .highPrice(45.25)
                 .lowPrice(45.04)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.12)
                 .closePrice(45.15)
                 .highPrice(45.20)
                 .lowPrice(45.10)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.15)
                 .closePrice(45.14)
                 .highPrice(45.20)
                 .lowPrice(45.10)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.13)
                 .closePrice(45.10)
                 .highPrice(45.16)
                 .lowPrice(45.07)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.12)
                 .closePrice(45.15)
                 .highPrice(45.22)
                 .lowPrice(45.10)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.15)
                 .closePrice(45.22)
                 .highPrice(45.27)
                 .lowPrice(45.14)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.24)
                 .closePrice(45.43)
                 .highPrice(45.45)
                 .lowPrice(45.20)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.43)
                 .closePrice(45.44)
                 .highPrice(45.50)
                 .lowPrice(45.39)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.43)
                 .closePrice(45.55)
                 .highPrice(45.60)
                 .lowPrice(45.35)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.58)
                 .closePrice(45.55)
                 .highPrice(45.61)
                 .lowPrice(45.39)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.45)
                 .closePrice(45.01)
                 .highPrice(45.55)
                 .lowPrice(44.80)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(45.03)
                 .closePrice(44.23)
                 .highPrice(45.04)
                 .lowPrice(44.17)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(44.23)
                 .closePrice(43.95)
                 .highPrice(44.29)
                 .lowPrice(43.81)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(43.91)
                 .closePrice(43.08)
                 .highPrice(43.99)
                 .lowPrice(43.08)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(43.07)
                 .closePrice(43.55)
                 .highPrice(43.65)
                 .lowPrice(43.06)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i--))
+                .endTime(now.minusSeconds(i--))
                 .openPrice(43.56)
                 .closePrice(43.95)
                 .highPrice(43.99)
                 .lowPrice(43.53)
                 .add();
         series.barBuilder()
-                .endTime(ZonedDateTime.now().minusSeconds(i))
+                .endTime(now.minusSeconds(i))
                 .openPrice(43.93)
                 .closePrice(44.47)
                 .highPrice(44.58)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -47,7 +47,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void growingBarSeriesTest() {
-        ZonedDateTime now = ZonedDateTime.now();
+        var now = Instant.now();
         var mockBarSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         mockBarSeries.barBuilder()
                 .endTime(now)
@@ -106,7 +106,7 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void startUpAndDownTrendTest() {
-        ZonedDateTime now = ZonedDateTime.now();
+        var now = Instant.now();
         var mockBarSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
 
         // values of removable bars are much higher to be sure that they will not affect
@@ -311,30 +311,21 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
     @Test
     public void startWithDownAndUpTrendTest() {
         final var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
-        series.barBuilder().openPrice(4261.48).closePrice(4285.08).highPrice(4485.39).lowPrice(4200.74).add(); // The
-                                                                                                               // first
-                                                                                                               // daily
-                                                                                                               // candle
-                                                                                                               // of
-                                                                                                               // BTCUSDT
-                                                                                                               // in
-        // the Binance cryptocurrency exchange.
-        // 17 Aug 2017
-        series.barBuilder().openPrice(4285.08).closePrice(4108.37).highPrice(4371.52).lowPrice(3938.77).add(); // starting
-                                                                                                               // with
-                                                                                                               // down
-                                                                                                               // trend
-        series.barBuilder().openPrice(4108.37).closePrice(4139.98).highPrice(4184.69).lowPrice(3850.00).add(); // hold
-                                                                                                               // trend...
+        // The first daily candle of BTCUSDT in the Binance cryptocurrency exchange. 17
+        // Aug 2017..
+        series.barBuilder().openPrice(4261.48).closePrice(4285.08).highPrice(4485.39).lowPrice(4200.74).add();
+        // starting with down trend..
+        series.barBuilder().openPrice(4285.08).closePrice(4108.37).highPrice(4371.52).lowPrice(3938.77).add();
+        // hold trend...
+        series.barBuilder().openPrice(4108.37).closePrice(4139.98).highPrice(4184.69).lowPrice(3850.00).add();
         series.barBuilder().openPrice(4120.98).closePrice(4086.29).highPrice(4211.08).lowPrice(4032.62).add();
         series.barBuilder().openPrice(4069.13).closePrice(4016.00).highPrice(4119.62).lowPrice(3911.79).add();
         series.barBuilder().openPrice(4016.00).closePrice(4040.00).highPrice(4104.82).lowPrice(3400.00).add();
         series.barBuilder().openPrice(4040.00).closePrice(4114.01).highPrice(4265.80).lowPrice(4013.89).add();
-        series.barBuilder().openPrice(4147.00).closePrice(4316.01).highPrice(4371.68).lowPrice(4085.01).add(); // switch
-                                                                                                               // to up
-                                                                                                               // trend
-        series.barBuilder().openPrice(4316.01).closePrice(4280.68).highPrice(4453.91).lowPrice(4247.48).add(); // hold
-                                                                                                               // trend
+        // switch to up trend
+        series.barBuilder().openPrice(4147.00).closePrice(4316.01).highPrice(4371.68).lowPrice(4085.01).add();
+        // hold trend
+        series.barBuilder().openPrice(4316.01).closePrice(4280.68).highPrice(4453.91).lowPrice(4247.48).add();
         series.barBuilder().openPrice(4280.71).closePrice(4337.44).highPrice(4367.00).lowPrice(4212.41).add();
 
         var sar = new ParabolicSarIndicator(series);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingHighIndicatorTest.java
@@ -53,83 +53,45 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
     @Before
     public void setUp() {
         List<Bar> bars = new ArrayList<>();
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 0 -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(11).closePrice(11).highPrice(11).lowPrice(11).build()); // 1 -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build()); // 2 -
-        // Potential
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build()); // 3 -
-        // Plateau
-        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build()); // 4 -
-        // Plateau
-        bars.add(new MockBarBuilder(numFactory).openPrice(11).closePrice(11).highPrice(11).lowPrice(11).build()); // 5 -
-        // Down
-        // after
-        // plateau
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 6 -
-        // Down
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 7 -
-        // New
-        // potential
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 8 -
-        // Sharp
-        // down
-        bars.add(new MockBarBuilder(numFactory).openPrice(14).closePrice(14).highPrice(14).lowPrice(14).build()); // 9 -
-        // Higher
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 10
-        // -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build()); // 11
-        // -
-        // Down
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 12
-        // -
-        // Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build()); // 13
-        // -
-        // New
-        // potential
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 14
-        // -
-        // Down
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build()); // 15
-        // -
-        // Equal
-        // high
-        // to
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 16
-        // -
-        // Down
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build()); // 17
-        // -
-        // Equal
-        // high
-        // to
-        // swing
-        // high
-        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build()); // 18
-        // -
-        // Down
-        // movement
+
+        // 0 - Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 1 - Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(11).closePrice(11).highPrice(11).lowPrice(11).build());
+        // 2 - Potential swing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build());
+        // 3 - Plateau
+        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build());
+        // 4 - Plateau
+        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build());
+        // 5 -Down after plateau
+        bars.add(new MockBarBuilder(numFactory).openPrice(11).closePrice(11).highPrice(11).lowPrice(11).build());
+        // 6 -Down movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 7 - New potential swing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
+        // 8 - Sharp down
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 9 - Higher swing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(14).closePrice(14).highPrice(14).lowPrice(14).build());
+        // 10 - Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
+        // 11 - Down movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(12).closePrice(12).highPrice(12).lowPrice(12).build());
+        // 12 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
+        // 13- New potentialswing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build());
+        // 14 - Down movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
+        // 15 - Equal high to swing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build());
+        // 16 - Down movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
+        // 17 - Equal high to swing high
+        bars.add(new MockBarBuilder(numFactory).openPrice(15).closePrice(15).highPrice(15).lowPrice(15).build());
+        // 18 - Down movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(13).closePrice(13).highPrice(13).lowPrice(13).build());
 
         this.series = new MockBarSeriesBuilder().withNumFactory(numFactory).withBars(bars).build();
     }
@@ -240,31 +202,31 @@ public class RecentSwingHighIndicatorTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void testCalculate_OnMovingBarSeries_ReturnsValue() {
-        BarSeries movingSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1).build(); // movingSeries:
-        // [1]
+        // movingSeries: [1]
+        BarSeries movingSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1).build();
         ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
         RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(closePrice, 1, 1, 0);
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(2).build()); // movingSeries:
-        // [1, 2]
+        // movingSeries: [1, 2]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(2).build());
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(3).build()); // movingSeries:
-        // [1, 2,
-        // 3]
+        // movingSeries: [1, 2, 3]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(3).build());
         assertNumEquals(NaN.NaN, swingHighIndicator.getValue(movingSeries.getEndIndex()));
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(2).build()); // movingSeries:
-        // [1, 2,
-        // 3, 2]
+        // movingSeries: [1, 2, 3, 2]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(2).build());
         assertNumEquals(3, swingHighIndicator.getValue(movingSeries.getEndIndex()));
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_SurroundingBarsZero() {
         RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(series, 0);
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
         RecentSwingHighIndicator swingHighIndicator = new RecentSwingHighIndicator(new HighPriceIndicator(series), 1, 1,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RecentSwingLowIndicatorTest.java
@@ -53,71 +53,47 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
     @Before
     public void setUp() {
         List<Bar> bars = new ArrayList<>();
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 0 -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(9).closePrice(9).highPrice(9).lowPrice(9).build()); // 1 -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build()); // 2 -
-        // Potential
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build()); // 3 -
-        // Valley
-        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build()); // 4 -
-        // Valley
-        bars.add(new MockBarBuilder(numFactory).openPrice(9).closePrice(9).highPrice(9).lowPrice(9).build()); // 5 -
-        // Down
-        // after
-        // valley
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 6 -
-        // Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(7).closePrice(7).highPrice(7).lowPrice(7).build()); // 7 - New
-        // potential
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build()); // 8 -
-        // Sharp
-        // up
-        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build()); // 9 -
-        // Lower
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(7).closePrice(7).highPrice(7).lowPrice(7).build()); // 10 -
-        // Normal
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build()); // 11 - Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build()); // 12 -
-        // New
-        // potential
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build()); // 13 - Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build()); // 14 -
-        // Equal
-        // to
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build()); // 15 -
-        // Equal
-        // to
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build()); // 16 - Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build()); // 17 -
-        // Equal
-        // to
-        // swing
-        // low
-        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build()); // 18 - Up
-        // movement
-        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build()); // 19 - Up
-        // movement
+
+        // 0 -Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 1 - Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(9).closePrice(9).highPrice(9).lowPrice(9).build());
+        // 2 - Potential swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build());
+        // 3 -Valley
+        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build());
+        // 4 -Valley
+        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build());
+        // 5 - Down after valley
+        bars.add(new MockBarBuilder(numFactory).openPrice(9).closePrice(9).highPrice(9).lowPrice(9).build());
+        // 6 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 7 - New potential swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(7).closePrice(7).highPrice(7).lowPrice(7).build());
+        // 8 -Sharp up
+        bars.add(new MockBarBuilder(numFactory).openPrice(10).closePrice(10).highPrice(10).lowPrice(10).build());
+        // 9 - Lower swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build());
+        // 10 - Normal movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(7).closePrice(7).highPrice(7).lowPrice(7).build());
+        // 11 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(8).closePrice(8).highPrice(8).lowPrice(8).build());
+        // 12 - New potential swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build());
+        // 13 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build());
+        // 14 -Equal to swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build());
+        // 15 -Equal to swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build());
+        // 16 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build());
+        // 17 - Equal to swing low
+        bars.add(new MockBarBuilder(numFactory).openPrice(5).closePrice(5).highPrice(5).lowPrice(5).build());
+        // 18 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build());
+        // 19 - Up movement
+        bars.add(new MockBarBuilder(numFactory).openPrice(6).closePrice(6).highPrice(6).lowPrice(6).build());
 
         this.series = new MockBarSeriesBuilder().withNumFactory(numFactory).withBars(bars).build();
     }
@@ -236,31 +212,31 @@ public class RecentSwingLowIndicatorTest extends AbstractIndicatorTest<Indicator
 
     @Test
     public void testCalculate_OnMovingBarSeries_ReturnsValue() {
-        BarSeries movingSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).withMaxBarCount(10).build(); // movingSeries:
-        // [10]
+        // movingSeries: [10]
+        BarSeries movingSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).withMaxBarCount(10).build();
         ClosePriceIndicator closePrice = new ClosePriceIndicator(movingSeries);
         RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(closePrice, 1, 1, 0);
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(8).build()); // movingSeries:
-        // [10, 8]
+        // movingSeries: [10, 8]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(8).build());
         assertNumEquals(NaN.NaN, swingLowIndicator.getValue(movingSeries.getEndIndex()));
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(5).build()); // movingSeries:
-        // [10, 8,
-        // 5]
+        // movingSeries: [10, 8, 5]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(5).build());
         assertNumEquals(NaN.NaN, swingLowIndicator.getValue(movingSeries.getEndIndex()));
 
-        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(7).build()); // movingSeries:
-        // [10, 8,
-        // 5, 7]
+        // movingSeries: [10, 8, 5, 7]
+        movingSeries.addBar(new MockBarBuilder(numFactory).closePrice(7).build());
         assertNumEquals(5, swingLowIndicator.getValue(movingSeries.getEndIndex()));
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_SurroundingBarsZero() {
         RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(series, 0);
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_AllowedEqualBarsNegative() {
         RecentSwingLowIndicator swingLowIndicator = new RecentSwingLowIndicator(new LowPriceIndicator(series), 1, 1,

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -26,6 +26,8 @@ package org.ta4j.core.indicators;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+import java.time.Instant;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -58,8 +60,13 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
         randomAccessAfterFourAdditions();
     }
 
+    private Instant getNextEndTime() {
+        var lastBar = data.getLastBar();
+        return lastBar == null ? null : lastBar.getEndTime().plus(lastBar.getTimePeriod());
+    }
+
     private void firstAddition() {
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -75,7 +82,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void secondAddition() {
-        data.barBuilder().closePrice(10.).add();
+        data.barBuilder().closePrice(10.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -91,7 +98,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void thirdAddition() {
-        data.barBuilder().closePrice(20.).add();
+        data.barBuilder().closePrice(20.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -107,7 +114,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void fourthAddition() {
-        data.barBuilder().closePrice(30.).add();
+        data.barBuilder().closePrice(30.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -139,8 +146,8 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void whenBarCountIs1ResultShouldBeIndicatorValue() {
-        data.barBuilder().closePrice(5.).add();
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 1);
         for (int i = 0; i < data.getBarCount(); i++) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertIndicatorEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+import java.time.Instant;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -56,6 +58,11 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
                 .build();
     }
 
+    public Instant getNextEndTime() {
+        var lastBar = data.getLastBar();
+        return lastBar == null ? null : lastBar.getEndTime().plus(lastBar.getTimePeriod());
+    }
+
     @Test
     public void usingBarCount3UsingClosePrice() {
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
@@ -78,7 +85,7 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     @Test
     public void usingBarCount3UsingClosePriceMovingSerie() {
         data.setMaximumBarCount(13);
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/XLSIndicatorTest.java
@@ -23,8 +23,6 @@
  */
 package org.ta4j.core.indicators;
 
-import java.util.function.Function;
-
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.ExternalIndicatorTest;
 import org.ta4j.core.Indicator;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
@@ -26,7 +26,8 @@ package org.ta4j.core.indicators.aroon;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -49,8 +50,9 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
     @Before
     public void init() {
         data = new MockBarSeriesBuilder().withNumFactory(numFactory).withName("Aroon data").build();
+        Instant now = Instant.now();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(1))
+                .endTime(now.plus(Duration.ofDays(1)))
                 .openPrice(168.28)
                 .closePrice(169.87)
                 .highPrice(167.15)
@@ -59,7 +61,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .add();
 
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(2))
+                .endTime((now.plus(Duration.ofDays(2))))
                 .openPrice(168.84)
                 .closePrice(169.36)
                 .highPrice(168.20)
@@ -67,7 +69,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(3))
+                .endTime((now.plus(Duration.ofDays(3))))
                 .openPrice(168.88)
                 .closePrice(169.29)
                 .highPrice(166.41)
@@ -75,7 +77,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(4))
+                .endTime((now.plus(Duration.ofDays(4))))
                 .openPrice(168.00)
                 .closePrice(168.38)
                 .highPrice(166.18)
@@ -83,7 +85,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(5))
+                .endTime((now.plus(Duration.ofDays(5))))
                 .openPrice(166.89)
                 .closePrice(167.70)
                 .highPrice(166.33)
@@ -91,7 +93,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(6))
+                .endTime((now.plus(Duration.ofDays(6))))
                 .openPrice(165.25)
                 .closePrice(168.43)
                 .highPrice(165)
@@ -99,7 +101,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(7))
+                .endTime((now.plus(Duration.ofDays(7))))
                 .openPrice(168.17)
                 .closePrice(170.18)
                 .highPrice(167.63)
@@ -107,7 +109,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(8))
+                .endTime((now.plus(Duration.ofDays(8))))
                 .openPrice(170.42)
                 .closePrice(172.15)
                 .highPrice(170.06)
@@ -115,7 +117,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(9))
+                .endTime(now.plus(Duration.ofDays(9)))
                 .openPrice(172.41)
                 .closePrice(172.92)
                 .highPrice(171.31)
@@ -123,7 +125,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(10))
+                .endTime(now.plus(Duration.ofDays(10)))
                 .openPrice(171.2)
                 .closePrice(172.39)
                 .highPrice(169.55)
@@ -131,7 +133,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(11))
+                .endTime(now.plus(Duration.ofDays(11)))
                 .openPrice(170.91)
                 .closePrice(172.48)
                 .highPrice(169.57)
@@ -139,7 +141,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(12))
+                .endTime(now.plus(Duration.ofDays(12)))
                 .openPrice(171.8)
                 .closePrice(173.31)
                 .highPrice(170.27)
@@ -147,7 +149,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(13))
+                .endTime(now.plus(Duration.ofDays(13)))
                 .openPrice(173.09)
                 .closePrice(173.49)
                 .highPrice(170.8)
@@ -155,7 +157,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(14))
+                .endTime(now.plus(Duration.ofDays(14)))
                 .openPrice(172.41)
                 .closePrice(173.89)
                 .highPrice(172.2)
@@ -163,7 +165,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(15))
+                .endTime(now.plus(Duration.ofDays(15)))
                 .openPrice(173.87)
                 .closePrice(174.17)
                 .highPrice(175)
@@ -171,7 +173,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(16))
+                .endTime(now.plus(Duration.ofDays(16)))
                 .openPrice(173)
                 .closePrice(173.17)
                 .highPrice(172.06)
@@ -179,7 +181,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(17))
+                .endTime(now.plus(Duration.ofDays(17)))
                 .openPrice(172.26)
                 .closePrice(172.28)
                 .highPrice(170.5)
@@ -187,7 +189,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(18))
+                .endTime(now.plus(Duration.ofDays(18)))
                 .openPrice(170.88)
                 .closePrice(172.34)
                 .highPrice(170.26)
@@ -195,7 +197,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(19))
+                .endTime(now.plus(Duration.ofDays(19)))
                 .openPrice(171.85)
                 .closePrice(172.07)
                 .highPrice(169.34)
@@ -203,7 +205,7 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
                 .volume(0)
                 .add();
         data.barBuilder()
-                .endTime(ZonedDateTime.now().plusDays(20))
+                .endTime(now.plus(Duration.ofDays(20)))
                 .openPrice(170.75)
                 .closePrice(172.56)
                 .highPrice(170.36)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
@@ -26,9 +26,9 @@ package org.ta4j.core.indicators.aroon;
 import static org.junit.Assert.assertNotNull;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -209,7 +209,7 @@ public class AroonOscillatorIndicatorTest {
         var dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd", Locale.getDefault());
         for (int i = dataLine.length - 1; i >= 0; i--) {
             String[] tickData = dataLine[i].split(",");
-            ZonedDateTime date = LocalDate.parse(tickData[0], dtf).atStartOfDay(ZoneId.systemDefault());
+            Instant date = LocalDate.parse(tickData[0], dtf).atStartOfDay(ZoneOffset.UTC).toInstant();
             data.barBuilder()
                     .endTime(date)
                     .openPrice(tickData[3])

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonUpIndicatorTest.java
@@ -27,7 +27,8 @@ import static junit.framework.TestCase.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 import static org.ta4j.core.num.NaN.NaN;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -91,9 +92,10 @@ public class AroonUpIndicatorTest {
     @Test
     public void onlyNaNValues() {
         var series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var now = Instant.now();
         for (long i = 0; i <= 1000; i++) {
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(NaN)
                     .closePrice(NaN)
                     .highPrice(NaN)
@@ -111,10 +113,11 @@ public class AroonUpIndicatorTest {
     @Test
     public void naNValuesInInterval() {
         var series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var now = Instant.now();
         for (long i = 0; i <= 10; i++) { // (0, NaN, 2, NaN, 4, NaN, 6, NaN, 8, ...)
             Num highPrice = i % 2 == 0 ? series.numFactory().numOf(i) : NaN;
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(NaN)
                     .closePrice(NaN)
                     .highPrice(highPrice)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/DateTimeIndicatorTest.java
@@ -25,9 +25,7 @@ package org.ta4j.core.indicators.helpers;
 
 import static org.junit.Assert.assertEquals;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
+import java.time.Instant;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
@@ -39,18 +37,17 @@ import org.ta4j.core.num.NumFactory;
 
 public class DateTimeIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_ZONED_DATE_TIME;
-
     public DateTimeIndicatorTest(NumFactory numFactory) {
         super(numFactory);
     }
 
     @Test
     public void test() {
-        ZonedDateTime expectedZonedDateTime = ZonedDateTime.parse("2019-09-17T00:04:00-00:00", DATE_TIME_FORMATTER);
+
+        Instant expectedDateTime = Instant.parse("2019-09-17T00:04:00Z");
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
-        series.barBuilder().endTime(expectedZonedDateTime).add();
+        series.barBuilder().endTime(expectedDateTime).add();
         DateTimeIndicator dateTimeIndicator = new DateTimeIndicator(series, Bar::getEndTime);
-        assertEquals(expectedZonedDateTime, dateTimeIndicator.getValue(0));
+        assertEquals(expectedDateTime, dateTimeIndicator.getValue(0));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/HighestValueIndicatorTest.java
@@ -27,12 +27,11 @@ import static junit.framework.TestCase.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 import static org.ta4j.core.num.NaN.NaN;
 
-import java.time.ZonedDateTime;
-
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
@@ -83,10 +82,11 @@ public class HighestValueIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void onlyNaNValues() {
-        BaseBarSeries series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var now = Instant.now();
         for (long i = 0; i <= 10000; i++) {
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(NaN)
                     .closePrice(NaN)
                     .highPrice(NaN)
@@ -103,11 +103,12 @@ public class HighestValueIndicatorTest extends AbstractIndicatorTest<Indicator<N
 
     @Test
     public void naNValuesInIntervall() {
-        BaseBarSeries series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var series = new MockBarSeriesBuilder().withName("NaN test").build();
+        var now = Instant.now();
         for (long i = 0; i <= 10; i++) { // (0, NaN, 2, NaN, 3, NaN, 4, NaN, 5, ...)
             Num closePrice = i % 2 == 0 ? series.numFactory().numOf(i) : NaN;
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(NaN)
                     .closePrice(closePrice)
                     .highPrice(NaN)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/LowPriceIndicatorTest.java
@@ -46,7 +46,6 @@ public class LowPriceIndicatorTest extends AbstractIndicatorTest<Indicator<Num>,
     @Before
     public void setUp() {
         barSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).withDefaultData().build();
-        ;
         lowPriceIndicator = new LowPriceIndicator(barSeries);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/PreviousValueIndicatorTest.java
@@ -26,7 +26,7 @@ package org.ta4j.core.indicators.helpers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Random;
 
 import org.junit.Before;
@@ -52,13 +52,14 @@ public class PreviousValueIndicatorTest {
     @Before
     public void setUp() {
         var r = new Random();
+        var now = Instant.now();
         this.series = new MockBarSeriesBuilder().withName("test").build();
         for (int i = 0; i < 1000; i++) {
             double open = r.nextDouble();
             double close = r.nextDouble();
             double max = Math.max(close + r.nextDouble(), open + r.nextDouble());
             double min = Math.min(0, Math.min(close - r.nextDouble(), open - r.nextDouble()));
-            ZonedDateTime dateTime = ZonedDateTime.now().minusSeconds(1001 - i);
+            Instant dateTime = now.minusSeconds(1001 - i);
             series.barBuilder()
                     .endTime(dateTime)
                     .openPrice(open)

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/pivotpoints/PivotPointIndicatorTest.java
@@ -37,8 +37,9 @@ import static org.ta4j.core.indicators.pivotpoints.TimeLevel.WEEK;
 import static org.ta4j.core.indicators.pivotpoints.TimeLevel.YEAR;
 import static org.ta4j.core.num.NaN.NaN;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -56,7 +57,6 @@ public class PivotPointIndicatorTest {
 
     @Before
     public void initDataForDailyBarCount() {
-
         String rawData5Minutes = "2017-09-27,22:00:00,167.86,167.949,167.63,167.68,1746768,0\n"
                 + "2017-09-28,15:35:00,167.94,168.37,167.6,168.24,706119,0\n"
                 + "2017-09-28,15:40:00,168.27,168.399,167.16,167.34,501414,0\n"
@@ -608,8 +608,10 @@ public class PivotPointIndicatorTest {
         series5Minutes = new MockBarSeriesBuilder().withName("FB_5_minutes").build();
         for (String aDataLine : dataLine) {
             String[] barData = aDataLine.split(",");
-            ZonedDateTime date = ZonedDateTime.parse(barData[0] + " " + barData[1] + " PST",
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z"));
+            Instant date = ZonedDateTime
+                    .parse(barData[0] + " " + barData[1] + " PST", DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z"))
+                    .toInstant();
+
             double open = Double.parseDouble(barData[2]);
             double high = Double.parseDouble(barData[3]);
             double low = Double.parseDouble(barData[4]);
@@ -809,8 +811,9 @@ public class PivotPointIndicatorTest {
         series1Hours = new MockBarSeriesBuilder().withName("FB_1_hours").build();
         for (String aDataLine : dataLine) {
             String[] barData = aDataLine.split(",");
-            ZonedDateTime date = ZonedDateTime.parse(barData[0] + " " + barData[1] + " PST",
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z"));
+            Instant date = ZonedDateTime
+                    .parse(barData[0] + " " + barData[1] + " PST", DateTimeFormatter.ofPattern("yyyy-MM-dd H:m:s z"))
+                    .toInstant();
             double open = Double.parseDouble(barData[2]);
             double high = Double.parseDouble(barData[3]);
             double low = Double.parseDouble(barData[4]);
@@ -993,8 +996,9 @@ public class PivotPointIndicatorTest {
         series1Days = new MockBarSeriesBuilder().withName("FB_daily").build();
         for (int i = dataLine.length - 1; i >= 0; i--) {
             String[] barData = dataLine[i].split(",");
-            ZonedDateTime date = LocalDate.parse(barData[0], DateTimeFormatter.ofPattern("yyyy/MM/dd"))
-                    .atStartOfDay(ZoneId.systemDefault());
+            Instant date = LocalDate.parse(barData[0], DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant();
             double close = Double.parseDouble(barData[1]);
             double volume = Double.parseDouble(barData[2]);
             double open = Double.parseDouble(barData[3]);
@@ -1300,8 +1304,9 @@ public class PivotPointIndicatorTest {
         series1Weeks = new MockBarSeriesBuilder().withName("FB_daily").build();
         for (String aDataLine : dataLine) {
             String[] barData = aDataLine.split(",");
-            ZonedDateTime date = LocalDate.parse(barData[0], DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-                    .atStartOfDay(ZoneId.systemDefault());
+            Instant date = LocalDate.parse(barData[0], DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                    .atStartOfDay(ZoneOffset.UTC)
+                    .toInstant();
             double open = Double.parseDouble(barData[1]);
             double high = Double.parseDouble(barData[2]);
             double low = Double.parseDouble(barData[3]);
@@ -1333,39 +1338,47 @@ public class PivotPointIndicatorTest {
         assertEquals(pp.getValue(0), NaN);// first bar no data for calculation
         // result of calculation for 7-27 bar is not adequate because the previous day
         // is incomplete..
-        assertNumEquals(Double.valueOf("170.426666"), pp.getValue(170));
-        assertNumEquals(Double.valueOf("169.1266666"), pp.getValue(series5Minutes.getEndIndex() - 80)); // prev last bar
-        assertNumEquals(Double.valueOf("170.383333"), pp.getValue(series5Minutes.getEndIndex())); // last bar
+        assertNumEquals(Double.valueOf("170.91666666666666"), pp.getValue(170));
+        assertNumEquals(Double.valueOf("169.20666666666666666666666666667"),
+                pp.getValue(series5Minutes.getEndIndex() - 80)); // prev last bar
+        assertNumEquals(Double.valueOf("170.07666666666666666666666666667"), pp.getValue(series5Minutes.getEndIndex())); // last
+                                                                                                                         // bar
 
         // s1
         assertEquals(s1.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("167.58333"), s1.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("169.456666666"), s1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("167.74333333333333333333333333334"),
+                s1.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("168.84333333333333333333333333334"), s1.getValue(series5Minutes.getEndIndex()));
 
         // s2
         assertEquals(s2.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("166.746666"), s2.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("167.673333"), s2.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("166.82666666666666666666666666667"),
+                s2.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("167.36666666666666666666666666667"), s2.getValue(series5Minutes.getEndIndex()));
 
         // s3
         assertEquals(s3.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("165.2033"), s3.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("166.74666666"), s3.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("165.36333333333333333333333333334"),
+                s3.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("166.13333333333333333333333333334"), s3.getValue(series5Minutes.getEndIndex()));
 
         // r1
         assertEquals(r1.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("169.963333"), r1.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("172.1666"), r1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("170.12333333333333333333333333334"),
+                r1.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("171.55333333333333333333333333334"), r1.getValue(series5Minutes.getEndIndex()));
 
         // r2
         assertEquals(r2.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("171.5066666"), r2.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("173.09333"), r2.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("171.58666666666666666666666666667"),
+                r2.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("172.78666666666666666666666666667"), r2.getValue(series5Minutes.getEndIndex()));
 
         // r3
         assertEquals(r3.getValue(0), NaN);
-        assertNumEquals(Double.valueOf("172.3433333"), r3.getValue(series5Minutes.getEndIndex() - 80));
-        assertNumEquals(Double.valueOf("174.87666666"), r3.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(Double.valueOf("172.50333333333333333333333333334"),
+                r3.getValue(series5Minutes.getEndIndex() - 80));
+        assertNumEquals(Double.valueOf("174.26333333333333333333333333334"), r3.getValue(series5Minutes.getEndIndex()));
 
         DeMarkPivotPointIndicator deMarkpp = new DeMarkPivotPointIndicator(series5Minutes, DAY);
         DeMarkReversalIndicator deMarkR1 = new DeMarkReversalIndicator(deMarkpp,
@@ -1375,12 +1388,12 @@ public class PivotPointIndicatorTest {
         assertNumEquals(deMarkpp.getValue(0), NaN);
         assertNumEquals(deMarkR1.getValue(0), NaN);
         assertNumEquals(deMarkS1.getValue(0), NaN);
-        assertNumEquals(170.735, deMarkpp.getValue(222));
-        assertNumEquals(172.66, deMarkR1.getValue(222));
-        assertNumEquals(169.81, deMarkS1.getValue(222));
-        assertNumEquals(170.615, deMarkpp.getValue(series5Minutes.getEndIndex()));
-        assertNumEquals(172.63, deMarkR1.getValue(series5Minutes.getEndIndex()));
-        assertNumEquals(169.92, deMarkS1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(170.7875, deMarkpp.getValue(222));
+        assertNumEquals(171.3250, deMarkR1.getValue(222));
+        assertNumEquals(169.7050, deMarkS1.getValue(222));
+        assertNumEquals(170.385, deMarkpp.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(172.170, deMarkR1.getValue(series5Minutes.getEndIndex()));
+        assertNumEquals(169.460, deMarkS1.getValue(series5Minutes.getEndIndex()));
 
     }
 
@@ -1489,23 +1502,23 @@ public class PivotPointIndicatorTest {
 
         // pp
         assertEquals(pp.getValue(0), NaN);
-        assertEquals(pp.getValue(19), NaN); // no previous month for calculation
-        assertNumEquals(Double.valueOf("126.32333"), pp.getValue(20));
-        assertNumEquals(Double.valueOf("134.3415333"), pp.getValue(39));
-        assertNumEquals(Double.valueOf("150.67999"), pp.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("164.18000"), pp.getValue(series1Days.getEndIndex()));
+        assertEquals(pp.getValue(19), NaN);
+        assertNumEquals(pp.getValue(19), NaN); // no previous month for calculation
+        assertNumEquals(Double.valueOf("134.34153333333333333333333333333"), pp.getValue(39));
+        assertNumEquals(Double.valueOf("150.68"), pp.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.valueOf("164.18"), pp.getValue(series1Days.getEndIndex()));
 
         // s1
         assertEquals(s1.getValue(0), NaN);
         assertEquals(s1.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("144.8599999"), s1.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.valueOf("144.86"), s1.getValue(series1Days.getEndIndex() - 19));
         assertNumEquals(Double.valueOf("152.87"), s1.getValue(series1Days.getEndIndex()));
 
         // s2
         assertEquals(s2.getValue(0), NaN);
         assertEquals(s2.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("138.73999999"), s2.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("136.49000"), s2.getValue(series1Days.getEndIndex()));
+        assertNumEquals(Double.valueOf("138.74"), s2.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.valueOf("136.49"), s2.getValue(series1Days.getEndIndex()));
 
         // s3
         assertEquals(s3.getValue(0), NaN);
@@ -1516,21 +1529,20 @@ public class PivotPointIndicatorTest {
         // r1
         assertEquals(r1.getValue(0), NaN);
         assertEquals(r1.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("156.79999"), r1.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("180.56000"), r1.getValue(series1Days.getEndIndex()));
+        assertNumEquals(Double.valueOf("156.80"), r1.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.valueOf("180.56"), r1.getValue(series1Days.getEndIndex()));
 
         // r2
-        assertEquals(r2.getValue(0), NaN);
-        assertEquals(r2.getValue(19), NaN); // no previous month
-        assertNumEquals(Double.valueOf("162.61999"), r2.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("191.87000"), r2.getValue(series1Days.getEndIndex()));
+        assertEquals(r3.getValue(0), NaN);
+        assertEquals(r3.getValue(19), NaN); // no previous month
+        assertNumEquals(Double.valueOf("162.62"), r2.getValue(series1Days.getEndIndex() - 19));
+        assertNumEquals(Double.valueOf("191.87"), r2.getValue(series1Days.getEndIndex()));
 
         // r3
         assertEquals(r3.getValue(0), NaN);
         assertEquals(r3.getValue(19), NaN); // no previous month
         assertNumEquals(Double.valueOf("168.74"), r3.getValue(series1Days.getEndIndex() - 19));
-        assertNumEquals(Double.valueOf("208.25000"), r3.getValue(series1Days.getEndIndex()));
-
+        assertNumEquals(Double.valueOf("208.25"), r3.getValue(series1Days.getEndIndex()));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
@@ -26,7 +26,7 @@ package org.ta4j.core.indicators.statistics;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -49,29 +49,31 @@ public class CorrelationCoefficientIndicatorTest extends AbstractIndicatorTest<I
 
     @Before
     public void setUp() {
-        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         int i = 20;
+        var now = Instant.now();
+        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+
         // close, volume
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(6).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(7).volume(105).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(10).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(13).volume(120).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(15).volume(180).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(200).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(85).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(70).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(5).volume(90).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(110).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i)).closePrice(10).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(6).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(7).volume(105).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(10).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(13).volume(120).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(15).volume(180).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(200).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(85).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(70).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(5).volume(90).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(110).add();
+        data.barBuilder().endTime(now.minusSeconds(i)).closePrice(10).volume(95).add();
 
         close = new ClosePriceIndicator(data);
         volume = new VolumeIndicator(data, 2);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CovarianceIndicatorTest.java
@@ -25,7 +25,7 @@ package org.ta4j.core.indicators.statistics;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,28 +48,30 @@ public class CovarianceIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
     @Before
     public void setUp() {
-        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         int i = 20;
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(6).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(7).volume(105).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(10).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(13).volume(120).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(15).volume(180).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(200).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(85).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(70).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(5).volume(90).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(110).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i)).closePrice(10).volume(95).add();
+        var now = Instant.now();
+        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(6).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(7).volume(105).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(10).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(13).volume(120).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(15).volume(180).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(200).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(85).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(70).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(5).volume(90).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(110).add();
+        data.barBuilder().endTime(now.minusSeconds(i)).closePrice(10).volume(95).add();
         close = new ClosePriceIndicator(data);
         volume = new VolumeIndicator(data, 2);
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/PearsonCorrelationIndicatorTest.java
@@ -25,7 +25,7 @@ package org.ta4j.core.indicators.statistics;
 
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,29 +48,31 @@ public class PearsonCorrelationIndicatorTest extends AbstractIndicatorTest<Indic
 
     @Before
     public void setUp() {
-        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         int i = 20;
+        var now = Instant.now();
+        BarSeries data = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+
         // close, volume
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(6).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(7).volume(105).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(10).volume(130).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(13).volume(120).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(15).volume(180).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(12).volume(160).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(200).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(150).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(4).volume(85).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(3).volume(70).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(5).volume(90).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(8).volume(100).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(9).volume(95).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i--)).closePrice(11).volume(110).add();
-        data.barBuilder().endTime(ZonedDateTime.now().minusSeconds(i)).closePrice(10).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(6).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(7).volume(105).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(10).volume(130).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(13).volume(120).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(15).volume(180).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(12).volume(160).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(200).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(150).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(4).volume(85).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(3).volume(70).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(5).volume(90).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(8).volume(100).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(9).volume(95).add();
+        data.barBuilder().endTime(now.minusSeconds(i--)).closePrice(11).volume(110).add();
+        data.barBuilder().endTime(now.minusSeconds(i)).closePrice(10).volume(95).add();
 
         close = new ClosePriceIndicator(data);
         volume = new VolumeIndicator(data, 2);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -62,7 +62,6 @@ public class SuperTrendIndicatorTest {
         data.barBuilder().openPrice(19.28).closePrice(10.34).highPrice(20.58).lowPrice(10.11).add();
         data.barBuilder().openPrice(10.34).closePrice(9.83).highPrice(12.80).lowPrice(8.83).add();
         data.barBuilder().openPrice(11.83).closePrice(7.35).highPrice(11.41).lowPrice(5.01).add();
-
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -57,7 +57,6 @@ public class SuperTrendUpperBandIndicatorTest {
         data.barBuilder().openPrice(19.00).closePrice(18.35).highPrice(19.41).lowPrice(18.01).add();
         data.barBuilder().openPrice(19.89).closePrice(6.36).highPrice(20.22).lowPrice(6.21).add();
         data.barBuilder().openPrice(19.28).closePrice(10.34).highPrice(20.58).lowPrice(10.11).add();
-
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
@@ -26,8 +26,7 @@ package org.ta4j.core.mocks;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.BaseBarConvertibleBuilder;
@@ -38,7 +37,7 @@ import org.ta4j.core.num.NumFactory;
  */
 public class MockBarBuilder extends BaseBarConvertibleBuilder {
 
-    private Clock clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
+    private Clock clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneOffset.UTC);
     private boolean periodSet;
     private boolean endTimeSet;
 
@@ -50,7 +49,7 @@ public class MockBarBuilder extends BaseBarConvertibleBuilder {
     }
 
     @Override
-    public BaseBarConvertibleBuilder endTime(final ZonedDateTime endTime) {
+    public BaseBarConvertibleBuilder endTime(final Instant endTime) {
         endTimeSet = true;
         return super.endTime(endTime);
     }
@@ -69,7 +68,7 @@ public class MockBarBuilder extends BaseBarConvertibleBuilder {
         }
 
         if (!endTimeSet) {
-            endTime(ZonedDateTime.now(Clock.offset(clock, timePeriod.multipliedBy(++countOfProducedBars))));
+            endTime(Instant.now(Clock.offset(clock, timePeriod.multipliedBy(++countOfProducedBars))));
         }
         return super.build();
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeriesBuilder.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeriesBuilder.java
@@ -23,7 +23,8 @@
  */
 package org.ta4j.core.mocks;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
@@ -70,9 +71,10 @@ public class MockBarSeriesBuilder extends BaseBarSeriesBuilder {
     }
 
     private static void doublesToBars(final BarSeries series, final List<Double> data) {
+        var now = Instant.now();
         for (int i = 0; i < data.size(); i++) {
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().minusMinutes((data.size() + 1 - i)))
+                    .endTime(now.minus(Duration.ofMinutes((data.size() + 1 - i))))
                     .closePrice(data.get(i))
                     .openPrice(0)
                     .add();
@@ -85,9 +87,10 @@ public class MockBarSeriesBuilder extends BaseBarSeriesBuilder {
     }
 
     private static void arbitraryBars(final BarSeries series) {
+        var now = Instant.now();
         for (double i = 0d; i < 5000; i++) {
             series.barBuilder()
-                    .endTime(ZonedDateTime.now().minusMinutes((long) (5001 - i)))
+                    .endTime(now.minus(Duration.ofMinutes((long) (5001 - i))))
                     .openPrice(i)
                     .closePrice(i + 1)
                     .highPrice(i + 2)

--- a/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/num/DecimalNumTest.java
@@ -31,7 +31,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -120,7 +120,7 @@ public class DecimalNumTest {
 
     private void init() {
         final Duration timePeriod = Duration.ofDays(1);
-        ZonedDateTime endTime = ZonedDateTime.now();
+        Instant endTime = Instant.now();
         final double[] deltas = { 20.8, 30.1, -15.3, 10.2, -16.7, -9.8 };
         Num superPrecisionNum = FIRST_SUPER_PRECISION_NUM;
         this.superPrecisionSeries = new BaseBarSeriesBuilder().withName("superPrecision")

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopGainRuleTest.java
@@ -26,7 +26,8 @@ package org.ta4j.core.rules;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class AverageTrueRangeStopGainRuleTest {
         series = new MockBarSeriesBuilder().withName("Test Series").build();
 
         series.barBuilder()
-                .endTime(ZonedDateTime.now())
+                .endTime(Instant.now())
                 .openPrice(10)
                 .highPrice(12)
                 .lowPrice(8)
@@ -52,7 +53,7 @@ public class AverageTrueRangeStopGainRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(11)
                 .highPrice(13)
                 .lowPrice(9)
@@ -60,7 +61,7 @@ public class AverageTrueRangeStopGainRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(12)
                 .highPrice(14)
                 .lowPrice(10)
@@ -68,7 +69,7 @@ public class AverageTrueRangeStopGainRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(13)
                 .highPrice(15)
                 .lowPrice(11)
@@ -76,7 +77,7 @@ public class AverageTrueRangeStopGainRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(14)
                 .highPrice(16)
                 .lowPrice(12)
@@ -97,7 +98,7 @@ public class AverageTrueRangeStopGainRuleTest {
 
         // Simulate a price rise to trigger stop gain
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(16)
                 .closePrice(19)
                 .lowPrice(15)
@@ -119,7 +120,7 @@ public class AverageTrueRangeStopGainRuleTest {
 
         // Simulate a price drop to trigger stop gain
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(7)
                 .highPrice(8)
                 .lowPrice(4)

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeStopLossRuleTest.java
@@ -26,7 +26,8 @@ package org.ta4j.core.rules;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,11 +52,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testLongPositionStopLoss() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)
@@ -72,7 +73,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price remains above stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(90)
                 .highPrice(95)
                 .lowPrice(85)
@@ -82,7 +83,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price drops below stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(90)
                 .highPrice(95)
                 .lowPrice(85)
@@ -93,11 +94,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testShortPositionStopLoss() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)
@@ -114,7 +115,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price below stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(110)
                 .highPrice(123)
                 .lowPrice(113)
@@ -124,7 +125,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price rises above stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(110)
                 .highPrice(127)
                 .lowPrice(117)
@@ -135,11 +136,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testNoStopLoss() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)
@@ -155,7 +156,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price stays within stop loss range
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(98)
                 .highPrice(102)
                 .lowPrice(97)
@@ -167,11 +168,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testCustomReferencePrice() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)
@@ -188,7 +189,7 @@ public class AverageTrueRangeStopLossRuleTest {
 
         // Price drops below stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(90)
                 .highPrice(90)
                 .lowPrice(73)
@@ -199,11 +200,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testNoTradingRecord() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)
@@ -218,11 +219,11 @@ public class AverageTrueRangeStopLossRuleTest {
 
     @Test
     public void testClosedPosition() {
-        var initialEndDateTime = ZonedDateTime.now();
+        var now = Instant.now();
 
         for (int i = 0; i < 10; i++) {
             series.barBuilder()
-                    .endTime(initialEndDateTime.plusDays(i))
+                    .endTime(now.plus(Duration.ofDays(i)))
                     .openPrice(100)
                     .highPrice(105)
                     .lowPrice(95)

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/AverageTrueRangeTrailingStopLossRuleTest.java
@@ -26,7 +26,8 @@ package org.ta4j.core.rules;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
         series = new MockBarSeriesBuilder().withName("Test Series").build();
 
         series.barBuilder()
-                .endTime(ZonedDateTime.now())
+                .endTime(Instant.now())
                 .openPrice(10)
                 .highPrice(12)
                 .lowPrice(8)
@@ -52,7 +53,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(11)
                 .highPrice(13)
                 .lowPrice(9)
@@ -60,7 +61,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(12)
                 .highPrice(14)
                 .lowPrice(10)
@@ -68,7 +69,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(13)
                 .highPrice(15)
                 .lowPrice(11)
@@ -76,7 +77,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
                 .volume(1000)
                 .add();
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(14)
                 .highPrice(16)
                 .lowPrice(12)
@@ -97,7 +98,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
 
         // Simulate a price drop to trigger stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(11)
                 .highPrice(12)
                 .lowPrice(9)
@@ -119,7 +120,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
 
         // Simulate a price increase to trigger stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(15)
                 .highPrice(16)
                 .lowPrice(14)
@@ -154,7 +155,7 @@ public class AverageTrueRangeTrailingStopLossRuleTest {
 
         // Simulate a price drop to trigger stop loss
         series.barBuilder()
-                .endTime(series.getLastBar().getEndTime().plusDays(1))
+                .endTime(series.getLastBar().getEndTime().plus(Duration.ofDays(1)))
                 .openPrice(11)
                 .highPrice(12)
                 .lowPrice(9)

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -27,9 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.time.DayOfWeek;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
+import java.time.Instant;
 import org.junit.Test;
 import org.ta4j.core.Bar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
@@ -45,15 +43,15 @@ public class DayOfWeekRuleTest extends AbstractIndicatorTest<Object, Object> {
 
     @Test
     public void isSatisfied() {
-        final DateTimeFormatter dtf = DateTimeFormatter.ISO_ZONED_DATE_TIME;
         final var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-16T12:00:00-00:00", dtf)).add(); // Index=0, Mon
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T12:00:00-00:00", dtf)).add(); // 1, Tue
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-18T12:00:00-00:00", dtf)).add(); // 2, Wed
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-19T12:00:00-00:00", dtf)).add(); // 3, Thu
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-20T12:00:00-00:00", dtf)).add(); // 4, Fri
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-21T12:00:00-00:00", dtf)).add(); // 5, Sat
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-22T12:00:00-00:00", dtf)).add(); // 6, Sun
+
+        series.barBuilder().endTime(Instant.parse("2019-09-16T12:00:00Z")).add(); // Index=0, Mon
+        series.barBuilder().endTime(Instant.parse("2019-09-17T12:00:00Z")).add(); // 1, Tue
+        series.barBuilder().endTime(Instant.parse("2019-09-18T12:00:00Z")).add(); // 2, Wed
+        series.barBuilder().endTime(Instant.parse("2019-09-19T12:00:00Z")).add(); // 3, Thu
+        series.barBuilder().endTime(Instant.parse("2019-09-20T12:00:00Z")).add(); // 4, Fri
+        series.barBuilder().endTime(Instant.parse("2019-09-21T12:00:00Z")).add(); // 5, Sat
+        series.barBuilder().endTime(Instant.parse("2019-09-22T12:00:00Z")).add(); // 6, Sun
         var dateTime = new DateTimeIndicator(series, Bar::getEndTime);
         DayOfWeekRule rule = new DayOfWeekRule(dateTime, DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
                 DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TimeRangeRuleTest.java
@@ -26,10 +26,9 @@ package org.ta4j.core.rules;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
 import java.time.LocalTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.ta4j.core.Bar;
@@ -46,29 +45,28 @@ public class TimeRangeRuleTest extends AbstractIndicatorTest<Object, Object> {
 
     @Test
     public void isSatisfiedForBuy() {
-        final DateTimeFormatter dtf = DateTimeFormatter.ISO_ZONED_DATE_TIME;
         final var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
 
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T00:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T05:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T07:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T08:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T15:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T15:05:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T16:59:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T17:05:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T23:00:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T23:30:00-00:00", dtf)).closePrice(100).add();
-        series.barBuilder().endTime(ZonedDateTime.parse("2019-09-17T23:35:00-00:00", dtf)).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T00:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T05:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T07:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T08:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T15:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T15:05:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T16:59:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T17:05:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T23:00:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T23:30:00Z")).closePrice(100).add();
+        series.barBuilder().endTime(Instant.parse("2019-09-17T23:35:00Z")).closePrice(100).add();
 
         var dateTimeIndicator = new DateTimeIndicator(series, Bar::getBeginTime);
-        TimeRangeRule rule = new TimeRangeRule(
-                Arrays.asList(new TimeRangeRule.TimeRange(LocalTime.of(0, 0), LocalTime.of(4, 0)),
-                        new TimeRangeRule.TimeRange(LocalTime.of(6, 0), LocalTime.of(7, 0)),
-                        new TimeRangeRule.TimeRange(LocalTime.of(12, 0), LocalTime.of(15, 0)),
-                        new TimeRangeRule.TimeRange(LocalTime.of(17, 0), LocalTime.of(21, 0)),
-                        new TimeRangeRule.TimeRange(LocalTime.of(22, 0), LocalTime.of(23, 30))),
-                dateTimeIndicator);
+        var _00_04 = new TimeRangeRule.TimeRange(LocalTime.of(0, 0), LocalTime.of(4, 0));
+        var _06_07 = new TimeRangeRule.TimeRange(LocalTime.of(6, 0), LocalTime.of(7, 0));
+        var _12_15 = new TimeRangeRule.TimeRange(LocalTime.of(12, 0), LocalTime.of(15, 0));
+        var _17_21 = new TimeRangeRule.TimeRange(LocalTime.of(17, 0), LocalTime.of(21, 0));
+        var _22_2330 = new TimeRangeRule.TimeRange(LocalTime.of(22, 0), LocalTime.of(23, 30));
+        var allRanges = List.of(_00_04, _06_07, _12_15, _17_21, _22_2330);
+        TimeRangeRule rule = new TimeRangeRule(allRanges, dateTimeIndicator);
 
         assertTrue(rule.isSatisfied(0, null));
         assertFalse(rule.isSatisfied(1, null));

--- a/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/utils/BarSeriesUtilsTest.java
@@ -27,8 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +50,7 @@ import org.ta4j.core.num.NumFactory;
 public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     private BarSeries series;
-    private ZonedDateTime time;
+    private Instant time;
 
     public BarSeriesUtilsTest(final NumFactory numFactory) {
         super(numFactory);
@@ -64,7 +63,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     public void replaceBarIfChangedTest() {
 
         final List<Bar> bars = new ArrayList<>();
-        this.time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
+        this.time = Instant.parse("2019-06-01T01:01:00Z");
 
         final Bar bar0 = new MockBarBuilder(numFactory).endTime(time)
                 .openPrice(1d)
@@ -76,7 +75,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(7)
                 .build();
 
-        final Bar bar1 = new MockBarBuilder(numFactory).endTime(time.plusDays(1))
+        final Bar bar1 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -86,7 +85,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(1)
                 .build();
 
-        final Bar bar2 = new MockBarBuilder(numFactory).endTime(time.plusDays(2))
+        final Bar bar2 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(2d)
                 .closePrice(2d)
                 .highPrice(2d)
@@ -96,7 +95,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(2)
                 .build();
 
-        final Bar bar3 = new MockBarBuilder(numFactory).endTime(time.plusDays(3))
+        final Bar bar3 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(3)))
                 .openPrice(3d)
                 .closePrice(3d)
                 .highPrice(3d)
@@ -106,7 +105,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(3)
                 .build();
 
-        final Bar bar4 = new MockBarBuilder(numFactory).endTime(time.plusDays(4))
+        final Bar bar4 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(4)))
                 .openPrice(3d)
                 .closePrice(4d)
                 .highPrice(5d)
@@ -116,7 +115,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(4)
                 .build();
 
-        final Bar bar5 = new MockBarBuilder(numFactory).endTime(time.plusDays(5))
+        final Bar bar5 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(5)))
                 .openPrice(4d)
                 .closePrice(5d)
                 .highPrice(5d)
@@ -126,7 +125,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(5)
                 .build();
 
-        final Bar bar6 = new MockBarBuilder(numFactory).endTime(time.plusDays(6))
+        final Bar bar6 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(6)))
                 .openPrice(6d)
                 .closePrice(6d)
                 .highPrice(6d)
@@ -198,7 +197,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     public void findMissingBarsTest() {
 
         final List<Bar> bars = new ArrayList<>();
-        this.time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
+        this.time = Instant.parse("2019-06-01T01:01:00Z");
 
         final Bar bar0 = new MockBarBuilder(this.numFactory).endTime(this.time)
                 .openPrice(1d)
@@ -210,7 +209,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(7)
                 .build();
 
-        final Bar bar1 = new MockBarBuilder(this.numFactory).endTime(this.time.plusDays(1))
+        final Bar bar1 = new MockBarBuilder(this.numFactory).endTime(this.time.plus(Duration.ofDays(1)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -220,7 +219,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(1)
                 .build();
 
-        final Bar bar4 = new MockBarBuilder(this.numFactory).endTime(this.time.plusDays(4))
+        final Bar bar4 = new MockBarBuilder(this.numFactory).endTime(this.time.plus(Duration.ofDays(4)))
                 .openPrice(3d)
                 .closePrice(4d)
                 .highPrice(4d)
@@ -230,7 +229,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(4)
                 .build();
 
-        final Bar bar5 = new MockBarBuilder(this.numFactory).endTime(this.time.plusDays(5))
+        final Bar bar5 = new MockBarBuilder(this.numFactory).endTime(this.time.plus(Duration.ofDays(5)))
                 .openPrice(5d)
                 .closePrice(5d)
                 .highPrice(5d)
@@ -240,7 +239,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(5)
                 .build();
 
-        final Bar bar7 = new MockBarBuilder(this.numFactory).endTime(this.time.plusDays(7))
+        final Bar bar7 = new MockBarBuilder(this.numFactory).endTime(this.time.plus(Duration.ofDays(7)))
                 .openPrice(0d)
                 .closePrice(0d)
                 .highPrice(0d)
@@ -251,7 +250,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         final Bar bar8 = new MockBarBuilder(this.numFactory).timePeriod(Duration.ofDays(1))
-                .endTime(this.time.plusDays(8))
+                .endTime(this.time.plus(Duration.ofDays(8)))
                 .openPrice(NaN.NaN)
                 .highPrice(NaN.NaN)
                 .lowPrice(NaN.NaN)
@@ -270,12 +269,12 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         bars.forEach(series::addBar);
 
         // return the beginTime of each missing bar
-        final List<ZonedDateTime> missingBars = BarSeriesUtils.findMissingBars(this.series, false);
+        final List<Instant> missingBars = BarSeriesUtils.findMissingBars(this.series, false);
 
         // there must be 3 missing bars (bar2, bar3, bar6)
-        assertEquals(missingBars.get(0), this.time.plusDays(2));
-        assertEquals(missingBars.get(1), this.time.plusDays(3));
-        assertEquals(missingBars.get(2), this.time.plusDays(6));
+        assertEquals(missingBars.get(0), this.time.plus(Duration.ofDays(2)));
+        assertEquals(missingBars.get(1), this.time.plus(Duration.ofDays(3)));
+        assertEquals(missingBars.get(2), this.time.plus(Duration.ofDays(6)));
         // there must be 1 bar with invalid data (e.g. price, volume)
         assertEquals(missingBars.get(3), bar8.getEndTime());
     }
@@ -332,7 +331,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
     public void findOverlappingBarsTest() {
 
         final List<Bar> bars = new ArrayList<>();
-        this.time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
+        this.time = Instant.parse("2019-06-01T01:01:00Z");
 
         final Bar bar0 = new MockBarBuilder(numFactory).endTime(time)
                 .openPrice(1d)
@@ -355,7 +354,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         final Bar bar8 = new MockBarBuilder(numFactory).timePeriod(Duration.ofDays(1))
-                .endTime(time.plusDays(8))
+                .endTime(time.plus(Duration.ofDays(3)))
                 .openPrice(NaN.NaN)
                 .closePrice(NaN.NaN)
                 .highPrice(NaN.NaN)
@@ -383,7 +382,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         final var barSeries = new MockBarSeriesBuilder().withName("1day").build();
 
         final List<Bar> bars = new ArrayList<>();
-        this.time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
+        this.time = Instant.parse("2019-06-01T01:01:00Z");
 
         final Bar bar0 = barSeries.barBuilder()
                 .endTime(time)
@@ -397,7 +396,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         final Bar bar1 = barSeries.barBuilder()
-                .endTime(time.plusDays(1))
+                .endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -408,7 +407,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .build();
 
         final Bar bar2 = barSeries.barBuilder()
-                .endTime(time.plusDays(2))
+                .endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -429,7 +428,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(bar2.getEndTime(), barSeries.getLastBar().getEndTime());
 
         final Bar bar3 = barSeries.barBuilder()
-                .endTime(time.plusDays(3))
+                .endTime(time.plus(Duration.ofDays(3)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -448,7 +447,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void sortBars() {
-        this.time = ZonedDateTime.of(2019, 6, 1, 1, 1, 0, 0, ZoneId.systemDefault());
+        this.time = Instant.parse("2019-06-01T01:01:00Z");
 
         final Bar bar0 = new MockBarBuilder(numFactory).endTime(time)
                 .openPrice(1d)
@@ -460,7 +459,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(7)
                 .build();
 
-        final Bar bar1 = new MockBarBuilder(numFactory).endTime(time.plusDays(1))
+        final Bar bar1 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(1)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -470,7 +469,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(1)
                 .build();
 
-        final Bar bar2 = new MockBarBuilder(numFactory).endTime(time.plusDays(2))
+        final Bar bar2 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(2)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)
@@ -480,7 +479,7 @@ public class BarSeriesUtilsTest extends AbstractIndicatorTest<BarSeries, Num> {
                 .trades(1)
                 .build();
 
-        final Bar bar3 = new MockBarBuilder(numFactory).endTime(time.plusDays(3))
+        final Bar bar3 = new MockBarBuilder(numFactory).endTime(time.plus(Duration.ofDays(3)))
                 .openPrice(1d)
                 .closePrice(1d)
                 .highPrice(1d)

--- a/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java
@@ -25,11 +25,11 @@ package ta4jexamples;
 
 import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.AnalysisCriterion.PositionFilter;
-import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseStrategy;
 import org.ta4j.core.Rule;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.criteria.PositionsRatioCriterion;
 import org.ta4j.core.criteria.ReturnOverMaxDrawdownCriterion;
 import org.ta4j.core.criteria.VersusEnterAndHoldCriterion;

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/BuyAndSellSignalsToChart.java
@@ -71,8 +71,7 @@ public class BuyAndSellSignalsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barSeries.getBarCount(); i++) {
             Bar bar = barSeries.getBar(i);
-            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime().toInstant())),
-                    indicator.getValue(i).doubleValue());
+            chartTimeSeries.add(new Minute(Date.from(bar.getEndTime())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }
@@ -92,16 +91,14 @@ public class BuyAndSellSignalsToChart {
         // Adding markers to plot
         for (Position position : positions) {
             // Buy signal
-            double buySignalBarTime = new Minute(
-                    Date.from(series.getBar(position.getEntry().getIndex()).getEndTime().toInstant()))
+            double buySignalBarTime = new Minute(Date.from(series.getBar(position.getEntry().getIndex()).getEndTime()))
                     .getFirstMillisecond();
             Marker buyMarker = new ValueMarker(buySignalBarTime);
             buyMarker.setPaint(Color.GREEN);
             buyMarker.setLabel("B");
             plot.addDomainMarker(buyMarker);
             // Sell signal
-            double sellSignalBarTime = new Minute(
-                    Date.from(series.getBar(position.getExit().getIndex()).getEndTime().toInstant()))
+            double sellSignalBarTime = new Minute(Date.from(series.getBar(position.getExit().getIndex()).getEndTime()))
                     .getFirstMillisecond();
             Marker sellMarker = new ValueMarker(sellSignalBarTime);
             sellMarker.setPaint(Color.RED);

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java
@@ -70,7 +70,7 @@ public class CashFlowToChart {
         org.jfree.data.time.TimeSeries chartBarSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barSeries.getBarCount(); i++) {
             Bar bar = barSeries.getBar(i);
-            chartBarSeries.add(new Minute(new Date(bar.getEndTime().toEpochSecond() * 1000)),
+            chartBarSeries.add(new Minute(new Date(bar.getEndTime().toEpochMilli())),
                     indicator.getValue(i).doubleValue());
         }
         return chartBarSeries;

--- a/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/analysis/StrategyAnalysis.java
@@ -24,10 +24,10 @@
 package ta4jexamples.analysis;
 
 import org.ta4j.core.AnalysisCriterion.PositionFilter;
-import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.criteria.AverageReturnPerBarCriterion;
 import org.ta4j.core.criteria.EnterAndHoldCriterion;
 import org.ta4j.core.criteria.LinearTransactionCostCriterion;

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageBacktest.java
@@ -24,7 +24,8 @@
 package ta4jexamples.backtesting;
 
 import java.time.Duration;
-import java.time.ZoneId;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import org.ta4j.core.BarSeries;
@@ -82,7 +83,7 @@ public class SimpleMovingAverageBacktest {
         return series;
     }
 
-    private static BaseBar createBar(BaseBarConvertibleBuilder barBuilder, ZonedDateTime endTime, Number openPrice,
+    private static BaseBar createBar(BaseBarConvertibleBuilder barBuilder, Instant endTime, Number openPrice,
             Number highPrice, Number lowPrice, Number closePrice, Number volume) {
         return barBuilder.timePeriod(Duration.ofDays(1))
                 .endTime(endTime)
@@ -94,8 +95,8 @@ public class SimpleMovingAverageBacktest {
                 .build();
     }
 
-    private static ZonedDateTime createDay(int day) {
-        return ZonedDateTime.of(2018, 01, day, 12, 0, 0, 0, ZoneId.systemDefault());
+    private static Instant createDay(int day) {
+        return ZonedDateTime.of(2018, 01, day, 12, 0, 0, 0, ZoneOffset.UTC).toInstant();
     }
 
     private static Strategy create3DaySmaStrategy(BarSeries series) {

--- a/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/barSeries/BuildBarSeries.java
@@ -24,7 +24,7 @@
 package ta4jexamples.barSeries;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,15 +59,15 @@ public class BuildBarSeries {
     private static BarSeries buildAndAddData() {
         var series = new BaseBarSeriesBuilder().withName("mySeries").build();
 
-        var endTime = ZonedDateTime.now();
-        // ZonedDateTime endTime, Number openPrice, Number highPrice, Number lowPrice,
+        var endTime = Instant.now();
+        // Instant endTime, Number openPrice, Number highPrice, Number lowPrice,
         // Number closePrice, volume
         addBars(series, endTime);
 
         return series;
     }
 
-    private static void addBars(final BarSeries series, final ZonedDateTime endTime) {
+    private static void addBars(final BarSeries series, final Instant endTime) {
         series.addBar(series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
                 .endTime(endTime)
@@ -79,7 +79,7 @@ public class BuildBarSeries {
                 .build());
         series.addBar(series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(1))
+                .endTime(endTime.plus(Duration.ofDays(1)))
                 .openPrice(111.43)
                 .highPrice(112.83)
                 .lowPrice(107.77)
@@ -88,7 +88,7 @@ public class BuildBarSeries {
                 .build());
         series.addBar(series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(2))
+                .endTime(endTime.plus(Duration.ofDays(2)))
                 .openPrice(107.90)
                 .highPrice(117.50)
                 .lowPrice(107.90)
@@ -102,7 +102,7 @@ public class BuildBarSeries {
                 .withNumFactory(DoubleNumFactory.getInstance())
                 .build();
 
-        var endTime = ZonedDateTime.now();
+        var endTime = Instant.now();
         addBars(series, endTime);
 
         return series;
@@ -113,7 +113,7 @@ public class BuildBarSeries {
                 .withNumFactory(DecimalNumFactory.getInstance())
                 .build();
 
-        ZonedDateTime endTime = ZonedDateTime.now();
+        var endTime = Instant.now();
         addBars(series, endTime);
         // ...
 
@@ -123,7 +123,7 @@ public class BuildBarSeries {
     private static BarSeries buildManually() {
         var series = new BaseBarSeriesBuilder().withName("mySeries").build(); // uses BigDecimalNum
 
-        ZonedDateTime endTime = ZonedDateTime.now();
+        var endTime = Instant.now();
         addBars(series, endTime);
         // ...
 
@@ -134,7 +134,7 @@ public class BuildBarSeries {
         var series = new BaseBarSeriesBuilder().withName("mySeries")
                 .withNumFactory(DoubleNumFactory.getInstance())
                 .build();
-        ZonedDateTime endTime = ZonedDateTime.now();
+        var endTime = Instant.now();
         addBars(series, endTime);
         // ...
 
@@ -148,7 +148,7 @@ public class BuildBarSeries {
 
         // create bars and add them to the series. The bars have the same Num type
         // as the series
-        ZonedDateTime endTime = ZonedDateTime.now();
+        var endTime = Instant.now();
         Bar b1 = series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
                 .endTime(endTime)
@@ -160,7 +160,7 @@ public class BuildBarSeries {
                 .build();
         Bar b2 = series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(1))
+                .endTime(endTime.plus(Duration.ofDays(1)))
                 .openPrice(111.43)
                 .highPrice(112.83)
                 .lowPrice(107.77)
@@ -169,7 +169,7 @@ public class BuildBarSeries {
                 .build();
         Bar b3 = series.barBuilder()
                 .timePeriod(Duration.ofDays(1))
-                .endTime(endTime.plusDays(2))
+                .endTime(endTime.plus(Duration.ofDays(2)))
                 .openPrice(107.90)
                 .highPrice(117.50)
                 .lowPrice(107.90)

--- a/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/bots/TradingBotOnMovingBarSeries.java
@@ -24,7 +24,7 @@
 package ta4jexamples.bots;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
@@ -41,6 +41,7 @@ import org.ta4j.core.num.DecimalNumFactory;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.rules.OverIndicatorRule;
 import org.ta4j.core.rules.UnderIndicatorRule;
+
 import ta4jexamples.loaders.CsvTradesLoader;
 
 /**
@@ -122,7 +123,7 @@ public class TradingBotOnMovingBarSeries {
         return new BaseBarConvertibleBuilder(DecimalNumFactory.getInstance()).amount(1)
                 .volume(1)
                 .timePeriod(Duration.ofDays(1))
-                .endTime(ZonedDateTime.now())
+                .endTime(Instant.now())
                 .openPrice(openPrice)
                 .highPrice(highPrice)
                 .lowPrice(lowPrice)

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java
@@ -69,7 +69,7 @@ public class CandlestickChart {
 
         for (int i = 0; i < nbBars; i++) {
             Bar bar = series.getBar(i);
-            dates[i] = new Date(bar.getEndTime().toEpochSecond() * 1000);
+            dates[i] = new Date(bar.getEndTime().toEpochMilli());
             opens[i] = bar.getOpenPrice().doubleValue();
             highs[i] = bar.getHighPrice().doubleValue();
             lows[i] = bar.getLowPrice().doubleValue();
@@ -92,7 +92,7 @@ public class CandlestickChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries("Btc price");
         for (int i = 0; i < series.getBarCount(); i++) {
             Bar bar = series.getBar(i);
-            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochSecond() * 1000)),
+            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochMilli())),
                     indicator.getValue(i).doubleValue());
         }
         dataset.addSeries(chartTimeSeries);

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChartWithChopIndicator.java
@@ -90,7 +90,7 @@ public class CandlestickChartWithChopIndicator {
 
         for (int i = 0; i < nbBars; i++) {
             Bar bar = series.getBar(i);
-            dates[i] = new Date(bar.getEndTime().toEpochSecond() * 1000);
+            dates[i] = new Date(bar.getEndTime().toEpochMilli());
             opens[i] = bar.getOpenPrice().doubleValue();
             highs[i] = bar.getHighPrice().doubleValue();
             lows[i] = bar.getLowPrice().doubleValue();
@@ -113,7 +113,7 @@ public class CandlestickChartWithChopIndicator {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries("Btc price");
         for (int i = 0; i < series.getBarCount(); i++) {
             Bar bar = series.getBar(i);
-            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochSecond() * 1000)),
+            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochMilli())),
                     indicator.getValue(i).doubleValue());
         }
         dataset.addSeries(chartTimeSeries);
@@ -128,7 +128,7 @@ public class CandlestickChartWithChopIndicator {
             Bar bar = series.getBar(i);
             if (i < CHOP_INDICATOR_TIMEFRAME)
                 continue;
-            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochSecond() * 1000)),
+            chartTimeSeries.add(new Second(new Date(bar.getEndTime().toEpochMilli())),
                     indicator.getValue(i).doubleValue());
         }
         dataset.addSeries(chartTimeSeries);
@@ -206,14 +206,14 @@ public class CandlestickChartWithChopIndicator {
 
         // CHOP oscillator upper/lower threshold guidelines
         XYLineAnnotation lineAnnotation = new XYLineAnnotation(
-                (double) series.getFirstBar().getBeginTime().toEpochSecond() * 1000d, CHOP_LOWER_THRESHOLD,
-                (double) series.getLastBar().getEndTime().toEpochSecond() * 1000d, CHOP_LOWER_THRESHOLD,
-                dashedThinLineStyle, Color.GREEN);
+                (double) series.getFirstBar().getBeginTime().toEpochMilli(), CHOP_LOWER_THRESHOLD,
+                (double) series.getLastBar().getEndTime().toEpochMilli(), CHOP_LOWER_THRESHOLD, dashedThinLineStyle,
+                Color.GREEN);
         lineAnnotation.setToolTipText("tradable below this");
         indicatorXYPlot.addAnnotation(lineAnnotation);
-        lineAnnotation = new XYLineAnnotation((double) series.getFirstBar().getBeginTime().toEpochSecond() * 1000d,
-                CHOP_UPPER_THRESHOLD, (double) series.getLastBar().getEndTime().toEpochSecond() * 1000d,
-                CHOP_UPPER_THRESHOLD, dashedThinLineStyle, Color.RED);
+        lineAnnotation = new XYLineAnnotation((double) series.getFirstBar().getBeginTime().toEpochMilli(),
+                CHOP_UPPER_THRESHOLD, (double) series.getLastBar().getEndTime().toEpochMilli(), CHOP_UPPER_THRESHOLD,
+                dashedThinLineStyle, Color.RED);
         lineAnnotation.setToolTipText("too choppy above this");
         indicatorXYPlot.addAnnotation(lineAnnotation);
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/indicators/IndicatorsToChart.java
@@ -66,7 +66,7 @@ public class IndicatorsToChart {
         org.jfree.data.time.TimeSeries chartTimeSeries = new org.jfree.data.time.TimeSeries(name);
         for (int i = 0; i < barSeries.getBarCount(); i++) {
             Bar bar = barSeries.getBar(i);
-            chartTimeSeries.add(new Day(Date.from(bar.getEndTime().toInstant())), indicator.getValue(i).doubleValue());
+            chartTimeSeries.add(new Day(Date.from(bar.getEndTime())), indicator.getValue(i).doubleValue());
         }
         return chartTimeSeries;
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvBarsLoader.java
@@ -27,19 +27,20 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
 
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvValidationException;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseBarSeriesBuilder;
 
 /**
  * This class build a Ta4j bar series from a CSV file containing bars.
@@ -70,7 +71,7 @@ public class CsvBarsLoader {
                     .build()) {
                 String[] line;
                 while ((line = csvReader.readNext()) != null) {
-                    ZonedDateTime date = LocalDate.parse(line[0], DATE_FORMAT).atStartOfDay(ZoneId.systemDefault());
+                    Instant date = LocalDate.parse(line[0], DATE_FORMAT).atStartOfDay(ZoneOffset.UTC).toInstant();
                     double open = Double.parseDouble(line[1]);
                     double high = Double.parseDouble(line[2]);
                     double low = Double.parseDouble(line[3]);

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/CsvTradesLoader.java
@@ -27,8 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
@@ -65,16 +63,10 @@ public class CsvTradesLoader {
         if ((lines != null) && !lines.isEmpty()) {
 
             // Getting the first and last trades timestamps
-            ZonedDateTime beginTime = ZonedDateTime
-                    .ofInstant(Instant.ofEpochMilli(Long.parseLong(lines.get(0)[0]) * 1000), ZoneId.systemDefault());
-            ZonedDateTime endTime = ZonedDateTime.ofInstant(
-                    Instant.ofEpochMilli(Long.parseLong(lines.get(lines.size() - 1)[0]) * 1000),
-                    ZoneId.systemDefault());
+            Instant beginTime = Instant.ofEpochMilli(Long.parseLong(lines.get(0)[0]) * 1000);
+            Instant endTime = Instant.ofEpochMilli(Long.parseLong(lines.get(lines.size() - 1)[0]) * 1000);
             if (beginTime.isAfter(endTime)) {
-                Instant beginInstant = beginTime.toInstant();
-                Instant endInstant = endTime.toInstant();
-                beginTime = ZonedDateTime.ofInstant(endInstant, ZoneId.systemDefault());
-                endTime = ZonedDateTime.ofInstant(beginInstant, ZoneId.systemDefault());
+                beginTime = endTime;
                 // Since the CSV file has the most recent trades at the top of the file, we'll
                 // reverse the list to feed
                 // the List<Bar> correctly.
@@ -95,11 +87,11 @@ public class CsvTradesLoader {
      * @param duration  the bar duration (in seconds)
      * @param lines     the csv data returned by CSVReader.readAll()
      */
-    private static void buildSeries(BarSeries series, ZonedDateTime beginTime, ZonedDateTime endTime, int duration,
+    private static void buildSeries(BarSeries series, Instant beginTime, Instant endTime, int duration,
             List<String[]> lines) {
 
         Duration barDuration = Duration.ofSeconds(duration);
-        ZonedDateTime barEndTime = beginTime;
+        Instant barEndTime = beginTime;
         ListIterator<String[]> iterator = lines.listIterator();
         // line number of trade data
         do {
@@ -109,8 +101,7 @@ public class CsvTradesLoader {
             do {
                 // get a trade
                 String[] tradeLine = iterator.next();
-                ZonedDateTime tradeTimeStamp = ZonedDateTime
-                        .ofInstant(Instant.ofEpochMilli(Long.parseLong(tradeLine[0]) * 1000), ZoneId.systemDefault());
+                Instant tradeTimeStamp = Instant.ofEpochMilli(Long.parseLong(tradeLine[0]) * 1000);
                 // if the trade happened during the bar
                 if (bar.inPeriod(tradeTimeStamp)) {
                     // add the trade to the bar

--- a/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/loaders/jsonhelper/GsonBarData.java
@@ -25,8 +25,6 @@ package ta4jexamples.loaders.jsonhelper;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BaseBarSeries;
@@ -42,7 +40,7 @@ public class GsonBarData {
 
     public static GsonBarData from(Bar bar) {
         var result = new GsonBarData();
-        result.endTime = bar.getEndTime().toInstant().toEpochMilli();
+        result.endTime = bar.getEndTime().toEpochMilli();
         result.openPrice = bar.getOpenPrice().getDelegate();
         result.highPrice = bar.getHighPrice().getDelegate();
         result.lowPrice = bar.getLowPrice().getDelegate();
@@ -54,10 +52,9 @@ public class GsonBarData {
 
     public void addTo(BaseBarSeries barSeries) {
         var endTimeInstant = Instant.ofEpochMilli(endTime);
-        var endBarTime = ZonedDateTime.ofInstant(endTimeInstant, ZoneId.systemDefault());
         barSeries.barBuilder()
                 .timePeriod(Duration.ofDays(1))
-                .endTime(endBarTime)
+                .endTime(endTimeInstant)
                 .openPrice(openPrice)
                 .highPrice(highPrice)
                 .lowPrice(lowPrice)

--- a/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/num/CompareNumTypes.java
@@ -24,7 +24,7 @@
 package ta4jexamples.num;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Random;
 
 import org.ta4j.core.BarSeries;
@@ -65,9 +65,10 @@ public class CompareNumTypes {
                 .withNumFactory(DecimalNumFactory.getInstance(256))
                 .build();
 
+        var now = Instant.now();
         int[] randoms = new Random().ints(NUMBARS, 80, 100).toArray();
         for (int i = 0; i < randoms.length; i++) {
-            ZonedDateTime date = ZonedDateTime.now().minusSeconds(NUMBARS - i);
+            Instant date = now.minusSeconds(NUMBARS - i);
             seriesD.barBuilder()
                     .timePeriod(Duration.ofDays(1))
                     .endTime(date)

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/UnstableIndicatorStrategy.java
@@ -24,8 +24,7 @@
 package ta4jexamples.strategies;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 import org.ta4j.core.BarSeries;
@@ -46,7 +45,8 @@ import org.ta4j.core.rules.CrossedUpIndicatorRule;
 public class UnstableIndicatorStrategy {
 
     public static final Duration MINUTE = Duration.ofMinutes(1);
-    public static final ZonedDateTime TIME = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    public static final Instant TIME = Instant.parse("2020-01-01T00:00:00Z");
 
     public static Strategy buildStrategy(BarSeries series) {
         ClosePriceIndicator close = new ClosePriceIndicator(series);

--- a/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/walkforward/WalkForward.java
@@ -24,7 +24,7 @@
 package ta4jexamples.walkforward;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,8 +34,8 @@ import org.ta4j.core.AnalysisCriterion;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Strategy;
 import org.ta4j.core.Trade.TradeType;
-import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.backtest.BarSeriesManager;
 import org.ta4j.core.criteria.pnl.ReturnCriterion;
 import org.ta4j.core.num.Num;
 
@@ -70,12 +70,12 @@ public class WalkForward {
         beginIndexes.add(beginIndex);
 
         // Building the first interval before next split
-        ZonedDateTime beginInterval = series.getFirstBar().getEndTime();
-        ZonedDateTime endInterval = beginInterval.plus(splitDuration);
+        Instant beginInterval = series.getFirstBar().getEndTime();
+        Instant endInterval = beginInterval.plus(splitDuration);
 
         for (int i = beginIndex; i <= endIndex; i++) {
             // For each bar...
-            ZonedDateTime barTime = series.getBar(i).getEndTime();
+            Instant barTime = series.getBar(i).getEndTime();
             if (barTime.isBefore(beginInterval) || !barTime.isBefore(endInterval)) {
                 // Bar out of the interval
                 if (!endInterval.isAfter(barTime)) {
@@ -109,15 +109,15 @@ public class WalkForward {
     public static BarSeries subseries(BarSeries series, int beginIndex, Duration duration) {
 
         // Calculating the sub-series interval
-        ZonedDateTime beginInterval = series.getBar(beginIndex).getEndTime();
-        ZonedDateTime endInterval = beginInterval.plus(duration);
+        Instant beginInterval = series.getBar(beginIndex).getEndTime();
+        Instant endInterval = beginInterval.plus(duration);
 
         // Checking bars belonging to the sub-series (starting at the provided index)
         int subseriesNbBars = 0;
         int endIndex = series.getEndIndex();
         for (int i = beginIndex; i <= endIndex; i++) {
             // For each bar...
-            ZonedDateTime barTime = series.getBar(i).getEndTime();
+            Instant barTime = series.getBar(i).getEndTime();
             if (barTime.isBefore(beginInterval) || !barTime.isBefore(endInterval)) {
                 // Bar out of the interval
                 break;


### PR DESCRIPTION
Fixes #1188

Changes proposed in this pull request:

- Replaced `ZonedDateTime` with `Instant`

For convenience, I also added:
- `Bar.getZonedBeginTime` and `Bar.getZonedEndTime`: the Instant wrapped as ZonedDateTime

- `Bar.getSystemBeginTime` and `Bar.getSystemEndTime`: the Instant converted to systems default time zone

- `BarSeries.getSeriesPeriodDescriptionInDefaultTimeZone`

Other minor changes:
- Fixed `BaseBar.toString()` to avoid `NullPointerException` if any of its property is null (it can, because especially test classes do not fill all properties and using bar.toString could lead ot NPE).
- Fixed `SMAIndicatorTest` and `SMAIndicatorMovingSeriesTest` to set the `endTime` of the next bar correctly (otherwise a bar with a date of 1970 is added to the last bar which has throws an IllegalArgumentException)
- improved `TimeRangeRule` (to use record instead of static class)
- some minor javadoc cleanups


- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
