### PR TITLE
fix ReturnCriterion and ReturnOverMaxDrawdown with base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Extracted NumFactory as source of numbers with defined precision
 
 ### Fixed
-
+- Consider `base` when calculating `ReturnCriterion` of a position
 
 ### Changed
 - Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)
@@ -18,7 +18,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Added
-
+- Added `base` to `ReturnOverMaxDrawdown` to include or exclude the base from the calculation
 
 ## 0.17 (released September 9, 2024)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -36,32 +36,55 @@ import org.ta4j.core.num.Num;
  * format.
  *
  * <pre>
- * RoMaD = {@link ReturnCriterion gross return (with base)} / {@link MaximumDrawdownCriterion maximum drawdown}
+ * RoMaD with base = {@link ReturnCriterion gross return} / {@link MaximumDrawdownCriterion maximum drawdown}
+ * RoMaD without base = ({@link ReturnCriterion gross return} - 1) / {@link MaximumDrawdownCriterion maximum drawdown}
  * </pre>
  */
 public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
 
-    private final AnalysisCriterion grossReturnCriterion = new ReturnCriterion();
+    private final AnalysisCriterion grossReturnCriterion;
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
+
+    /**
+     * Constructor.
+     *
+     * <p>
+     * Uses the following formula:
+     *
+     * <pre>RoMaD with base = ({@link #grossReturnCriterion}) /  {@link #maxDrawdownCriterion} </pre>
+     */
+    public ReturnOverMaxDrawdownCriterion() {
+        this(true);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param addBase if true, then the base percentage of {@code 1} (equivalent to
+     *                100%) is added to the {@link #grossReturnCriterion}
+     */
+    public ReturnOverMaxDrawdownCriterion(boolean addBase) {
+        this.grossReturnCriterion = new ReturnCriterion(addBase);
+    }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, position);
+        final var maxDrawdown = maxDrawdownCriterion.calculate(series, position);
         if (maxDrawdown.isZero()) {
             return NaN.NaN;
         } else {
-            final Num totalProfit = grossReturnCriterion.calculate(series, position);
+            final var totalProfit = grossReturnCriterion.calculate(series, position);
             return totalProfit.dividedBy(maxDrawdown);
         }
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        final Num maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
+        final var maxDrawdown = maxDrawdownCriterion.calculate(series, tradingRecord);
         if (maxDrawdown.isZero()) {
             return NaN.NaN;
         } else {
-            final Num totalProfit = grossReturnCriterion.calculate(series, tradingRecord);
+            final var totalProfit = grossReturnCriterion.calculate(series, tradingRecord);
             return totalProfit.dividedBy(maxDrawdown);
         }
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorMovingSeriesTest.java
@@ -26,6 +26,8 @@ package org.ta4j.core.indicators;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+import java.time.ZonedDateTime;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -49,6 +51,11 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
         data.setMaximumBarCount(4);
     }
 
+    private ZonedDateTime getNextEndTime() {
+        var lastBar = data.getLastBar();
+        return lastBar == null ? null : lastBar.getEndTime().plus(lastBar.getTimePeriod());
+    }
+
     @Test
     public void usingBarCount3MovingSeries() {
         firstAddition();
@@ -59,7 +66,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void firstAddition() {
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -75,7 +82,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void secondAddition() {
-        data.barBuilder().closePrice(10.).add();
+        data.barBuilder().closePrice(10.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -91,7 +98,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void thirdAddition() {
-        data.barBuilder().closePrice(20.).add();
+        data.barBuilder().closePrice(20.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -107,7 +114,7 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
     }
 
     private void fourthAddition() {
-        data.barBuilder().closePrice(30.).add();
+        data.barBuilder().closePrice(30.).endTime(getNextEndTime()).add();
         Indicator<Num> indicator2 = getIndicator(new ClosePriceIndicator(data), 2);
 
         // unstable bars skipped, unpredictable results
@@ -139,8 +146,8 @@ public class SMAIndicatorMovingSeriesTest extends AbstractIndicatorTest<Indicato
 
     @Test
     public void whenBarCountIs1ResultShouldBeIndicatorValue() {
-        data.barBuilder().closePrice(5.).add();
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 1);
         for (int i = 0; i < data.getBarCount(); i++) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SMAIndicatorTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.assertIndicatorEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
+import java.time.ZonedDateTime;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -56,6 +58,11 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
                 .build();
     }
 
+    private ZonedDateTime getNextEndTime() {
+        var lastBar = data.getLastBar();
+        return lastBar == null ? null : lastBar.getEndTime().plus(lastBar.getTimePeriod());
+    }
+
     @Test
     public void usingBarCount3UsingClosePrice() {
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
@@ -78,7 +85,7 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     @Test
     public void usingBarCount3UsingClosePriceMovingSerie() {
         data.setMaximumBarCount(13);
-        data.barBuilder().closePrice(5.).add();
+        data.barBuilder().closePrice(5.).endTime(getNextEndTime()).add();
 
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
 


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/802

Changes proposed in this pull request:

### Fixed
- Consider `base` when calculating `ReturnCriterion` of a position

### Added
- Added `base` to `ReturnOverMaxDrawdown` to include or exclude the base from the calculation

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
