### PR TITLE
Use parameters flag for compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,9 @@
                     <release>21</release>
                     <source>21</source>
                     <target>21</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/1271

Changes proposed in this pull request:
- Use -parameters flag for compilation, to enable more richer reflection and KSP processing
