### PR TITLE
#150 Use highest and lowest indicators as instance variables

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -47,7 +47,9 @@ import org.ta4j.core.num.Num;
 public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
 
     private final LowPriceIndicator lowPriceIndicator;
+    private final LowestValueIndicator lowestValueIndicator;
     private final HighPriceIndicator highPriceIndicator;
+    private final HighestValueIndicator highestValueIndicator;
 
     private final Num maxAcceleration;
     private final Num accelerationStart;
@@ -99,7 +101,9 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
     public ParabolicSarIndicator(BarSeries series, Num aF, Num maxA, Num increment) {
         super(series);
         this.lowPriceIndicator = new LowPriceIndicator(series);
+        this.lowestValueIndicator = new LowestValueIndicator(lowPriceIndicator, 2);
         this.highPriceIndicator = new HighPriceIndicator(series);
+        this.highestValueIndicator = new HighestValueIndicator(highPriceIndicator, 2);
         this.maxAcceleration = maxA;
         this.accelerationStart = aF;
         this.accelerationIncrement = increment;
@@ -149,13 +153,13 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
             isUpTrendMap.put(index, is_up_trend);
 
             if (is_up_trend) { // up trend
-                sar = new LowestValueIndicator(lowPriceIndicator, 2).getValue(index - 1); // put the lowest low value of
+                sar = lowestValueIndicator.getValue(index - 1); // put the lowest low value of
                 // two
-                lastExtreme.put(index, new HighestValueIndicator(highPriceIndicator, 2).getValue(index - 1));
+                lastExtreme.put(index, highestValueIndicator.getValue(index - 1));
             } else { // down trend
-                sar = new HighestValueIndicator(highPriceIndicator, 2).getValue(index - 1); // put the highest high
+                sar = highestValueIndicator.getValue(index - 1); // put the highest high
                 // value of
-                lastExtreme.put(index, new LowestValueIndicator(lowPriceIndicator, 2).getValue(index - 1));
+                lastExtreme.put(index, lowestValueIndicator.getValue(index - 1));
             }
             return sar;
         }
@@ -206,12 +210,12 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         if (is_up_trend) {
-            Num lowestPriceOfTwoPreviousBars = new LowestValueIndicator(lowPriceIndicator, 2).getValue(index - 1);
+            Num lowestPriceOfTwoPreviousBars = lowestValueIndicator.getValue(index - 1);
             if (sar.isGreaterThan(lowestPriceOfTwoPreviousBars)) {
                 sar = lowestPriceOfTwoPreviousBars;
             }
         } else {
-            Num highestPriceOfTwoPreviousBars = new HighestValueIndicator(highPriceIndicator, 2).getValue(index - 1);
+            Num highestPriceOfTwoPreviousBars = highestValueIndicator.getValue(index - 1);
             if (sar.isLessThan(highestPriceOfTwoPreviousBars)) {
                 sar = highestPriceOfTwoPreviousBars;
             }


### PR DESCRIPTION
- there is no need to create them each execution


Fixes #1250.

Changes proposed in this pull request:
- made highest and lowest as instance variables

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
