### PR TITLE
#1186 heikin ashi bar builder

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,4 @@ Contributors
     milczarekIT (Bartosz Milczarek)
     kennethjor (Kenneth Jørgensen)
     brhurley (Brian Hurley)
-	
+	francescopeloi (Francesco Peloi)

--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,4 @@ Contributors
     milczarekIT (Bartosz Milczarek)
     kennethjor (Kenneth Jørgensen)
     brhurley (Brian Hurley)
-	francescopeloi (Francesco Peloi)
+    francescopeloi (Francesco Peloi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Added
+- added `HeikinAshiBarBuilder`: Heikin-Ashi bar builder implementation
 - added `Bar.getZonedBeginTime`: the bar's begin time usable as ZonedDateTime
 - added `Bar.getZonedEndTime`: the bar's end time usable as ZonedDateTime
 - added `Bar.getSystemZonedBeginTime`: the bar's begin time converted to system time zone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 
 ### Added
+- added `HeikinAshiBarAggregator`: Heikin-Ashi bar aggregator implementation
 - added `HeikinAshiBarBuilder`: Heikin-Ashi bar builder implementation
 - added `Bar.getZonedBeginTime`: the bar's begin time usable as ZonedDateTime
 - added `Bar.getZonedEndTime`: the bar's end time usable as ZonedDateTime

--- a/ta4j-core/src/main/java/org/ta4j/core/aggregator/HeikinAshiBarAggregator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/aggregator/HeikinAshiBarAggregator.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.aggregator;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.bars.HeikinAshiBarBuilder;
+import org.ta4j.core.num.Num;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aggregates a list of {@link BaseBar bars} into another one by following
+ * Heikin-Ashi logic
+ */
+public class HeikinAshiBarAggregator implements BarAggregator {
+
+    @Override
+    public List<Bar> aggregate(List<Bar> ohlcBars) {
+        var heikinAshiBars = new ArrayList<Bar>();
+        var haBuilder = new HeikinAshiBarBuilder();
+        Num previousOpen = null;
+        Num previousClose = null;
+
+        for (Bar ohlcBar : ohlcBars) {
+            haBuilder.timePeriod(ohlcBar.getTimePeriod())
+                    .endTime(ohlcBar.getEndTime())
+                    .openPrice(ohlcBar.getOpenPrice())
+                    .highPrice(ohlcBar.getHighPrice())
+                    .lowPrice(ohlcBar.getLowPrice())
+                    .closePrice(ohlcBar.getClosePrice())
+                    .volume(ohlcBar.getVolume())
+                    .amount(ohlcBar.getAmount())
+                    .trades(ohlcBar.getTrades());
+
+            if (previousOpen != null && previousClose != null) {
+                haBuilder.previousHeikinAshiOpenPrice(previousOpen).previousHeikinAshiClosePrice(previousClose);
+            } else {
+                haBuilder.previousHeikinAshiOpenPrice(null).previousHeikinAshiClosePrice(null);
+            }
+
+            var haBar = haBuilder.build();
+            heikinAshiBars.add(haBar);
+
+            previousOpen = haBar.getOpenPrice();
+            previousClose = haBar.getClosePrice();
+        }
+        return heikinAshiBars;
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
@@ -76,41 +76,4 @@ public class HeikinAshiBarBuilder extends TimeBarBuilder {
         }
     }
 
-    /**
-     * Transform a list of OHLC bars into a list of Heikin-Ashi bars
-     *
-     * @return list of Heikin-Ashi bars
-     */
-    public static List<Bar> fromOhlcTtoHeikinAshi(List<Bar> ohlcBars) {
-        var heikinAshiBars = new ArrayList<Bar>();
-        var haBuilder = new HeikinAshiBarBuilder();
-        Num previousOpen = null;
-        Num previousClose = null;
-
-        for (Bar ohlcBar : ohlcBars) {
-            haBuilder.timePeriod(ohlcBar.getTimePeriod())
-                    .endTime(ohlcBar.getEndTime())
-                    .openPrice(ohlcBar.getOpenPrice())
-                    .highPrice(ohlcBar.getHighPrice())
-                    .lowPrice(ohlcBar.getLowPrice())
-                    .closePrice(ohlcBar.getClosePrice())
-                    .volume(ohlcBar.getVolume())
-                    .amount(ohlcBar.getAmount())
-                    .trades(ohlcBar.getTrades());
-
-            if (previousOpen != null && previousClose != null) {
-                haBuilder.previousHeikinAshiOpenPrice(previousOpen).previousHeikinAshiClosePrice(previousClose);
-            } else {
-                haBuilder.previousHeikinAshiOpenPrice(null).previousHeikinAshiClosePrice(null);
-            }
-
-            var haBar = haBuilder.build();
-            heikinAshiBars.add(haBar);
-
-            previousOpen = haBar.getOpenPrice();
-            previousClose = haBar.getClosePrice();
-        }
-        return heikinAshiBars;
-    }
-
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Heikin-Ashi bar builder
+ * @see <a href="https://www.investopedia.com/trading/heikin-ashi-better-candlestick/">Heikin-Ashi</a>
+ */
+public class HeikinAshiBarBuilder extends TimeBarBuilder {
+    private Num previousHeikinAshiOpenPrice;
+    private Num previousHeikinAshiClosePrice;
+
+    public HeikinAshiBarBuilder() {
+        super();
+    }
+
+    public HeikinAshiBarBuilder(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    public HeikinAshiBarBuilder previousHeikinAshiOpenPrice(Num previousOpen) {
+        previousHeikinAshiOpenPrice = previousOpen;
+        return this;
+    }
+
+    public HeikinAshiBarBuilder previousHeikinAshiClosePrice(Num previousClose) {
+        previousHeikinAshiClosePrice = previousClose;
+        return this;
+    }
+
+    @Override
+    public Bar build() {
+        if (previousHeikinAshiOpenPrice == null || previousHeikinAshiClosePrice == null) {
+            return super.build();
+        } else {
+            var numFactory = openPrice.getNumFactory();
+            var heikinAshiClose = openPrice.plus(highPrice)
+                    .plus(lowPrice)
+                    .plus(closePrice)
+                    .dividedBy(numFactory.numOf(4));
+            var heikinAshiOpen = previousHeikinAshiOpenPrice.plus(previousHeikinAshiClosePrice)
+                    .dividedBy(numFactory.numOf(2));
+            var heikinAshiHigh = highPrice.max(heikinAshiOpen).max(heikinAshiClose);
+            var heikinAshiLow = lowPrice.min(heikinAshiOpen).min(heikinAshiClose);
+            return new BaseBar(timePeriod, endTime, heikinAshiOpen, heikinAshiHigh, heikinAshiLow, heikinAshiClose,
+                    volume, amount, trades);
+        }
+    }
+
+    public List<Bar> fromOhlcTtoHeikinAshi(List<Bar> ohlcBars) {
+        var heikinAshiBars = new ArrayList<Bar>();
+        var haBuilder = new HeikinAshiBarBuilder();
+        Num previousOpen = null;
+        Num previousClose = null;
+
+        for (Bar ohlcBar : ohlcBars) {
+            haBuilder.timePeriod(ohlcBar.getTimePeriod())
+                    .endTime(ohlcBar.getEndTime())
+                    .openPrice(ohlcBar.getOpenPrice())
+                    .highPrice(ohlcBar.getHighPrice())
+                    .lowPrice(ohlcBar.getLowPrice())
+                    .closePrice(ohlcBar.getClosePrice())
+                    .volume(ohlcBar.getVolume())
+                    .amount(ohlcBar.getAmount())
+                    .trades(ohlcBar.getTrades());
+
+            if (previousOpen != null && previousClose != null) {
+                haBuilder.previousHeikinAshiOpenPrice(previousOpen).previousHeikinAshiClosePrice(previousClose);
+            } else {
+                haBuilder.previousHeikinAshiOpenPrice(null).previousHeikinAshiClosePrice(null);
+            }
+
+            var haBar = haBuilder.build();
+            heikinAshiBars.add(haBar);
+
+            previousOpen = haBar.getOpenPrice();
+            previousClose = haBar.getClosePrice();
+        }
+        return heikinAshiBars;
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
@@ -76,7 +76,7 @@ public class HeikinAshiBarBuilder extends TimeBarBuilder {
         }
     }
 
-    public List<Bar> fromOhlcTtoHeikinAshi(List<Bar> ohlcBars) {
+    public static List<Bar> fromOhlcTtoHeikinAshi(List<Bar> ohlcBars) {
         var heikinAshiBars = new ArrayList<Bar>();
         var haBuilder = new HeikinAshiBarBuilder();
         Num previousOpen = null;

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
@@ -76,6 +76,11 @@ public class HeikinAshiBarBuilder extends TimeBarBuilder {
         }
     }
 
+    /**
+     * Transform a list of OHLC bars into a list of Heikin-Ashi bars
+     *
+     * @return list of Heikin-Ashi bars
+     */
     public static List<Bar> fromOhlcTtoHeikinAshi(List<Bar> ohlcBars) {
         var heikinAshiBars = new ArrayList<Bar>();
         var haBuilder = new HeikinAshiBarBuilder();

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilderFactory.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilderFactory.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import org.ta4j.core.BarBuilder;
+import org.ta4j.core.BarBuilderFactory;
+import org.ta4j.core.BarSeries;
+
+public class HeikinAshiBarBuilderFactory implements BarBuilderFactory {
+
+    @Override
+    public BarBuilder createBarBuilder(BarSeries series) {
+        return new HeikinAshiBarBuilder(series.numFactory()).bindTo(series);
+    }
+
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
+import org.ta4j.core.Bar;
 import org.ta4j.core.BarBuilder;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
@@ -40,15 +41,15 @@ import org.ta4j.core.num.NumFactory;
 public class TimeBarBuilder implements BarBuilder {
 
     private final NumFactory numFactory;
-    private Duration timePeriod;
-    private Instant endTime;
-    private Num openPrice;
-    private Num highPrice;
-    private Num lowPrice;
-    private Num closePrice;
-    private Num volume;
-    private Num amount;
-    private long trades;
+    Duration timePeriod;
+    Instant endTime;
+    Num openPrice;
+    Num highPrice;
+    Num lowPrice;
+    Num closePrice;
+    Num volume;
+    Num amount;
+    long trades;
     private BarSeries baseBarSeries;
 
     /** A builder to build a new {@link BaseBar} with {@link DoubleNumFactory} */
@@ -66,19 +67,19 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder timePeriod(final Duration timePeriod) {
+    public BarBuilder timePeriod(final Duration timePeriod) {
         this.timePeriod = timePeriod;
         return this;
     }
 
     @Override
-    public TimeBarBuilder endTime(final Instant endTime) {
+    public BarBuilder endTime(final Instant endTime) {
         this.endTime = endTime;
         return this;
     }
 
     @Override
-    public TimeBarBuilder openPrice(final Num openPrice) {
+    public BarBuilder openPrice(final Num openPrice) {
         this.openPrice = openPrice;
         return this;
     }
@@ -108,13 +109,13 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder highPrice(final Num highPrice) {
+    public BarBuilder highPrice(final Num highPrice) {
         this.highPrice = highPrice;
         return this;
     }
 
     @Override
-    public TimeBarBuilder lowPrice(final Num lowPrice) {
+    public BarBuilder lowPrice(final Num lowPrice) {
         this.lowPrice = lowPrice;
         return this;
     }
@@ -132,7 +133,7 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder closePrice(final Num closePrice) {
+    public BarBuilder closePrice(final Num closePrice) {
         this.closePrice = closePrice;
         return this;
     }
@@ -150,7 +151,7 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder volume(final Num volume) {
+    public BarBuilder volume(final Num volume) {
         this.volume = volume;
         return this;
     }
@@ -168,7 +169,7 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder amount(final Num amount) {
+    public BarBuilder amount(final Num amount) {
         this.amount = amount;
         return this;
     }
@@ -186,25 +187,25 @@ public class TimeBarBuilder implements BarBuilder {
     }
 
     @Override
-    public TimeBarBuilder trades(final long trades) {
+    public BarBuilder trades(final long trades) {
         this.trades = trades;
         return this;
     }
 
     @Override
-    public TimeBarBuilder trades(final String trades) {
+    public BarBuilder trades(final String trades) {
         trades(Long.parseLong(trades));
         return this;
     }
 
     @Override
-    public TimeBarBuilder bindTo(final BarSeries barSeries) {
+    public BarBuilder bindTo(final BarSeries barSeries) {
         this.baseBarSeries = Objects.requireNonNull(barSeries);
         return this;
     }
 
     @Override
-    public BaseBar build() {
+    public Bar build() {
         return new BaseBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
                 this.closePrice, this.volume, this.amount, this.trades);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilderFactory.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilderFactory.java
@@ -23,13 +23,14 @@
  */
 package org.ta4j.core.bars;
 
+import org.ta4j.core.BarBuilder;
 import org.ta4j.core.BarBuilderFactory;
 import org.ta4j.core.BarSeries;
 
 public class TimeBarBuilderFactory implements BarBuilderFactory {
 
     @Override
-    public TimeBarBuilder createBarBuilder(BarSeries series) {
+    public BarBuilder createBarBuilder(BarSeries series) {
         return new TimeBarBuilder(series.numFactory()).bindTo(series);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
@@ -1,0 +1,61 @@
+package org.ta4j.core.aggregator;
+
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HeikinAshiBarAggregatorTest extends AbstractIndicatorTest<BarSeries, Num> {
+
+    public HeikinAshiBarAggregatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    private final HeikinAshiBarAggregator unit = new HeikinAshiBarAggregator();
+
+    @Test
+    public void testAggregate() {
+        var endTime = Instant.parse("2024-01-01T01:00:00Z");
+        var timePeriod = Duration.ofHours(1);
+
+        Bar bar1 = new BaseBar(timePeriod, endTime, numFactory.numOf(100), numFactory.numOf(105), numFactory.numOf(95),
+                numFactory.numOf(100), numFactory.numOf(10), numFactory.numOf(50), 1);
+        var bar2 = new BaseBar(timePeriod, endTime.plus(1, ChronoUnit.HOURS), numFactory.numOf(100),
+                numFactory.numOf(110), numFactory.numOf(98), numFactory.numOf(105), numFactory.numOf(20),
+                numFactory.numOf(100), 2);
+
+        var ohlcBars = List.of(bar1, bar2);
+        var haBars = unit.aggregate(ohlcBars);
+        assertEquals(2, haBars.size());
+
+        // First HA bar should be identical to the original bar, since no previous HA
+        // data
+        var firstHA = haBars.getFirst();
+        assertEquals(bar1.getOpenPrice(), firstHA.getOpenPrice());
+        assertEquals(bar1.getHighPrice(), firstHA.getHighPrice());
+        assertEquals(bar1.getLowPrice(), firstHA.getLowPrice());
+        assertEquals(bar1.getClosePrice(), firstHA.getClosePrice());
+
+        // Second HA bar uses first bar’s HA open/close in the formula
+        var secondHA = haBars.get(1);
+        var haClose2Expected = bar2.getOpenPrice()
+                .plus(bar2.getHighPrice())
+                .plus(bar2.getLowPrice())
+                .plus(bar2.getClosePrice())
+                .dividedBy(numFactory.numOf(4));
+        var haOpen2Expected = firstHA.getOpenPrice().plus(firstHA.getClosePrice()).dividedBy(numFactory.numOf(2));
+        assertEquals(haOpen2Expected, secondHA.getOpenPrice());
+        assertEquals(haClose2Expected, secondHA.getClosePrice());
+    }
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package org.ta4j.core.aggregator;
 
 import org.junit.Test;

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HeikinAshiBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
+
+    public HeikinAshiBarBuilderTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    private final HeikinAshiBarBuilder unit = new HeikinAshiBarBuilder(numFactory);
+
+    @Test
+    public void testBuild() {
+        var inputBar = new BaseBar(Duration.ofHours(1), Instant.parse("2024-01-01T01:00:00Z"), numFactory.numOf(100),
+                numFactory.numOf(110), numFactory.numOf(95), numFactory.numOf(105), numFactory.numOf(10),
+                numFactory.numOf(1000), 1);
+
+        // No previous HA data: should return bar as-is.
+        var resultBar = unit.timePeriod(inputBar.getTimePeriod())
+                .endTime(inputBar.getEndTime())
+                .openPrice(inputBar.getOpenPrice())
+                .highPrice(inputBar.getHighPrice())
+                .lowPrice(inputBar.getLowPrice())
+                .closePrice(inputBar.getClosePrice())
+                .volume(inputBar.getVolume())
+                .amount(inputBar.getAmount())
+                .trades(inputBar.getTrades())
+                .build();
+
+        assertEquals(inputBar.getOpenPrice(), resultBar.getOpenPrice());
+        assertEquals(inputBar.getHighPrice(), resultBar.getHighPrice());
+        assertEquals(inputBar.getLowPrice(), resultBar.getLowPrice());
+        assertEquals(inputBar.getClosePrice(), resultBar.getClosePrice());
+
+        // Setup for second bar with previous HA data
+        var builderWithPrevious = new HeikinAshiBarBuilder().previousHeikinAshiOpenPrice(numFactory.numOf(100))
+                .previousHeikinAshiClosePrice(numFactory.numOf(105))
+                .timePeriod(inputBar.getTimePeriod())
+                .endTime(inputBar.getEndTime())
+                .openPrice(inputBar.getOpenPrice())
+                .highPrice(inputBar.getHighPrice())
+                .lowPrice(inputBar.getLowPrice())
+                .closePrice(inputBar.getClosePrice())
+                .volume(inputBar.getVolume())
+                .amount(inputBar.getAmount())
+                .trades(inputBar.getTrades());
+
+        var haBar = builderWithPrevious.build();
+
+        // Heikin-Ashi formula checks
+        var haCloseExpected = (numFactory.numOf(100)
+                .plus(numFactory.numOf(110))
+                .plus(numFactory.numOf(95))
+                .plus(numFactory.numOf(105))).dividedBy(numFactory.numOf(4));
+        var haOpenExpected = (numFactory.numOf(100).plus(numFactory.numOf(105))).dividedBy(numFactory.numOf(2));
+
+        assertEquals(haOpenExpected, haBar.getOpenPrice());
+        assertEquals(haCloseExpected, haBar.getClosePrice());
+    }
+
+    @Test
+    public void testHeikinAshiWithThreeBars() {
+        var endTime = Instant.parse("2024-01-01T01:00:00Z");
+        var timePeriod = Duration.ofHours(1);
+
+        Bar bar1 = new BaseBar(timePeriod, endTime, numFactory.numOf(100), numFactory.numOf(105), numFactory.numOf(95),
+                numFactory.numOf(100), numFactory.numOf(10), numFactory.numOf(50), 1);
+        var bar2 = new BaseBar(timePeriod, endTime.plus(1, ChronoUnit.HOURS), numFactory.numOf(100),
+                numFactory.numOf(110), numFactory.numOf(98), numFactory.numOf(105), numFactory.numOf(20),
+                numFactory.numOf(100), 2);
+
+        var ohlcBars = List.of(bar1, bar2);
+        var haBars = unit.fromOhlcTtoHeikinAshi(ohlcBars);
+        assertEquals(2, haBars.size());
+
+        // First HA bar should be identical to the original bar, since no previous HA
+        // data
+        var firstHA = haBars.getFirst();
+        assertEquals(bar1.getOpenPrice(), firstHA.getOpenPrice());
+        assertEquals(bar1.getHighPrice(), firstHA.getHighPrice());
+        assertEquals(bar1.getLowPrice(), firstHA.getLowPrice());
+        assertEquals(bar1.getClosePrice(), firstHA.getClosePrice());
+
+        // Second HA bar uses first bar’s HA open/close in the formula
+        var secondHA = haBars.get(1);
+        var haClose2Expected = bar2.getOpenPrice()
+                .plus(bar2.getHighPrice())
+                .plus(bar2.getLowPrice())
+                .plus(bar2.getClosePrice())
+                .dividedBy(numFactory.numOf(4));
+        var haOpen2Expected = firstHA.getOpenPrice().plus(firstHA.getClosePrice()).dividedBy(numFactory.numOf(2));
+        assertEquals(haOpen2Expected, secondHA.getOpenPrice());
+        assertEquals(haClose2Expected, secondHA.getClosePrice());
+    }
+
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
@@ -24,7 +24,6 @@
 package org.ta4j.core.bars;
 
 import org.junit.Test;
-import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
@@ -33,8 +32,6 @@ import org.ta4j.core.num.NumFactory;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -93,41 +90,6 @@ public class HeikinAshiBarBuilderTest extends AbstractIndicatorTest<BarSeries, N
 
         assertEquals(haOpenExpected, haBar.getOpenPrice());
         assertEquals(haCloseExpected, haBar.getClosePrice());
-    }
-
-    @Test
-    public void testHeikinAshiWithThreeBars() {
-        var endTime = Instant.parse("2024-01-01T01:00:00Z");
-        var timePeriod = Duration.ofHours(1);
-
-        Bar bar1 = new BaseBar(timePeriod, endTime, numFactory.numOf(100), numFactory.numOf(105), numFactory.numOf(95),
-                numFactory.numOf(100), numFactory.numOf(10), numFactory.numOf(50), 1);
-        var bar2 = new BaseBar(timePeriod, endTime.plus(1, ChronoUnit.HOURS), numFactory.numOf(100),
-                numFactory.numOf(110), numFactory.numOf(98), numFactory.numOf(105), numFactory.numOf(20),
-                numFactory.numOf(100), 2);
-
-        var ohlcBars = List.of(bar1, bar2);
-        var haBars = HeikinAshiBarBuilder.fromOhlcTtoHeikinAshi(ohlcBars);
-        assertEquals(2, haBars.size());
-
-        // First HA bar should be identical to the original bar, since no previous HA
-        // data
-        var firstHA = haBars.getFirst();
-        assertEquals(bar1.getOpenPrice(), firstHA.getOpenPrice());
-        assertEquals(bar1.getHighPrice(), firstHA.getHighPrice());
-        assertEquals(bar1.getLowPrice(), firstHA.getLowPrice());
-        assertEquals(bar1.getClosePrice(), firstHA.getClosePrice());
-
-        // Second HA bar uses first bar’s HA open/close in the formula
-        var secondHA = haBars.get(1);
-        var haClose2Expected = bar2.getOpenPrice()
-                .plus(bar2.getHighPrice())
-                .plus(bar2.getLowPrice())
-                .plus(bar2.getClosePrice())
-                .dividedBy(numFactory.numOf(4));
-        var haOpen2Expected = firstHA.getOpenPrice().plus(firstHA.getClosePrice()).dividedBy(numFactory.numOf(2));
-        assertEquals(haOpen2Expected, secondHA.getOpenPrice());
-        assertEquals(haClose2Expected, secondHA.getClosePrice());
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
@@ -107,7 +107,7 @@ public class HeikinAshiBarBuilderTest extends AbstractIndicatorTest<BarSeries, N
                 numFactory.numOf(100), 2);
 
         var ohlcBars = List.of(bar1, bar2);
-        var haBars = unit.fromOhlcTtoHeikinAshi(ohlcBars);
+        var haBars = HeikinAshiBarBuilder.fromOhlcTtoHeikinAshi(ohlcBars);
         assertEquals(2, haBars.size());
 
         // First HA bar should be identical to the original bar, since no previous HA

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import org.junit.Test;
+import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
@@ -48,7 +49,7 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
         final Duration duration = Duration.between(beginTime, endTime);
 
-        final BaseBar bar = new TimeBarBuilder(numFactory).timePeriod(duration)
+        final Bar bar = new TimeBarBuilder(numFactory).timePeriod(duration)
                 .endTime(endTime)
                 .openPrice(numOf(101))
                 .highPrice(numOf(103))

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilder.java
@@ -26,7 +26,8 @@ package org.ta4j.core.mocks;
 import java.time.Duration;
 import java.time.Instant;
 
-import org.ta4j.core.BaseBar;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarBuilder;
 import org.ta4j.core.bars.TimeBarBuilder;
 import org.ta4j.core.num.NumFactory;
 
@@ -44,20 +45,20 @@ public class MockBarBuilder extends TimeBarBuilder {
     }
 
     @Override
-    public TimeBarBuilder endTime(final Instant endTime) {
+    public BarBuilder endTime(final Instant endTime) {
         endTimeSet = true;
         return super.endTime(endTime);
     }
 
     @Override
-    public TimeBarBuilder timePeriod(final Duration timePeriod) {
+    public BarBuilder timePeriod(final Duration timePeriod) {
         periodSet = true;
         this.timePeriod = timePeriod;
         return super.timePeriod(this.timePeriod);
     }
 
     @Override
-    public BaseBar build() {
+    public Bar build() {
         if (!periodSet) {
             timePeriod(Duration.ofDays(1));
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilderFactory.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/mocks/MockBarBuilderFactory.java
@@ -23,13 +23,13 @@
  */
 package org.ta4j.core.mocks;
 
+import org.ta4j.core.BarBuilder;
 import org.ta4j.core.BarBuilderFactory;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.bars.TimeBarBuilder;
 
 public class MockBarBuilderFactory implements BarBuilderFactory {
     @Override
-    public TimeBarBuilder createBarBuilder(final BarSeries series) {
+    public BarBuilder createBarBuilder(final BarSeries series) {
         return new MockBarBuilder(series.numFactory()).bindTo(series);
     }
 }


### PR DESCRIPTION
Fixes #1186.

Changes proposed in this pull request:
- Heikin-Ashi bar builder implementation

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 

Re-used the TimeBarBuilder implementation as it's mostly the same aside the build method. 

To me HA bars are an abstraction on top of OHLC bars (you need OHLC bars to calculate HA bars). I am not sure if they deserve their own Bar type, or a BarBuilder is enough, or only a conversion method would do.