### PR TITLE
fixed ReturnOverMaxDrawdownCriterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Fixed EnterAndHoldCriterion to keep track of transaction and hold costs
 - Clarify PnL criterion comments about trading costs
 - Refactor ProfitLossPercentageCriterion to calculate aggregated return
+- Fixed calculation of `ReturnOverMaxDrawdownCriterion`
 
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterion.java
@@ -36,12 +36,12 @@ import org.ta4j.core.num.Num;
  * format.
  *
  * <pre>
- * RoMaD = {@link NetReturnCriterion net return (with base)} / {@link MaximumDrawdownCriterion maximum drawdown}
+ * RoMaD = {@link NetReturnCriterion net return (without base)} / {@link MaximumDrawdownCriterion maximum drawdown}
  * </pre>
  */
 public class ReturnOverMaxDrawdownCriterion extends AbstractAnalysisCriterion {
 
-    private final AnalysisCriterion netReturnCriterion = new NetReturnCriterion();
+    private final AnalysisCriterion netReturnCriterion = new NetReturnCriterion(false);
     private final AnalysisCriterion maxDrawdownCriterion = new MaximumDrawdownCriterion();
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/NetReturnCriterion.java
@@ -41,6 +41,7 @@ import org.ta4j.core.num.Num;
  * {@link BarSeries series}.
  */
 public class NetReturnCriterion extends AbstractReturnCriterion {
+
     public NetReturnCriterion() {
         super();
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ReturnOverMaxDrawdownCriterionTest.java
@@ -60,7 +60,7 @@ public class ReturnOverMaxDrawdownCriterionTest extends AbstractCriterionTest {
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
                 Trade.buyAt(2, series), Trade.sellAt(4, series), Trade.buyAt(5, series), Trade.sellAt(7, series));
 
-        double totalProfit = (105d / 100) * (90d / 95d) * (120d / 95);
+        double totalProfit = (105d / 100) * (90d / 95d) * (120d / 95) - 1;
         double peak = (105d / 100) * (100d / 95);
         double low = (105d / 100) * (90d / 95) * (80d / 95);
 


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/802

Changes proposed in this pull request:
- remove the base when calculating `ReturnOverMaxDrawdownCriterion`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
