### PR TITLE
Introduce BarPool for memory optimization and bar reuse

### DIFF
--- a/BarPool.md
+++ b/BarPool.md
@@ -1,0 +1,122 @@
+# BarPool - Memory Optimization in ta4j
+
+## Overview
+
+The `BarPool` is a memory optimization feature in ta4j that reduces memory usage and garbage collection overhead by reusing `Bar` instances. Instead of creating new `Bar` objects each time they are needed, the `BarPool` maintains a pool of previously used bars that can be reset and reused.
+
+## Purpose
+
+In trading applications, especially those processing high-frequency data or running backtests over long periods, a large number of `Bar` objects are created and discarded. This can lead to:
+
+1. Increased memory usage
+2. More frequent garbage collection pauses
+3. Overall reduced performance
+
+The `BarPool` addresses these issues by implementing an object pool pattern for `Bar` instances, allowing them to be reused rather than constantly created and garbage collected.
+
+## Implementation Details
+
+### BarPool Class
+
+The `BarPool` is implemented as a singleton class that maintains separate pools for different time periods. Key features include:
+
+- Singleton pattern ensures a single instance is shared across the application
+- Thread-safe implementation using concurrent collections
+- Separate pools for different time periods (e.g., 1-minute bars, 5-minute bars)
+- Maximum pool size limit to prevent excessive memory usage
+
+### Integration with Existing Components
+
+The `BarPool` is integrated with several key components in ta4j:
+
+1. **TimeBarBuilder**: Uses the `BarPool` to get `Bar` instances when building new bars
+2. **BaseBarSeries**: Returns bars to the pool when they are removed due to:
+   - Exceeding the maximum bar count
+   - Being replaced by newer bars
+
+### BaseBar Modifications
+
+The `BaseBar` class has been enhanced with a `resetBar()` method that allows a bar to be reused by resetting all its properties with new values.
+
+## Usage
+
+The `BarPool` is designed to work automatically with existing ta4j components. When you use `TimeBarBuilder` to create bars or set a maximum bar count on a `BaseBarSeries`, the `BarPool` is used behind the scenes.
+
+### Direct Usage
+
+While most users won't need to interact with the `BarPool` directly, it can be used as follows:
+
+```java
+// Get the singleton instance
+BarPool barPool = BarPool.getInstance();
+
+// Get a bar from the pool (or create a new one if none available)
+Bar bar = barPool.getBar(
+    Duration.ofMinutes(1),  // time period
+    endTime,                // end time
+    openPrice,              // open price
+    highPrice,              // high price
+    lowPrice,               // low price
+    closePrice,             // close price
+    volume,                 // volume
+    amount,                 // amount
+    trades                  // number of trades
+);
+
+// Use the bar...
+
+// Return the bar to the pool when done
+barPool.returnBar(bar);
+```
+
+### Automatic Usage with TimeBarBuilder
+
+The `TimeBarBuilder` automatically uses the `BarPool`:
+
+```java
+// Create a builder
+TimeBarBuilder builder = new TimeBarBuilder();
+
+// Configure the builder
+builder.timePeriod(Duration.ofMinutes(1))
+       .endTime(endTime)
+       .openPrice(openPrice)
+       .highPrice(highPrice)
+       .lowPrice(lowPrice)
+       .closePrice(closePrice)
+       .volume(volume)
+       .amount(amount)
+       .trades(trades);
+
+// Build a bar (uses BarPool internally)
+Bar bar = builder.build();
+```
+
+### Automatic Usage with BaseBarSeries
+
+When you set a maximum bar count on a `BaseBarSeries`, removed bars are automatically returned to the pool:
+
+```java
+// Create a bar series with maximum bar count
+BaseBarSeries series = new BaseBarSeriesBuilder()
+        .withName("my series")
+        .withMaxBarCount(1000)  // Only keep the most recent 1000 bars
+        .build();
+
+// As new bars are added and old ones are removed, 
+// the removed bars are automatically returned to the pool
+```
+
+## Performance Benefits
+
+The `BarPool` provides several performance benefits:
+
+1. **Reduced Memory Allocation**: By reusing existing objects, fewer new objects need to be allocated
+2. **Less Garbage Collection**: Fewer objects being created means less work for the garbage collector
+3. **Improved Cache Locality**: Reusing the same objects can lead to better CPU cache utilization
+
+These benefits are particularly noticeable in applications that process large amounts of market data or run extensive backtests.
+
+## Thread Safety
+
+The `BarPool` implementation is thread-safe, using `ConcurrentHashMap` and `ConcurrentLinkedQueue` to ensure safe operation in multi-threaded environments.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Ta4j is an open source Java library for [technical analysis](http://en.wikipedia
  * [x] More than 130 technical indicators (Aroon, ATR, moving averages, parabolic SAR, RSI, etc.)
  * [x] A powerful engine for building custom trading strategies
  * [x] Utilities to run and compare strategies
+ * [x] Memory optimization with object pooling for Bar instances ([details](BarPool.md))
  * [x] Minimal 3rd party dependencies
  * [x] Simple integration
  * [x] One more thing: it's MIT licensed

--- a/ta4j-core/src/main/java/org/ta4j/core/BarPool.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarPool.java
@@ -1,0 +1,99 @@
+package org.ta4j.core;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * An object pool for {@link Bar} instances to reduce memory usage and garbage collection.
+ * This class maintains a pool of {@link BaseBar} objects that can be reused instead of
+ * creating new instances each time.
+ */
+public class BarPool {
+
+    /** Singleton instance of the BarPool */
+    private static final BarPool INSTANCE = new BarPool();
+
+    /** Map of pools for different time periods */
+    private final Map<Duration, ConcurrentLinkedQueue<BaseBar>> pools = new ConcurrentHashMap<>();
+
+    /** Maximum size for each pool */
+    private static final int MAX_POOL_SIZE = 10_000;
+
+    /**
+     * Private constructor to enforce singleton pattern
+     */
+    private BarPool() {
+    }
+
+    /**
+     * Gets the singleton instance of the BarPool
+     * 
+     * @return the singleton instance
+     */
+    public static BarPool getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Gets a Bar from the pool or creates a new one if none is available
+     * 
+     * @param timePeriod the time period
+     * @param endTime    the end time of the bar period
+     * @param openPrice  the open price of the bar period
+     * @param highPrice  the highest price of the bar period
+     * @param lowPrice   the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume     the total traded volume of the bar period
+     * @param amount     the total traded amount of the bar period
+     * @param trades     the number of trades of the bar period
+     * @return a Bar instance (either from the pool or newly created)
+     */
+    public Bar getBar(Duration timePeriod, Instant endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+            Num volume, Num amount, long trades) {
+        
+        // Get or create the pool for this time period
+        ConcurrentLinkedQueue<BaseBar> pool = pools.computeIfAbsent(timePeriod, 
+                k -> new ConcurrentLinkedQueue<>());
+        
+        // Try to get a bar from the pool
+        BaseBar bar = pool.poll();
+        
+        if (bar == null) {
+            // If no bar is available in the pool, create a new one
+            return new BaseBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        } else {
+            // Reset the bar with the new values
+            bar.resetBar(endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+            return bar;
+        }
+    }
+
+    /**
+     * Returns a Bar to the pool for reuse
+     * 
+     * @param bar the Bar to return to the pool
+     */
+    public void returnBar(Bar bar) {
+        if (bar instanceof BaseBar) {
+            BaseBar baseBar = (BaseBar) bar;
+            Duration timePeriod = bar.getTimePeriod();
+            
+            ConcurrentLinkedQueue<BaseBar> pool = pools.get(timePeriod);
+            if (pool != null && pool.size() < MAX_POOL_SIZE) {
+                pool.offer(baseBar);
+            }
+        }
+    }
+
+    /**
+     * Clears all pools
+     */
+    public void clear() {
+        pools.clear();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBar.java
@@ -40,10 +40,10 @@ public class BaseBar implements Bar {
     private final Duration timePeriod;
 
     /** The begin time of the bar period (in UTC). */
-    private final Instant beginTime;
+    private Instant beginTime;
 
     /** The end time of the bar period (in UTC). */
-    private final Instant endTime;
+    private Instant endTime;
 
     /** The open price of the bar period. */
     private Num openPrice;
@@ -200,5 +200,31 @@ public class BaseBar implements Bar {
                 && Objects.equals(highPrice, other.highPrice) && Objects.equals(lowPrice, other.lowPrice)
                 && Objects.equals(closePrice, other.closePrice) && Objects.equals(volume, other.volume)
                 && Objects.equals(amount, other.amount) && trades == other.trades;
+    }
+
+    /**
+     * Resets this bar with the provided values.
+     * This method is used by the BarPool to reuse Bar instances.
+     *
+     * @param endTime    the end time of the bar period (in UTC)
+     * @param openPrice  the open price of the bar period
+     * @param highPrice  the highest price of the bar period
+     * @param lowPrice   the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume     the total traded volume of the bar period
+     * @param amount     the total traded amount of the bar period
+     * @param trades     the number of trades of the bar period
+     */
+    public void resetBar(Instant endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+            Num volume, Num amount, long trades) {
+        this.endTime = Objects.requireNonNull(endTime, "End time cannot be null");
+        this.beginTime = endTime.minus(timePeriod);
+        this.openPrice = openPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.closePrice = closePrice;
+        this.volume = volume;
+        this.amount = amount;
+        this.trades = trades;
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -251,7 +251,10 @@ public class BaseBarSeries implements BarSeries {
 
         if (!this.bars.isEmpty()) {
             if (replace) {
+                // Return the replaced bar to the pool
+                Bar replacedBar = this.bars.get(this.bars.size() - 1);
                 this.bars.set(this.bars.size() - 1, bar);
+                org.ta4j.core.BarPool.getInstance().returnBar(replacedBar);
                 return;
             }
             final int lastBarIndex = this.bars.size() - 1;
@@ -296,8 +299,14 @@ public class BaseBarSeries implements BarSeries {
             // Removing old bars
             final int nbBarsToRemove = barCount - this.maximumBarCount;
             if (nbBarsToRemove == 1) {
-                this.bars.remove(0);
+                Bar removedBar = this.bars.remove(0);
+                // Return the removed bar to the pool
+                org.ta4j.core.BarPool.getInstance().returnBar(removedBar);
             } else {
+                // Return the bars to be removed to the pool
+                for (int i = 0; i < nbBarsToRemove; i++) {
+                    org.ta4j.core.BarPool.getInstance().returnBar(this.bars.get(i));
+                }
                 this.bars.subList(0, nbBarsToRemove).clear();
             }
             // Updating removed bars count

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarBuilder;
+import org.ta4j.core.BarPool;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseBar;
 import org.ta4j.core.num.DoubleNumFactory;
@@ -206,7 +207,7 @@ public class TimeBarBuilder implements BarBuilder {
 
     @Override
     public Bar build() {
-        return new BaseBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
+        return BarPool.getInstance().getBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
                 this.closePrice, this.volume, this.amount, this.trades);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/BarPoolTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarPoolTest.java
@@ -1,0 +1,233 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.num.DoubleNum;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.Num;
+
+/**
+ * Tests for the {@link BarPool} class.
+ */
+public class BarPoolTest {
+
+    private BarPool barPool;
+    private Duration timePeriod;
+    private Instant endTime;
+    private Num openPrice, highPrice, lowPrice, closePrice, volume, amount;
+    private long trades;
+
+    @Before
+    public void setUp() {
+        barPool = BarPool.getInstance();
+        timePeriod = Duration.ofMinutes(1);
+        endTime = Instant.parse("2023-01-01T12:00:00Z");
+        
+        // Initialize with DoubleNum values
+        Num zero = DoubleNumFactory.getInstance().numOf(0);
+        openPrice = DoubleNumFactory.getInstance().numOf(100);
+        highPrice = DoubleNumFactory.getInstance().numOf(110);
+        lowPrice = DoubleNumFactory.getInstance().numOf(90);
+        closePrice = DoubleNumFactory.getInstance().numOf(105);
+        volume = DoubleNumFactory.getInstance().numOf(1000);
+        amount = DoubleNumFactory.getInstance().numOf(105000);
+        trades = 10;
+    }
+
+    @After
+    public void tearDown() {
+        // Clear the pool after each test to ensure tests don't affect each other
+        barPool.clear();
+    }
+
+    @Test
+    public void testSingletonPattern() {
+        BarPool instance1 = BarPool.getInstance();
+        BarPool instance2 = BarPool.getInstance();
+        
+        assertSame("BarPool should be a singleton", instance1, instance2);
+    }
+
+    @Test
+    public void testGetBarCreatesNewBarWhenPoolEmpty() {
+        Bar bar = barPool.getBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        
+        assertNotNull("Should create a new bar when pool is empty", bar);
+        assertEquals("Bar should have correct time period", timePeriod, bar.getTimePeriod());
+        assertEquals("Bar should have correct end time", endTime, bar.getEndTime());
+        assertEquals("Bar should have correct open price", openPrice, bar.getOpenPrice());
+        assertEquals("Bar should have correct high price", highPrice, bar.getHighPrice());
+        assertEquals("Bar should have correct low price", lowPrice, bar.getLowPrice());
+        assertEquals("Bar should have correct close price", closePrice, bar.getClosePrice());
+        assertEquals("Bar should have correct volume", volume, bar.getVolume());
+        assertEquals("Bar should have correct amount", amount, bar.getAmount());
+        assertEquals("Bar should have correct trades", trades, bar.getTrades());
+    }
+
+    @Test
+    public void testReturnAndReuseBar() {
+        // Get a bar from the pool (will create a new one since pool is empty)
+        Bar bar1 = barPool.getBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        
+        // Return the bar to the pool
+        barPool.returnBar(bar1);
+        
+        // Get another bar with different values
+        Instant newEndTime = endTime.plusSeconds(60);
+        Num newClosePrice = DoubleNumFactory.getInstance().numOf(106);
+        Bar bar2 = barPool.getBar(timePeriod, newEndTime, openPrice, highPrice, lowPrice, newClosePrice, volume, amount, trades);
+        
+        // The second bar should be the same instance as the first one, but with updated values
+        assertSame("Should reuse bar from pool", bar1, bar2);
+        assertEquals("Bar should have updated end time", newEndTime, bar2.getEndTime());
+        assertEquals("Bar should have updated close price", newClosePrice, bar2.getClosePrice());
+    }
+
+    @Test
+    public void testDifferentTimePeriods() {
+        // Create bars with different time periods
+        Duration period1 = Duration.ofMinutes(1);
+        Duration period5 = Duration.ofMinutes(5);
+        
+        Bar bar1min = barPool.getBar(period1, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        Bar bar5min = barPool.getBar(period5, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        
+        // Return both bars to the pool
+        barPool.returnBar(bar1min);
+        barPool.returnBar(bar5min);
+        
+        // Get bars with the same time periods again
+        Bar newBar1min = barPool.getBar(period1, endTime.plusSeconds(60), openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        Bar newBar5min = barPool.getBar(period5, endTime.plusSeconds(300), openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        
+        // Each bar should be reused from its respective pool
+        assertSame("Should reuse 1-minute bar from pool", bar1min, newBar1min);
+        assertSame("Should reuse 5-minute bar from pool", bar5min, newBar5min);
+        assertNotSame("Bars with different periods should be different instances", newBar1min, newBar5min);
+    }
+
+    @Test
+    public void testPoolSizeLimit() throws Exception {
+        // Access the private MAX_POOL_SIZE field using reflection
+        Field maxPoolSizeField = BarPool.class.getDeclaredField("MAX_POOL_SIZE");
+        maxPoolSizeField.setAccessible(true);
+        int maxPoolSize = (int) maxPoolSizeField.get(null);
+        
+        // Access the private pools field using reflection
+        Field poolsField = BarPool.class.getDeclaredField("pools");
+        poolsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Duration, ConcurrentLinkedQueue<BaseBar>> pools = 
+            (Map<Duration, ConcurrentLinkedQueue<BaseBar>>) poolsField.get(barPool);
+        
+        // Create and return more bars than the maximum pool size
+        for (int i = 0; i < maxPoolSize + 10; i++) {
+            Bar bar = barPool.getBar(timePeriod, endTime.plusSeconds(i), openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+            barPool.returnBar(bar);
+        }
+        
+        // Check that the pool size doesn't exceed the maximum
+        ConcurrentLinkedQueue<BaseBar> pool = pools.get(timePeriod);
+        assertTrue("Pool size should not exceed maximum", pool.size() <= maxPoolSize);
+    }
+
+    @Test
+    public void testNonBaseBarNotAddedToPool() {
+        // Create a non-BaseBar implementation
+        Bar nonBaseBar = new Bar() {
+            @Override
+            public Duration getTimePeriod() { return timePeriod; }
+            @Override
+            public Instant getBeginTime() { return endTime.minus(timePeriod); }
+            @Override
+            public Instant getEndTime() { return endTime; }
+            @Override
+            public Num getOpenPrice() { return openPrice; }
+            @Override
+            public Num getHighPrice() { return highPrice; }
+            @Override
+            public Num getLowPrice() { return lowPrice; }
+            @Override
+            public Num getClosePrice() { return closePrice; }
+            @Override
+            public Num getVolume() { return volume; }
+            @Override
+            public Num getAmount() { return amount; }
+            @Override
+            public long getTrades() { return trades; }
+            @Override
+            public void addTrade(Num tradeVolume, Num tradePrice) { }
+            @Override
+            public void addPrice(Num price) { }
+        };
+        
+        // Try to return the non-BaseBar to the pool
+        barPool.returnBar(nonBaseBar);
+        
+        // Get a bar from the pool - it should be a new instance, not the one we tried to return
+        Bar newBar = barPool.getBar(timePeriod, endTime, openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+        
+        assertNotSame("Non-BaseBar implementation should not be added to pool", nonBaseBar, newBar);
+    }
+
+    @Test
+    public void testClearPool() throws Exception {
+        // Create and return some bars to the pool
+        for (int i = 0; i < 5; i++) {
+            Bar bar = barPool.getBar(timePeriod, endTime.plusSeconds(i), openPrice, highPrice, lowPrice, closePrice, volume, amount, trades);
+            barPool.returnBar(bar);
+        }
+        
+        // Access the private pools field using reflection
+        Field poolsField = BarPool.class.getDeclaredField("pools");
+        poolsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Duration, ConcurrentLinkedQueue<BaseBar>> pools = 
+            (Map<Duration, ConcurrentLinkedQueue<BaseBar>>) poolsField.get(barPool);
+        
+        // Verify that the pool is not empty
+        assertTrue("Pool should not be empty before clearing", !pools.isEmpty());
+        
+        // Clear the pool
+        barPool.clear();
+        
+        // Verify that the pool is now empty
+        assertTrue("Pool should be empty after clearing", pools.isEmpty());
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderPoolTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderPoolTest.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarPool;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.Num;
+
+/**
+ * Tests for the integration between {@link TimeBarBuilder} and {@link BarPool}.
+ */
+public class TimeBarBuilderPoolTest {
+
+    private BarPool barPool;
+    private TimeBarBuilder builder;
+    private Duration timePeriod;
+    private Instant endTime;
+    private Num openPrice, highPrice, lowPrice, closePrice, volume, amount;
+    private long trades;
+
+    @Before
+    public void setUp() {
+        barPool = BarPool.getInstance();
+        builder = new TimeBarBuilder(DoubleNumFactory.getInstance());
+        timePeriod = Duration.ofMinutes(1);
+        endTime = Instant.parse("2023-01-01T12:00:00Z");
+
+        // Initialize with DoubleNum values
+        openPrice = DoubleNumFactory.getInstance().numOf(100);
+        highPrice = DoubleNumFactory.getInstance().numOf(110);
+        lowPrice = DoubleNumFactory.getInstance().numOf(90);
+        closePrice = DoubleNumFactory.getInstance().numOf(105);
+        volume = DoubleNumFactory.getInstance().numOf(1000);
+        amount = DoubleNumFactory.getInstance().numOf(105000);
+        trades = 10;
+    }
+
+    @After
+    public void tearDown() {
+        // Clear the pool after each test to ensure tests don't affect each other
+        barPool.clear();
+    }
+
+    @Test
+    public void testTimeBarBuilderUsesBarPool() {
+        // Configure the builder
+        builder.timePeriod(timePeriod)
+               .endTime(endTime)
+               .openPrice(openPrice)
+               .highPrice(highPrice)
+               .lowPrice(lowPrice)
+               .closePrice(closePrice)
+               .volume(volume)
+               .amount(amount)
+               .trades(trades);
+
+        // Build a bar
+        Bar bar1 = builder.build();
+
+        // Verify the bar has the correct properties
+        assertNotNull("Bar should not be null", bar1);
+        assertEquals("Bar should have correct time period", timePeriod, bar1.getTimePeriod());
+        assertEquals("Bar should have correct end time", endTime, bar1.getEndTime());
+        assertEquals("Bar should have correct open price", openPrice, bar1.getOpenPrice());
+        assertEquals("Bar should have correct high price", highPrice, bar1.getHighPrice());
+        assertEquals("Bar should have correct low price", lowPrice, bar1.getLowPrice());
+        assertEquals("Bar should have correct close price", closePrice, bar1.getClosePrice());
+        assertEquals("Bar should have correct volume", volume, bar1.getVolume());
+        assertEquals("Bar should have correct amount", amount, bar1.getAmount());
+        assertEquals("Bar should have correct trades", trades, bar1.getTrades());
+
+        // Return the bar to the pool
+        barPool.returnBar(bar1);
+
+        // Build another bar with the same time period
+        builder.endTime(endTime.plusSeconds(60));
+        Bar bar2 = builder.build();
+
+        // The second bar should be the same instance as the first one, but with updated values
+        assertSame("TimeBarBuilder should reuse bar from pool", bar1, bar2);
+        assertEquals("Bar should have updated end time", endTime.plusSeconds(60), bar2.getEndTime());
+    }
+
+    @Test
+    public void testTimeBarBuilderWithBarSeries() throws Exception {
+        // Create a bar series with maximum bar count of 1
+        BaseBarSeries series = new BaseBarSeriesBuilder()
+                .withName("test series")
+                .withNumFactory(DoubleNumFactory.getInstance())
+                .withMaxBarCount(1)
+                .build();
+
+        // Access the private pools field using reflection to check the pool state
+        Field poolsField = BarPool.class.getDeclaredField("pools");
+        poolsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Duration, ConcurrentLinkedQueue<BaseBar>> pools = 
+            (Map<Duration, ConcurrentLinkedQueue<BaseBar>>) poolsField.get(barPool);
+
+        // Initially, the pool should be empty
+        ConcurrentLinkedQueue<BaseBar> pool = pools.get(timePeriod);
+        assertEquals("Pool should be empty initially", 0, pool != null ? pool.size() : 0);
+
+        // Bind the builder to the series
+        builder.bindTo(series)
+               .timePeriod(timePeriod)
+               .endTime(endTime)
+               .openPrice(openPrice)
+               .highPrice(highPrice)
+               .lowPrice(lowPrice)
+               .closePrice(closePrice)
+               .volume(volume)
+               .amount(amount)
+               .trades(trades);
+
+        // Add a bar to the series
+        builder.add();
+
+        // Verify the bar was added to the series
+        assertEquals("Series should have 1 bar", 1, series.getBarCount());
+        Bar firstBar = series.getBar(0);
+        assertEquals("Bar should have correct end time", endTime, firstBar.getEndTime());
+
+        // Add a second bar with a later time - this should cause the first bar to be removed and returned to the pool
+        Instant laterTime = endTime.plusSeconds(60);
+        builder.endTime(laterTime).add();
+
+        // Verify the series still has 1 bar (the second one)
+        assertEquals("Series should still have 1 bar", 1, series.getBarCount());
+        Bar secondBar = series.getBar(0);
+        assertEquals("Bar should have updated end time", laterTime, secondBar.getEndTime());
+
+        // Now the pool should have the first bar
+        pool = pools.get(timePeriod);
+        assertEquals("Pool should have 1 bar", 1, pool.size());
+
+        // Add a third bar with an even later time - this should reuse the bar from the pool
+        Instant evenLaterTime = laterTime.plusSeconds(60);
+        builder.endTime(evenLaterTime).add();
+
+        // Verify the series still has 1 bar (the third one)
+        assertEquals("Series should still have 1 bar", 1, series.getBarCount());
+        Bar thirdBar = series.getBar(0);
+        assertEquals("Bar should have updated end time", evenLaterTime, thirdBar.getEndTime());
+
+        // The pool should still have 1 bar (the second one)
+        assertEquals("Pool should still have 1 bar", 1, pool.size());
+    }
+}


### PR DESCRIPTION
Implemented a singleton BarPool to reduce memory usage and garbage collection by reusing Bar instances. Updated BaseBar to support reset functionality for reuse and modified relevant components like BaseBarSeries and TimeBarBuilder to integrate with the pool. Added comprehensive tests and documentation for the new feature.

Changes proposed in this pull request:
- Add a BaseBar object pool for re-using objects in a high-frequency environment to reduce garbage collection

Since this isn't a "bug", I'm unsure of the template to use here. I'm curious if this would be considered useful by the community at large.