### PR TITLE
Add HFTBar (high-frequency trading) to use atomic types for thread safety

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/HFTBar.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/HFTBar.java
@@ -1,0 +1,360 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.ta4j.core.num.Num;
+
+/**
+ * High-Frequency Trading implementation of a {@link Bar}.
+ * 
+ * <p>
+ * This implementation is thread-safe. It uses atomic references and operations
+ * to ensure that multiple threads can safely read from and write to an HFTBar instance
+ * without explicit synchronization. This makes it suitable for use in multi-threaded
+ * environments such as high-frequency trading systems where multiple threads might be
+ * updating the same bar with new trades or prices.
+ */
+public class HFTBar implements Bar {
+
+    private static final long serialVersionUID = 8038383777467488147L;
+
+    /** The time period (e.g. 1 day, 15 min, etc.) of the bar. */
+    private final Duration timePeriod;
+
+    /** The begin time of the bar period (in UTC). */
+    private final Instant beginTime;
+
+    /** The end time of the bar period (in UTC). */
+    private final Instant endTime;
+
+    /** 
+     * The open price of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> openPrice;
+
+    /** 
+     * The high price of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> highPrice;
+
+    /** 
+     * The low price of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> lowPrice;
+
+    /** 
+     * The close price of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> closePrice;
+
+    /** 
+     * The total traded volume of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> volume;
+
+    /** 
+     * The total traded amount of the bar period.
+     * Uses AtomicReference for thread-safe operations.
+     */
+    private AtomicReference<Num> amount;
+
+    /** 
+     * The number of trades of the bar period.
+     * Uses AtomicLong for thread-safe operations.
+     */
+    private AtomicLong trades;
+
+    /**
+     * Constructor.
+     *
+     * <p>
+     * The {@link #beginTime} will be calculated by {@link #endTime} -
+     * {@link #timePeriod}.
+     * 
+     * <p>
+     * This constructor initializes all mutable fields with thread-safe atomic 
+     * references and counters. The price, volume, and amount fields are wrapped in 
+     * {@link AtomicReference} instances, and the trades count is stored in an 
+     * {@link AtomicLong}. This ensures that all operations on these fields can be 
+     * performed safely in a multi-threaded environment without explicit synchronization.
+     *
+     * @param timePeriod the time period
+     * @param endTime    the end time of the bar period (in UTC)
+     * @param openPrice  the open price of the bar period
+     * @param highPrice  the highest price of the bar period
+     * @param lowPrice   the lowest price of the bar period
+     * @param closePrice the close price of the bar period
+     * @param volume     the total traded volume of the bar period
+     * @param amount     the total traded amount of the bar period
+     * @param trades     the number of trades of the bar period
+     * @throws NullPointerException if {@link #endTime} or {@link #timePeriod} is
+     *                              {@code null}
+     */
+    public HFTBar(Duration timePeriod, Instant endTime, Num openPrice, Num highPrice, Num lowPrice, Num closePrice,
+            Num volume, Num amount, long trades) {
+        this.timePeriod = Objects.requireNonNull(timePeriod, "Time period cannot be null");
+        this.endTime = Objects.requireNonNull(endTime, "End time cannot be null");
+        this.beginTime = endTime.minus(timePeriod);
+        this.openPrice = new AtomicReference<>(openPrice);
+        this.highPrice = new AtomicReference<>(highPrice);
+        this.lowPrice = new AtomicReference<>(lowPrice);
+        this.closePrice = new AtomicReference<>(closePrice);
+        this.volume = new AtomicReference<>(volume);
+        this.amount = new AtomicReference<>(amount);
+        this.trades = new AtomicLong(trades);
+    }
+
+    @Override
+    public Duration getTimePeriod() {
+        return timePeriod;
+    }
+
+    @Override
+    public Instant getBeginTime() {
+        return beginTime;
+    }
+
+    @Override
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the open price at the time of the call.
+     */
+    @Override
+    public Num getOpenPrice() {
+        return openPrice.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the high price at the time of the call.
+     */
+    @Override
+    public Num getHighPrice() {
+        return highPrice.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the low price at the time of the call.
+     */
+    @Override
+    public Num getLowPrice() {
+        return lowPrice.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the close price at the time of the call.
+     */
+    @Override
+    public Num getClosePrice() {
+        return closePrice.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the volume at the time of the call.
+     */
+    @Override
+    public Num getVolume() {
+        return volume.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic reference,
+     * providing a thread-safe view of the amount at the time of the call.
+     */
+    @Override
+    public Num getAmount() {
+        return amount.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation returns the current value of the atomic counter,
+     * providing a thread-safe view of the trades count at the time of the call.
+     */
+    @Override
+    public long getTrades() {
+        return trades.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation is thread-safe. It uses atomic operations to ensure that
+     * multiple threads can safely add trades to the same bar without data corruption
+     * or inconsistency. The method uses compare-and-set operations to atomically
+     * update volume and amount, and atomic increment for the trades count.
+     */
+    @Override
+    public void addTrade(Num tradeVolume, Num tradePrice) {
+        addPrice(tradePrice);
+
+        Num currentVolume, newVolume;
+        do {
+            currentVolume = volume.get();
+            newVolume = currentVolume.plus(tradeVolume);
+        } while (!volume.compareAndSet(currentVolume, newVolume));
+
+        Num currentAmount, newAmount;
+        do {
+            currentAmount = amount.get();
+            newAmount = currentAmount.plus(tradeVolume.multipliedBy(tradePrice));
+        } while (!amount.compareAndSet(currentAmount, newAmount));
+
+        trades.incrementAndGet();
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * <p>
+     * This implementation is thread-safe. It uses atomic operations to ensure that
+     * multiple threads can safely update prices without data corruption or inconsistency.
+     * The method uses compare-and-set operations to atomically update open, high, and low prices
+     * when appropriate. Note that close price is always set to the most recent price.
+     * 
+     * <p>
+     * The high price is updated only if the new price is higher than the current high price,
+     * and the low price is updated only if the new price is lower than the current low price.
+     * These updates are performed atomically to ensure consistency in a multi-threaded environment.
+     */
+    @Override
+    public void addPrice(Num price) {
+        Num currentOpenPrice = openPrice.get();
+        if (currentOpenPrice == null) {
+            openPrice.compareAndSet(null, price);
+        }
+
+        closePrice.set(price);
+
+        Num currentHighPrice;
+        do {
+            currentHighPrice = highPrice.get();
+            if (currentHighPrice != null && !currentHighPrice.isLessThan(price)) {
+                break;
+            }
+        } while (!highPrice.compareAndSet(currentHighPrice, price));
+
+        Num currentLowPrice;
+        do {
+            currentLowPrice = lowPrice.get();
+            if (currentLowPrice != null && !currentLowPrice.isGreaterThan(price)) {
+                break;
+            }
+        } while (!lowPrice.compareAndSet(currentLowPrice, price));
+    }
+
+    /**
+     * Returns a string representation of this bar.
+     * 
+     * <p>
+     * This method is thread-safe as it uses the getter methods which access
+     * the atomic references in a thread-safe manner.
+     * 
+     * @return {end time, close price, open price, low price, high price, volume}
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "{end time: %1s, close price: %2s, open price: %3s, low price: %4s high price: %5s, volume: %6s}",
+                endTime, getClosePrice(), getOpenPrice(), getLowPrice(), getHighPrice(), getVolume());
+    }
+
+    /**
+     * Returns a hash code value for this bar.
+     * 
+     * <p>
+     * This method is thread-safe as it uses the getter methods which access
+     * the atomic references in a thread-safe manner.
+     * 
+     * @return a hash code value for this bar
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(beginTime, endTime, timePeriod, getOpenPrice(), getHighPrice(), getLowPrice(), getClosePrice(), getVolume(), getAmount(),
+                getTrades());
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * 
+     * <p>
+     * This method is thread-safe as it uses the getter methods which access
+     * the atomic references in a thread-safe manner.
+     * 
+     * @param obj the reference object with which to compare
+     * @return true if this object is the same as the obj argument; false otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof HFTBar))
+            return false;
+        final HFTBar other = (HFTBar) obj;
+        return Objects.equals(beginTime, other.beginTime) && Objects.equals(endTime, other.endTime)
+                && Objects.equals(timePeriod, other.timePeriod) && Objects.equals(getOpenPrice(), other.getOpenPrice())
+                && Objects.equals(getHighPrice(), other.getHighPrice()) && Objects.equals(getLowPrice(), other.getLowPrice())
+                && Objects.equals(getClosePrice(), other.getClosePrice()) && Objects.equals(getVolume(), other.getVolume())
+                && Objects.equals(getAmount(), other.getAmount()) && getTrades() == other.getTrades();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HFTBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HFTBarBuilder.java
@@ -1,0 +1,217 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarBuilder;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.HFTBar;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+/**
+ * A builder for creating HFTBar instances, optimized for high-frequency trading.
+ */
+public class HFTBarBuilder implements BarBuilder {
+
+    private final NumFactory numFactory;
+    Duration timePeriod;
+    Instant endTime;
+    Num openPrice;
+    Num highPrice;
+    Num lowPrice;
+    Num closePrice;
+    Num volume;
+    Num amount;
+    long trades;
+    private BarSeries barSeries;
+
+    /** A builder to build a new {@link HFTBar} with {@link DoubleNumFactory} */
+    public HFTBarBuilder() {
+        this(DoubleNumFactory.getInstance());
+    }
+
+    /**
+     * A builder to build a new {@link HFTBar}
+     *
+     * @param numFactory the factory to create numbers
+     */
+    public HFTBarBuilder(final NumFactory numFactory) {
+        this.numFactory = numFactory;
+    }
+
+    @Override
+    public BarBuilder timePeriod(final Duration timePeriod) {
+        this.timePeriod = timePeriod;
+        return this;
+    }
+
+    @Override
+    public BarBuilder endTime(final Instant endTime) {
+        this.endTime = endTime;
+        return this;
+    }
+
+    @Override
+    public BarBuilder openPrice(final Num openPrice) {
+        this.openPrice = openPrice;
+        return this;
+    }
+
+    @Override
+    public BarBuilder openPrice(final Number openPrice) {
+        openPrice(this.numFactory.numOf(openPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder openPrice(final String openPrice) {
+        openPrice(this.numFactory.numOf(openPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder highPrice(final Number highPrice) {
+        highPrice(this.numFactory.numOf(highPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder highPrice(final String highPrice) {
+        highPrice(this.numFactory.numOf(highPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder highPrice(final Num highPrice) {
+        this.highPrice = highPrice;
+        return this;
+    }
+
+    @Override
+    public BarBuilder lowPrice(final Num lowPrice) {
+        this.lowPrice = lowPrice;
+        return this;
+    }
+
+    @Override
+    public BarBuilder lowPrice(final Number lowPrice) {
+        lowPrice(this.numFactory.numOf(lowPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder lowPrice(final String lowPrice) {
+        lowPrice(this.numFactory.numOf(lowPrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder closePrice(final Num closePrice) {
+        this.closePrice = closePrice;
+        return this;
+    }
+
+    @Override
+    public BarBuilder closePrice(final Number closePrice) {
+        closePrice(this.numFactory.numOf(closePrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder closePrice(final String closePrice) {
+        closePrice(this.numFactory.numOf(closePrice));
+        return this;
+    }
+
+    @Override
+    public BarBuilder volume(final Num volume) {
+        this.volume = volume;
+        return this;
+    }
+
+    @Override
+    public BarBuilder volume(final Number volume) {
+        volume(this.numFactory.numOf(volume));
+        return this;
+    }
+
+    @Override
+    public BarBuilder volume(final String volume) {
+        volume(this.numFactory.numOf(volume));
+        return this;
+    }
+
+    @Override
+    public BarBuilder amount(final Num amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    @Override
+    public BarBuilder amount(final Number amount) {
+        amount(this.numFactory.numOf(amount));
+        return this;
+    }
+
+    @Override
+    public BarBuilder amount(final String amount) {
+        amount(this.numFactory.numOf(amount));
+        return this;
+    }
+
+    @Override
+    public BarBuilder trades(final long trades) {
+        this.trades = trades;
+        return this;
+    }
+
+    @Override
+    public BarBuilder trades(final String trades) {
+        trades(Long.parseLong(trades));
+        return this;
+    }
+
+    @Override
+    public BarBuilder bindTo(final BarSeries barSeries) {
+        this.barSeries = Objects.requireNonNull(barSeries);
+        return this;
+    }
+
+    @Override
+    public Bar build() {
+        return new HFTBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
+                this.closePrice, this.volume, this.amount, this.trades);
+    }
+
+    @Override
+    public void add() {
+        this.barSeries.addBar(build());
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HFTBarBuilderFactory.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HFTBarBuilderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import org.ta4j.core.BarBuilder;
+import org.ta4j.core.BarBuilderFactory;
+import org.ta4j.core.BarSeries;
+
+/**
+ * Factory for creating {@link HFTBarBuilder} instances.
+ * This factory is used for high-frequency trading scenarios where thread-safety is important.
+ */
+public class HFTBarBuilderFactory implements BarBuilderFactory {
+
+    @Override
+    public BarBuilder createBarBuilder(BarSeries series) {
+        return new HFTBarBuilder(series.numFactory()).bindTo(series);
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/HFTBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/HFTBarBuilderTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2024 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.bars;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.Test;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.HFTBar;
+import org.ta4j.core.num.DoubleNumFactory;
+
+public class HFTBarBuilderTest {
+
+    @Test
+    public void testBuildHFTBar() {
+        final var series = new BaseBarSeriesBuilder().withBarBuilderFactory(new HFTBarBuilderFactory()).build();
+        final var now = Instant.now();
+        final var oneDay = Duration.ofDays(1);
+
+        series.barBuilder().timePeriod(oneDay).endTime(now).openPrice(1).highPrice(1).lowPrice(1).closePrice(1).volume(1).amount(1).trades(1).add();
+        series.barBuilder().timePeriod(oneDay).endTime(now.plus(Duration.ofDays(1))).openPrice(2).highPrice(2).lowPrice(2).closePrice(2).volume(1).amount(2).trades(1).add();
+        series.barBuilder().timePeriod(oneDay).endTime(now.plus(Duration.ofDays(2))).openPrice(5).highPrice(5).lowPrice(5).closePrice(5).volume(1).amount(5).trades(1).add();
+        series.barBuilder().timePeriod(oneDay).endTime(now.plus(Duration.ofDays(3))).openPrice(1).highPrice(1).lowPrice(1).closePrice(1).volume(1).amount(1).trades(1).add();
+        series.barBuilder().timePeriod(oneDay).endTime(now.plus(Duration.ofDays(4))).openPrice(4).highPrice(4).lowPrice(4).closePrice(4).volume(2).amount(8).trades(1).add();
+
+        assertEquals(5, series.getBarCount());
+
+        // Verify that all bars are HFTBar instances
+        for (int i = 0; i < series.getBarCount(); i++) {
+            assertTrue(series.getBar(i) instanceof HFTBar);
+        }
+
+        // Verify the properties of the first bar
+        final var bar0 = series.getBar(0);
+        assertNumEquals(1, bar0.getVolume());
+        assertNumEquals(1, bar0.getOpenPrice());
+        assertNumEquals(1, bar0.getClosePrice());
+        assertNumEquals(1, bar0.getHighPrice());
+        assertNumEquals(1, bar0.getLowPrice());
+        assertEquals(oneDay, bar0.getTimePeriod());
+        assertEquals(now, bar0.getEndTime());
+
+        // Verify the properties of the last bar
+        final var bar4 = series.getBar(4);
+        assertNumEquals(2, bar4.getVolume());
+        assertNumEquals(4, bar4.getOpenPrice());
+        assertNumEquals(4, bar4.getClosePrice());
+        assertNumEquals(4, bar4.getHighPrice());
+        assertNumEquals(4, bar4.getLowPrice());
+        assertEquals(oneDay, bar4.getTimePeriod());
+        assertEquals(now.plus(Duration.ofDays(4)), bar4.getEndTime());
+    }
+}


### PR DESCRIPTION
Add HFTBar implementation for high-frequency trading use cases

Introduced a thread-safe HFTBar class optimized for multi-threaded environments and high-frequency trading. Included a builder (HFTBarBuilder) and factory (HFTBarBuilderFactory) for creating instances, along with comprehensive test coverage. Adjusted BaseBar to remove thread-safe overhead, distinguishing it from HFTBar.

Changes proposed in this pull request:
- Add a new HFTBar (high-frequency) implementation

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
