### PR TITLE
Build bars with beginTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Removed/Deprecated
 
 ### Added
+- Bars can now be built by `beginTime` instead of `endTime`
 
 
 ## 0.18 (released May 15, 2025)

--- a/ta4j-core/src/main/java/org/ta4j/core/BarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarBuilder.java
@@ -31,13 +31,22 @@ import org.ta4j.core.num.Num;
 public interface BarBuilder {
 
     /**
-     * @param timePeriod the time period
+     * @param timePeriod the time period (optional if {@link #beginTime(Instant)}
+     *                   and {@link #endTime(Instant)} are given)
      * @return {@code this}
      */
     BarBuilder timePeriod(Duration timePeriod);
 
     /**
-     * @param endTime the end time of the bar period
+     * @param beginTime the begin time of the bar period (optional if
+     *                  {@link #endTime(Instant)} is given)
+     * @return {@code this}
+     */
+    BarBuilder beginTime(Instant beginTime);
+
+    /**
+     * @param endTime the end time of the bar period (optional if
+     *                {@link #beginTime(Instant)} is given)
      * @return {@code this}
      */
     BarBuilder endTime(Instant endTime);

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/HeikinAshiBarBuilder.java
@@ -68,8 +68,8 @@ public class HeikinAshiBarBuilder extends TimeBarBuilder {
                     .dividedBy(numFactory.numOf(2));
             var heikinAshiHigh = highPrice.max(heikinAshiOpen).max(heikinAshiClose);
             var heikinAshiLow = lowPrice.min(heikinAshiOpen).min(heikinAshiClose);
-            return new BaseBar(timePeriod, endTime, heikinAshiOpen, heikinAshiHigh, heikinAshiLow, heikinAshiClose,
-                    volume, amount, trades);
+            return new BaseBar(timePeriod, beginTime, endTime, heikinAshiOpen, heikinAshiHigh, heikinAshiLow,
+                    heikinAshiClose, volume, amount, trades);
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/TickBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/TickBarBuilder.java
@@ -45,6 +45,7 @@ public class TickBarBuilder implements BarBuilder {
     private int passedTicksCount;
     private BarSeries barSeries;
     private Duration timePeriod;
+    private Instant beginTime;
     private Instant endTime;
     private Num volume;
     private Num openPrice;
@@ -78,6 +79,12 @@ public class TickBarBuilder implements BarBuilder {
     @Override
     public BarBuilder timePeriod(final Duration timePeriod) {
         this.timePeriod = this.timePeriod == null ? timePeriod : this.timePeriod.plus(timePeriod);
+        return this;
+    }
+
+    @Override
+    public BarBuilder beginTime(final Instant beginTime) {
+        this.beginTime = beginTime;
         return this;
     }
 
@@ -216,7 +223,7 @@ public class TickBarBuilder implements BarBuilder {
      */
     @Override
     public Bar build() {
-        return new BaseBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
+        return new BaseBar(this.timePeriod, this.beginTime, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
                 this.closePrice, this.volume, this.amount, this.trades);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/TimeBarBuilder.java
@@ -42,6 +42,7 @@ public class TimeBarBuilder implements BarBuilder {
 
     private final NumFactory numFactory;
     Duration timePeriod;
+    Instant beginTime;
     Instant endTime;
     Num openPrice;
     Num highPrice;
@@ -69,6 +70,12 @@ public class TimeBarBuilder implements BarBuilder {
     @Override
     public BarBuilder timePeriod(final Duration timePeriod) {
         this.timePeriod = timePeriod;
+        return this;
+    }
+
+    @Override
+    public BarBuilder beginTime(final Instant beginTime) {
+        this.beginTime = beginTime;
         return this;
     }
 
@@ -206,7 +213,7 @@ public class TimeBarBuilder implements BarBuilder {
 
     @Override
     public Bar build() {
-        return new BaseBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
+        return new BaseBar(this.timePeriod, this.beginTime, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
                 this.closePrice, this.volume, this.amount, this.trades);
     }
 
@@ -214,4 +221,5 @@ public class TimeBarBuilder implements BarBuilder {
     public void add() {
         this.baseBarSeries.addBar(build());
     }
+
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/VolumeBarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/VolumeBarBuilder.java
@@ -45,6 +45,7 @@ public class VolumeBarBuilder implements BarBuilder {
     private final Num volumeThreshold;
     private BarSeries barSeries;
     private Duration timePeriod;
+    private Instant beginTime;
     private Instant endTime;
     private Num volume;
     private Num openPrice;
@@ -79,6 +80,12 @@ public class VolumeBarBuilder implements BarBuilder {
     @Override
     public BarBuilder timePeriod(final Duration timePeriod) {
         this.timePeriod = this.timePeriod == null ? timePeriod : this.timePeriod.plus(timePeriod);
+        return this;
+    }
+
+    @Override
+    public BarBuilder beginTime(final Instant beginTime) {
+        this.beginTime = beginTime;
         return this;
     }
 
@@ -217,7 +224,7 @@ public class VolumeBarBuilder implements BarBuilder {
      */
     @Override
     public Bar build() {
-        return new BaseBar(this.timePeriod, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
+        return new BaseBar(this.timePeriod, this.beginTime, this.endTime, this.openPrice, this.highPrice, this.lowPrice,
                 this.closePrice, this.volume, this.amount, this.trades);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarTest.java
@@ -25,6 +25,7 @@ package org.ta4j.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -58,6 +59,66 @@ public class BarTest extends AbstractIndicatorTest<BarSeries, Num> {
         this.beginTime = Instant.parse("2014-06-25T00:00:00Z");
         this.endTime = Instant.parse("2014-06-25T01:00:00Z");
         this.bar = new TimeBarBuilder(this.numFactory).timePeriod(Duration.ofHours(1))
+                .endTime(this.endTime)
+                .volume(0)
+                .amount(0)
+                .build();
+    }
+
+    @Test
+    public void createBars() {
+        var barByBeginTime = new TimeBarBuilder(this.numFactory).timePeriod(Duration.ofHours(1))
+                .beginTime(this.beginTime)
+                .volume(0)
+                .amount(0)
+                .build();
+
+        var barByEndTime = new TimeBarBuilder(this.numFactory).timePeriod(Duration.ofHours(1))
+                .endTime(this.endTime)
+                .volume(0)
+                .amount(0)
+                .build();
+
+        var barByBeginTimeAndEndTime = new TimeBarBuilder(this.numFactory).timePeriod(Duration.ofHours(1))
+                .beginTime(this.beginTime)
+                .endTime(this.endTime)
+                .volume(0)
+                .amount(0)
+                .build();
+
+        var barWithoutTimePeriod = new TimeBarBuilder(this.numFactory).beginTime(this.beginTime)
+                .endTime(this.endTime)
+                .volume(0)
+                .amount(0)
+                .build();
+
+        assertEquals(barByBeginTime.getBeginTime(), barByEndTime.getBeginTime());
+        assertEquals(barByBeginTime.getEndTime(), barByEndTime.getEndTime());
+        assertEquals(barByBeginTimeAndEndTime.getTimePeriod(), barWithoutTimePeriod.getTimePeriod());
+        assertEquals(barByBeginTimeAndEndTime.getTimePeriod(), Duration.between(beginTime, endTime));
+        assertNotEquals(barByBeginTimeAndEndTime.getTimePeriod(), Duration.between(endTime, beginTime));
+        assertEquals(barWithoutTimePeriod.getTimePeriod(), Duration.between(beginTime, endTime));
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("unused")
+    public void createBarsWithMissingBeginTime() {
+        // TimePeriod is not given and cannot be computed due to missing beginTime.
+        var bar = new TimeBarBuilder(this.numFactory).endTime(endTime).volume(0).amount(0).build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("unused")
+    public void createBarsWithMissingEndTime() {
+        // TimePeriod is not given and cannot be computed due to missing endTime.
+        var bar = new TimeBarBuilder(this.numFactory).beginTime(beginTime).volume(0).amount(0).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unused")
+    public void createBarsWithInvalidTimePeriod() {
+        var barByBeginTime = new TimeBarBuilder(this.numFactory).timePeriod(Duration.ofHours(2))
+                .beginTime(this.beginTime)
                 .endTime(this.endTime)
                 .volume(0)
                 .amount(0)

--- a/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/aggregator/HeikinAshiBarAggregatorTest.java
@@ -51,9 +51,9 @@ public class HeikinAshiBarAggregatorTest extends AbstractIndicatorTest<BarSeries
         var endTime = Instant.parse("2024-01-01T01:00:00Z");
         var timePeriod = Duration.ofHours(1);
 
-        Bar bar1 = new BaseBar(timePeriod, endTime, numFactory.numOf(100), numFactory.numOf(105), numFactory.numOf(95),
-                numFactory.numOf(100), numFactory.numOf(10), numFactory.numOf(50), 1);
-        var bar2 = new BaseBar(timePeriod, endTime.plus(1, ChronoUnit.HOURS), numFactory.numOf(100),
+        Bar bar1 = new BaseBar(timePeriod, null, endTime, numFactory.numOf(100), numFactory.numOf(105),
+                numFactory.numOf(95), numFactory.numOf(100), numFactory.numOf(10), numFactory.numOf(50), 1);
+        var bar2 = new BaseBar(timePeriod, null, endTime.plus(1, ChronoUnit.HOURS), numFactory.numOf(100),
                 numFactory.numOf(110), numFactory.numOf(98), numFactory.numOf(105), numFactory.numOf(20),
                 numFactory.numOf(100), 2);
 

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/HeikinAshiBarBuilderTest.java
@@ -45,9 +45,9 @@ public class HeikinAshiBarBuilderTest extends AbstractIndicatorTest<BarSeries, N
 
     @Test
     public void testBuild() {
-        var inputBar = new BaseBar(Duration.ofHours(1), Instant.parse("2024-01-01T01:00:00Z"), numFactory.numOf(100),
-                numFactory.numOf(110), numFactory.numOf(95), numFactory.numOf(105), numFactory.numOf(10),
-                numFactory.numOf(1000), 1);
+        var inputBar = new BaseBar(Duration.ofHours(1), null, Instant.parse("2024-01-01T01:00:00Z"),
+                numFactory.numOf(100), numFactory.numOf(110), numFactory.numOf(95), numFactory.numOf(105),
+                numFactory.numOf(10), numFactory.numOf(1000), 1);
 
         // No previous HA data: should return bar as-is.
         var resultBar = unit.timePeriod(inputBar.getTimePeriod())

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
@@ -42,7 +42,7 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
     }
 
     @Test
-    public void testBuildBar() {
+    public void testBuildBarWithEndTime() {
 
         final Instant beginTime = Instant.parse("2014-06-25T00:00:00Z");
         final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
@@ -50,6 +50,67 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         final Bar bar = new TimeBarBuilder(numFactory).timePeriod(duration)
                 .endTime(endTime)
+                .openPrice(numOf(101))
+                .highPrice(numOf(103))
+                .lowPrice(numOf(100))
+                .closePrice(numOf(102))
+                .trades(4)
+                .volume(numOf(40))
+                .amount(numOf(4020))
+                .build();
+
+        assertEquals(duration, bar.getTimePeriod());
+        assertEquals(beginTime, bar.getBeginTime());
+        assertEquals(endTime, bar.getEndTime());
+        assertEquals(numOf(101), bar.getOpenPrice());
+        assertEquals(numOf(103), bar.getHighPrice());
+        assertEquals(numOf(100), bar.getLowPrice());
+        assertEquals(numOf(102), bar.getClosePrice());
+        assertEquals(4, bar.getTrades());
+        assertEquals(numOf(40), bar.getVolume());
+        assertEquals(numOf(4020), bar.getAmount());
+    }
+
+    @Test
+    public void testBuildBarWithBeginTime() {
+
+        final Instant beginTime = Instant.parse("2014-06-25T00:00:00Z");
+        final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
+        final Duration duration = Duration.between(beginTime, endTime);
+
+        final Bar bar = new TimeBarBuilder(numFactory).timePeriod(duration)
+                .beginTime(beginTime)
+                .openPrice(numOf(101))
+                .highPrice(numOf(103))
+                .lowPrice(numOf(100))
+                .closePrice(numOf(102))
+                .trades(4)
+                .volume(numOf(40))
+                .amount(numOf(4020))
+                .build();
+
+        assertEquals(duration, bar.getTimePeriod());
+        assertEquals(beginTime, bar.getBeginTime());
+        assertEquals(endTime, bar.getEndTime());
+        assertEquals(numOf(101), bar.getOpenPrice());
+        assertEquals(numOf(103), bar.getHighPrice());
+        assertEquals(numOf(100), bar.getLowPrice());
+        assertEquals(numOf(102), bar.getClosePrice());
+        assertEquals(4, bar.getTrades());
+        assertEquals(numOf(40), bar.getVolume());
+        assertEquals(numOf(4020), bar.getAmount());
+    }
+
+    @Test
+    public void testBuildBarWithEndTimeAndBeginTime() {
+
+        final Instant beginTime = Instant.parse("2014-06-25T00:00:00Z");
+        final Instant endTime = Instant.parse("2014-06-25T01:00:00Z");
+        final Duration duration = Duration.between(beginTime, endTime);
+
+        final Bar bar = new TimeBarBuilder(numFactory).timePeriod(duration)
+                .endTime(endTime)
+                .beginTime(beginTime)
                 .openPrice(numOf(101))
                 .highPrice(numOf(103))
                 .lowPrice(numOf(100))


### PR DESCRIPTION
Fixes https://github.com/ta4j/ta4j/issues/1213 
Fixes https://github.com/ta4j/ta4j/issues/982

Changes proposed in this pull request:
- build bars by beginTime instead of endTime
- Additional checks to ensure consistency between beginTime, endTime and timePeriod

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
