### PR TITLE
Refactor ProfitLossPercentageCriterion to calculate aggregated return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Updated test status badge on README
 - Fixed EnterAndHoldCriterion to keep track of transaction and hold costs
 - Clarify PnL criterion comments about trading costs
+- Refactor ProfitLossPercentageCriterion to calculate aggregated return
 
 ### Changed
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterion.java
@@ -25,6 +25,7 @@ package org.ta4j.core.criteria.pnl;
 
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractAnalysisCriterion;
 import org.ta4j.core.num.Num;
@@ -42,9 +43,9 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        final var numFactory = series.numFactory();
+        var numFactory = series.numFactory();
         if (position.isClosed()) {
-            Num entryPrice = position.getEntry().getValue();
+            var entryPrice = position.getEntry().getValue();
             return position.getProfit().dividedBy(entryPrice).multipliedBy(numFactory.hundred());
         }
         return numFactory.zero();
@@ -52,20 +53,24 @@ public class ProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        final var numFactory = series.numFactory();
+        var numFactory = series.numFactory();
+        var zero = numFactory.zero();
 
-        Num totalProfit = tradingRecord.getPositions().stream()
+        var totalProfit = tradingRecord.getPositions()
+                .stream()
                 .filter(Position::isClosed)
                 .map(Position::getProfit)
-                .reduce(numFactory.zero(), Num::plus);
+                .reduce(zero, Num::plus);
 
-        Num totalEntryPrice = tradingRecord.getPositions().stream()
+        var totalEntryPrice = tradingRecord.getPositions()
+                .stream()
                 .filter(Position::isClosed)
-                .map(position -> position.getEntry().getValue())
-                .reduce(numFactory.zero(), Num::plus);
+                .map(Position::getEntry)
+                .map(Trade::getValue)
+                .reduce(zero, Num::plus);
 
         if (totalEntryPrice.isZero()) {
-            return numFactory.zero();
+            return zero;
         }
         return totalProfit.dividedBy(totalEntryPrice).multipliedBy(numFactory.hundred());
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/pnl/ProfitLossPercentageCriterionTest.java
@@ -50,7 +50,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
                 Trade.buyAt(3, series), Trade.sellAt(5, series));
         AnalysisCriterion profit = getCriterion();
-        assertNumEquals(10 + 5, profit.calculate(series, tradingRecord));
+        assertNumEquals(7.5, profit.calculate(series, tradingRecord));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
         AnalysisCriterion profit = getCriterion();
-        assertNumEquals(-5 + -30, profit.calculate(series, tradingRecord));
+        assertNumEquals(-17.5, profit.calculate(series, tradingRecord));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
                 Trade.buyAt(2, series), Trade.sellAt(5, series));
 
         AnalysisCriterion profit = getCriterion();
-        assertNumEquals(95 + -30, profit.calculate(series, tradingRecord));
+        assertNumEquals(32.5, profit.calculate(series, tradingRecord));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
                 Trade.sellAt(2, series), Trade.buyAt(3, series));
         AnalysisCriterion profit = getCriterion();
-        assertNumEquals(10 + 5, profit.calculate(series, tradingRecord));
+        assertNumEquals(7.5, profit.calculate(series, tradingRecord));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ProfitLossPercentageCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.sellAt(0, series), Trade.buyAt(1, series),
                 Trade.sellAt(2, series), Trade.buyAt(3, series));
         AnalysisCriterion profit = getCriterion();
-        assertNumEquals(-10 - 5, profit.calculate(series, tradingRecord));
+        assertNumEquals(-7.5, profit.calculate(series, tradingRecord));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1272

Changes proposed in this pull request:
- Refactor ProfitLossPercentageCriterion to calculate aggregated return

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
