### PR TITLE
swapped parameter naming in BaseBarSeries#addTrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Clarify PnL criterion comments about trading costs
 - Refactor ProfitLossPercentageCriterion to calculate aggregated return
 - Fixed strict rules of `ConvergenceDivergenceIndicator`
+- swapped parameter naming in  `BaseBarSeries#addTrade(final Number tradeVolume, final Number tradePrice)`
 
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -273,8 +273,8 @@ public class BaseBarSeries implements BarSeries {
     }
 
     @Override
-    public void addTrade(final Number price, final Number amount) {
-        addTrade(numFactory().numOf(price), numFactory().numOf(amount));
+    public void addTrade(final Number tradeVolume, final Number tradePrice) {
+        addTrade(numFactory().numOf(tradeVolume), numFactory().numOf(tradePrice));
     }
 
     @Override


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- swapped parameter naming in BaseBarSeries#addTrade as defined in its interface BarSeries#addTrade

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
