### PR TITLE
StopGainRule and StopLossRule now accept any price Indicator instead of only ClosePriceIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`
 - `ReturnOverMaxDrawdownCriterion` now returns 0 instead of `NaN` for strategies that never operate, and returns the net profit instead of `NaN` for strategies with no drawdown
-- `StopGainRule` and `StopLossRule` now accept any price `Indicator` instead of only `ClosePriceIndicator`
 - Changed snapshot distribution to Maven Central after OSSRH end-of-life
+- `StopGainRule` and `StopLossRule` now accept any price `Indicator` instead of only `ClosePriceIndicator`
 
 ### Removed/Deprecated
 - TransformIndicator and CombineIndicator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`
 - `ReturnOverMaxDrawdownCriterion` now returns 0 instead of `NaN` for strategies that never operate, and returns the net profit instead of `NaN` for strategies with no drawdown
+- `StopGainRule` and `StopLossRule` now accept any price `Indicator` instead of only `ClosePriceIndicator`
 - Changed snapshot distribution to Maven Central after OSSRH end-of-life
 
 ### Removed/Deprecated

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -36,6 +36,9 @@ import org.ta4j.core.num.Num;
  */
 public class StopGainRule extends AbstractRule {
 
+    /** The constant value for 100. */
+    private final Num HUNDRED;
+
     /** The reference price indicator. */
     private final Indicator<Num> priceIndicator;
 
@@ -61,6 +64,7 @@ public class StopGainRule extends AbstractRule {
     public StopGainRule(Indicator<Num> priceIndicator, Num gainPercentage) {
         this.priceIndicator = priceIndicator;
         this.gainPercentage = gainPercentage;
+        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
@@ -69,11 +73,11 @@ public class StopGainRule extends AbstractRule {
         boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            var currentPosition = tradingRecord.getCurrentPosition();
+            Position currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                var entryPrice = currentPosition.getEntry().getNetPrice();
-                var currentPrice = priceIndicator.getValue(index);
+                Num entryPrice = currentPosition.getEntry().getNetPrice();
+                Num currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);
@@ -87,16 +91,14 @@ public class StopGainRule extends AbstractRule {
     }
 
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
-        var hundred = priceIndicator.getBarSeries().numFactory().hundred();
-        var lossRatioThreshold = hundred.plus(gainPercentage).dividedBy(hundred);
-        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 
     private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        var hundred = priceIndicator.getBarSeries().numFactory().hundred();
-        var lossRatioThreshold = hundred.minus(gainPercentage).dividedBy(hundred);
-        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -70,14 +70,14 @@ public class StopGainRule extends AbstractRule {
     /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        boolean satisfied = false;
+        var satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
             Position currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = priceIndicator.getValue(index);
+                var entryPrice = currentPosition.getEntry().getNetPrice();
+                var currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);
@@ -91,14 +91,14 @@ public class StopGainRule extends AbstractRule {
     }
 
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 
     private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -36,9 +36,6 @@ import org.ta4j.core.num.Num;
  */
 public class StopGainRule extends AbstractRule {
 
-    /** The constant value for 100. */
-    private final Num HUNDRED;
-
     /** The reference price indicator. */
     private final Indicator<Num> priceIndicator;
 
@@ -64,7 +61,6 @@ public class StopGainRule extends AbstractRule {
     public StopGainRule(Indicator<Num> priceIndicator, Num gainPercentage) {
         this.priceIndicator = priceIndicator;
         this.gainPercentage = gainPercentage;
-        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
@@ -73,11 +69,11 @@ public class StopGainRule extends AbstractRule {
         boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            Position currentPosition = tradingRecord.getCurrentPosition();
+            var currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = priceIndicator.getValue(index);
+                var entryPrice = currentPosition.getEntry().getNetPrice();
+                var currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);
@@ -91,14 +87,16 @@ public class StopGainRule extends AbstractRule {
     }
 
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var hundred = priceIndicator.getBarSeries().numFactory().hundred();
+        var lossRatioThreshold = hundred.plus(gainPercentage).dividedBy(hundred);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 
     private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(gainPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var hundred = priceIndicator.getBarSeries().numFactory().hundred();
+        var lossRatioThreshold = hundred.minus(gainPercentage).dividedBy(hundred);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -23,24 +23,24 @@
  */
 package org.ta4j.core.rules;
 
+import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
 
 /**
  * A stop-gain rule.
  *
  * <p>
- * Satisfied when the close price reaches the gain threshold.
+ * Satisfied when a reference price reaches the gain threshold.
  */
 public class StopGainRule extends AbstractRule {
 
     /** The constant value for 100. */
     private final Num HUNDRED;
 
-    /** The close price indicator. */
-    private final ClosePriceIndicator closePrice;
+    /** The reference price indicator. */
+    private final Indicator<Num> priceIndicator;
 
     /** The gain percentage. */
     private final Num gainPercentage;
@@ -48,23 +48,23 @@ public class StopGainRule extends AbstractRule {
     /**
      * Constructor.
      *
-     * @param closePrice     the close price indicator
+     * @param priceIndicator the price indicator
      * @param gainPercentage the gain percentage
      */
-    public StopGainRule(ClosePriceIndicator closePrice, Number gainPercentage) {
-        this(closePrice, closePrice.getBarSeries().numFactory().numOf(gainPercentage));
+    public StopGainRule(Indicator<Num> priceIndicator, Number gainPercentage) {
+        this(priceIndicator, priceIndicator.getBarSeries().numFactory().numOf(gainPercentage));
     }
 
     /**
      * Constructor.
      *
-     * @param closePrice     the close price indicator
+     * @param priceIndicator the price indicator
      * @param gainPercentage the gain percentage
      */
-    public StopGainRule(ClosePriceIndicator closePrice, Num gainPercentage) {
-        this.closePrice = closePrice;
+    public StopGainRule(Indicator<Num> priceIndicator, Num gainPercentage) {
+        this.priceIndicator = priceIndicator;
         this.gainPercentage = gainPercentage;
-        HUNDRED = closePrice.getBarSeries().numFactory().hundred();
+        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
@@ -77,7 +77,7 @@ public class StopGainRule extends AbstractRule {
             if (currentPosition.isOpened()) {
 
                 Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = closePrice.getValue(index);
+                Num currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -36,9 +36,6 @@ import org.ta4j.core.num.Num;
  */
 public class StopLossRule extends AbstractRule {
 
-    /** The constant value for 100. */
-    private final Num HUNDRED;
-
     /** The reference price indicator. */
     private final Indicator<Num> priceIndicator;
 
@@ -64,20 +61,19 @@ public class StopLossRule extends AbstractRule {
     public StopLossRule(Indicator<Num> priceIndicator, Num lossPercentage) {
         this.priceIndicator = priceIndicator;
         this.lossPercentage = lossPercentage;
-        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        boolean satisfied = false;
+        var satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            Position currentPosition = tradingRecord.getCurrentPosition();
+            var currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = priceIndicator.getValue(index);
+                var entryPrice = currentPosition.getEntry().getNetPrice();
+                var currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
@@ -91,14 +87,16 @@ public class StopLossRule extends AbstractRule {
     }
 
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        final var hundred = priceIndicator.getBarSeries().numFactory().hundred();
+        var lossRatioThreshold = hundred.minus(lossPercentage).dividedBy(hundred);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        final var hundred = priceIndicator.getBarSeries().numFactory().hundred();
+        var lossRatioThreshold = hundred.plus(lossPercentage).dividedBy(hundred);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -73,11 +73,11 @@ public class StopLossRule extends AbstractRule {
         boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            Position currentPosition = tradingRecord.getCurrentPosition();
+            var currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = priceIndicator.getValue(index);
+                var entryPrice = currentPosition.getEntry().getNetPrice();
+                var currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
@@ -91,14 +91,14 @@ public class StopLossRule extends AbstractRule {
     }
 
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
-        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        var lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
+        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -23,21 +23,24 @@
  */
 package org.ta4j.core.rules;
 
+import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.num.Num;
 
 /**
  * A stop-loss rule.
  *
  * <p>
- * Satisfied when the close price reaches the loss threshold.
+ * Satisfied when a reference price reaches the loss threshold.
  */
 public class StopLossRule extends AbstractRule {
 
-    /** The close price indicator. */
-    private final ClosePriceIndicator closePrice;
+    /** The constant value for 100. */
+    private final Num HUNDRED;
+
+    /** The reference price indicator. */
+    private final Indicator<Num> priceIndicator;
 
     /** The loss percentage. */
     private final Num lossPercentage;
@@ -45,22 +48,23 @@ public class StopLossRule extends AbstractRule {
     /**
      * Constructor.
      *
-     * @param closePrice     the close price indicator
+     * @param priceIndicator the price indicator
      * @param lossPercentage the loss percentage
      */
-    public StopLossRule(ClosePriceIndicator closePrice, Number lossPercentage) {
-        this(closePrice, closePrice.getBarSeries().numFactory().numOf(lossPercentage));
+    public StopLossRule(Indicator<Num> priceIndicator, Number lossPercentage) {
+        this(priceIndicator, priceIndicator.getBarSeries().numFactory().numOf(lossPercentage));
     }
 
     /**
      * Constructor.
      *
-     * @param closePrice     the close price indicator
+     * @param priceIndicator the price indicator
      * @param lossPercentage the loss percentage
      */
-    public StopLossRule(ClosePriceIndicator closePrice, Num lossPercentage) {
-        this.closePrice = closePrice;
+    public StopLossRule(Indicator<Num> priceIndicator, Num lossPercentage) {
+        this.priceIndicator = priceIndicator;
         this.lossPercentage = lossPercentage;
+        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
@@ -73,7 +77,7 @@ public class StopLossRule extends AbstractRule {
             if (currentPosition.isOpened()) {
 
                 Num entryPrice = currentPosition.getEntry().getNetPrice();
-                Num currentPrice = closePrice.getValue(index);
+                Num currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
@@ -87,15 +91,13 @@ public class StopLossRule extends AbstractRule {
     }
 
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        final var hundred = closePrice.getBarSeries().numFactory().hundred();
-        Num lossRatioThreshold = hundred.minus(lossPercentage).dividedBy(hundred);
+        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
         Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        final var hundred = closePrice.getBarSeries().numFactory().hundred();
-        Num lossRatioThreshold = hundred.plus(lossPercentage).dividedBy(hundred);
+        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
         Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -36,6 +36,9 @@ import org.ta4j.core.num.Num;
  */
 public class StopLossRule extends AbstractRule {
 
+    /** The constant value for 100. */
+    private final Num HUNDRED;
+
     /** The reference price indicator. */
     private final Indicator<Num> priceIndicator;
 
@@ -61,19 +64,20 @@ public class StopLossRule extends AbstractRule {
     public StopLossRule(Indicator<Num> priceIndicator, Num lossPercentage) {
         this.priceIndicator = priceIndicator;
         this.lossPercentage = lossPercentage;
+        HUNDRED = priceIndicator.getBarSeries().numFactory().hundred();
     }
 
     /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        var satisfied = false;
+        boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            var currentPosition = tradingRecord.getCurrentPosition();
+            Position currentPosition = tradingRecord.getCurrentPosition();
             if (currentPosition.isOpened()) {
 
-                var entryPrice = currentPosition.getEntry().getNetPrice();
-                var currentPrice = priceIndicator.getValue(index);
+                Num entryPrice = currentPosition.getEntry().getNetPrice();
+                Num currentPrice = priceIndicator.getValue(index);
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
@@ -87,16 +91,14 @@ public class StopLossRule extends AbstractRule {
     }
 
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        final var hundred = priceIndicator.getBarSeries().numFactory().hundred();
-        var lossRatioThreshold = hundred.minus(lossPercentage).dividedBy(hundred);
-        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.minus(lossPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        final var hundred = priceIndicator.getBarSeries().numFactory().hundred();
-        var lossRatioThreshold = hundred.plus(lossPercentage).dividedBy(hundred);
-        var threshold = entryPrice.multipliedBy(lossRatioThreshold);
+        Num lossRatioThreshold = HUNDRED.plus(lossPercentage).dividedBy(HUNDRED);
+        Num threshold = entryPrice.multipliedBy(lossRatioThreshold);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -109,17 +109,17 @@ public class StopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void worksWithDifferentPriceIndicator() {
-        BarSeries series = new MockBarSeriesBuilder().withDefaultData().build();
-        HighPriceIndicator highPrice = new HighPriceIndicator(series);
-        StopGainRule rule = new StopGainRule(highPrice, numOf(10));
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withDefaultData().build();
+        var highPrice = new HighPriceIndicator(series);
+        var rule = new StopGainRule(highPrice, numOf(10));
 
-        TradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
-        Num amount = numOf(1);
+        var buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        var amount = numOf(1);
         buyRecord.enter(1, highPrice.getValue(1), amount);
         assertFalse(rule.isSatisfied(1, buyRecord));
         assertTrue(rule.isSatisfied(2, buyRecord));
 
-        TradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        var sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
         sellRecord.enter(3, highPrice.getValue(3), amount);
         assertFalse(rule.isSatisfied(3, sellRecord));
         assertTrue(rule.isSatisfied(2, sellRecord));

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -34,6 +34,7 @@ import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
@@ -104,5 +105,23 @@ public class StopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertFalse(rule.isSatisfied(2, tradingRecord));
         assertTrue(rule.isSatisfied(1, tradingRecord));
         assertTrue(rule.isSatisfied(10, tradingRecord));
+    }
+
+    @Test
+    public void worksWithDifferentPriceIndicator() {
+        BarSeries series = new MockBarSeriesBuilder().withDefaultData().build();
+        HighPriceIndicator highPrice = new HighPriceIndicator(series);
+        StopGainRule rule = new StopGainRule(highPrice, numOf(10));
+
+        TradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        Num amount = numOf(1);
+        buyRecord.enter(1, highPrice.getValue(1), amount);
+        assertFalse(rule.isSatisfied(1, buyRecord));
+        assertTrue(rule.isSatisfied(2, buyRecord));
+
+        TradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        sellRecord.enter(3, highPrice.getValue(3), amount);
+        assertFalse(rule.isSatisfied(3, sellRecord));
+        assertTrue(rule.isSatisfied(2, sellRecord));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -33,6 +33,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Trade;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
@@ -103,5 +104,23 @@ public class StopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertTrue(rule.isSatisfied(3, tradingRecord));
         assertFalse(rule.isSatisfied(4, tradingRecord));
         assertTrue(rule.isSatisfied(5, tradingRecord));
+    }
+
+    @Test
+    public void worksWithDifferentPriceIndicator() {
+        BarSeries series = new MockBarSeriesBuilder().withDefaultData().build();
+        HighPriceIndicator highPrice = new HighPriceIndicator(series);
+        StopLossRule rule = new StopLossRule(highPrice, numOf(10));
+
+        BaseTradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        Num amount = numOf(1);
+        buyRecord.enter(3, highPrice.getValue(3), amount);
+        assertFalse(rule.isSatisfied(3, buyRecord));
+        assertTrue(rule.isSatisfied(2, buyRecord));
+
+        BaseTradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        sellRecord.enter(1, highPrice.getValue(1), amount);
+        assertFalse(rule.isSatisfied(1, sellRecord));
+        assertTrue(rule.isSatisfied(2, sellRecord));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -108,17 +108,17 @@ public class StopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
 
     @Test
     public void worksWithDifferentPriceIndicator() {
-        BarSeries series = new MockBarSeriesBuilder().withDefaultData().build();
-        HighPriceIndicator highPrice = new HighPriceIndicator(series);
-        StopLossRule rule = new StopLossRule(highPrice, numOf(10));
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withDefaultData().build();
+        var highPrice = new HighPriceIndicator(series);
+        var rule = new StopLossRule(highPrice, numOf(10));
 
-        BaseTradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
-        Num amount = numOf(1);
+        var buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        var amount = numOf(1);
         buyRecord.enter(3, highPrice.getValue(3), amount);
         assertFalse(rule.isSatisfied(3, buyRecord));
         assertTrue(rule.isSatisfied(2, buyRecord));
 
-        BaseTradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+        var sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
         sellRecord.enter(1, highPrice.getValue(1), amount);
         assertFalse(rule.isSatisfied(1, sellRecord));
         assertTrue(rule.isSatisfied(2, sellRecord));


### PR DESCRIPTION
Changes proposed in this pull request:
- `StopGainRule` and `StopLossRule` now accept any price `Indicator` instead of only `ClosePriceIndicator`

- [x] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
