### PR TITLE
Fixed MockBarBuilder to use Instant.now for beginTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Fixed `SMAIndicatorTest` to set the endTime of the next bar correctly
 - Fixed `SMAIndicatorMovingSeriesTest` to set the endTime of the next bar correctly
 - Use UTC TimeZone for `AroonOscillatorIndicatorTest`, `PivotPointIndicatorTest`
+- Fixed `MockBarBuilder` to use `Instant.now` for beginTime
 
 ### Changed
 - Updated **jfreechart** dependency in **ta4j-examples** project from 1.5.3 to 1.5.5 to resolve [CVE-2023-52070](https://ossindex.sonatype.org/vulnerability/CVE-2023-6481?component-type=maven&component-name=ch.qos.logback%2Flogback-core)

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
@@ -23,18 +23,15 @@
  */
 package org.ta4j.core.mocks;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
-
 import org.ta4j.core.bars.BaseBar;
 import org.ta4j.core.bars.BaseBarBuilder;
 import org.ta4j.core.num.NumFactory;
 
 public class MockBarBuilder extends BaseBarBuilder {
 
-    private Clock clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneOffset.UTC);
+    private Instant beginTime = Instant.now();
     private boolean periodSet;
     private boolean endTimeSet;
 
@@ -65,8 +62,9 @@ public class MockBarBuilder extends BaseBarBuilder {
         }
 
         if (!endTimeSet) {
-            endTime(Instant.now(Clock.offset(clock, timePeriod.multipliedBy(++countOfProducedBars))));
+            endTime(beginTime.plus(timePeriod.multipliedBy(++countOfProducedBars)));
         }
         return super.build();
     }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeriesBuilder.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarSeriesBuilder.java
@@ -71,10 +71,11 @@ public class MockBarSeriesBuilder extends BaseBarSeriesBuilder {
     }
 
     private static void doublesToBars(final BarSeries series, final List<Double> data) {
-        var now = Instant.now();
+        final var now = Instant.now();
+        final var maxBars = data.size() + 1;
         for (int i = 0; i < data.size(); i++) {
             series.barBuilder()
-                    .endTime(now.minus(Duration.ofMinutes((data.size() + 1 - i))))
+                    .endTime(now.minus(Duration.ofMinutes(maxBars - i)))
                     .closePrice(data.get(i))
                     .openPrice(0)
                     .add();
@@ -87,7 +88,7 @@ public class MockBarSeriesBuilder extends BaseBarSeriesBuilder {
     }
 
     private static void arbitraryBars(final BarSeries series) {
-        var now = Instant.now();
+        final var now = Instant.now();
         for (double i = 0d; i < 5000; i++) {
             series.barBuilder()
                     .endTime(now.minus(Duration.ofMinutes((long) (5001 - i))))


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/1230

Changes proposed in this pull request:
- Fixed `MockBarBuilder` to use `Instant.now` for beginTime

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 


I replaced `Clock` by using simply `Instant` because we do not need a clock in this case (which wraps an UTC).

Both are equal:

```
private Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
   
endTime(Clock.offset(clock, timePeriod.multipliedBy(++countOfProducedBars)).instant());
```

Simplified to:

```
private Instant beginTime = Instant.now();
endTime(beginTime.plus(timePeriod.multipliedBy(++countOfProducedBars)));
```