### PR TITLE
correct calculation of unstable bars of SMA indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 - Fixed calculation of `ReturnOverMaxDrawdownCriterion`
 - swapped parameter naming in  `BaseBarSeries#addTrade(final Number tradeVolume, final Number tradePrice)`
 - Aggregation of amount and trades in `VolumeBarBuilder` and `TickBarBuilder`
+- Corrected the calculation of unstable bars of the SMA indicator
 
 ### Changed
 - Use `NetReturnCriterion` in `AverageReturnPerBarCriterion`, `EnterAndHoldCriterion` and `ReturnOverMaxDrawdownCriterion` to avoid optimistic bias of `GrossReturnCriterion`

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
@@ -37,7 +37,8 @@ import org.ta4j.core.num.Num;
 public class SMAIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private RunningTotalIndicator previousSum;
+    private final Indicator<Num> indicator;
+    private final RunningTotalIndicator previousSum;
 
     /**
      * Constructor.
@@ -48,6 +49,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     public SMAIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator);
         this.previousSum = new RunningTotalIndicator(indicator, barCount);
+        this.indicator = indicator;
         this.barCount = barCount;
     }
 
@@ -65,7 +67,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     /** @return {@link #barCount} */
     @Override
     public int getCountOfUnstableBars() {
-        return barCount;
+        return indicator.getCountOfUnstableBars() + barCount;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/SMAIndicator.java
@@ -67,7 +67,7 @@ public class SMAIndicator extends CachedIndicator<Num> {
     /** @return {@link #barCount} */
     @Override
     public int getCountOfUnstableBars() {
-        return indicator.getCountOfUnstableBars() + barCount;
+        return indicator.getCountOfUnstableBars() + barCount - 1;
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/SMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/SMAIndicatorTest.java
@@ -66,6 +66,39 @@ public class SMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
     }
 
     @Test
+    public void ensureCountOfUnstableBarsAddsToCountOfUnstableBarsOfPreviousIndicator() {
+        var closePrice = new ClosePriceIndicator(data);
+        var firstSMAindicator = new SMAIndicator(closePrice, 2);
+        var secondSMAindicator = new SMAIndicator(firstSMAindicator, 3);
+
+        assertEquals(1, firstSMAindicator.getCountOfUnstableBars());
+        assertNumEquals(1.5, firstSMAindicator.getValue(1));
+        assertNumEquals(2.5, firstSMAindicator.getValue(2));
+        assertNumEquals(3.5, firstSMAindicator.getValue(3));
+        assertNumEquals(3.5, firstSMAindicator.getValue(4));
+        assertNumEquals(3.5, firstSMAindicator.getValue(5));
+        assertNumEquals(4.5, firstSMAindicator.getValue(6));
+        assertNumEquals(4.5, firstSMAindicator.getValue(7));
+        assertNumEquals(3.5, firstSMAindicator.getValue(8));
+        assertNumEquals(3, firstSMAindicator.getValue(9));
+        assertNumEquals(3.5, firstSMAindicator.getValue(10));
+        assertNumEquals(3.5, firstSMAindicator.getValue(11));
+        assertNumEquals(2.5, firstSMAindicator.getValue(12));
+
+        assertEquals(3, secondSMAindicator.getCountOfUnstableBars());
+        assertNumEquals(2.5, secondSMAindicator.getValue(3));
+        assertNumEquals((2.5 + 3.5 + 3.5) / 3, secondSMAindicator.getValue(4));
+        assertNumEquals(3.5, secondSMAindicator.getValue(5));
+        assertNumEquals((3.5 + 3.5 + 4.5) / 3, secondSMAindicator.getValue(6));
+        assertNumEquals((3.5 + 4.5 + 4.5) / 3, secondSMAindicator.getValue(7));
+        assertNumEquals((4.5 + 4.5 + 3.5) / 3, secondSMAindicator.getValue(8));
+        assertNumEquals((4.5 + 3.5 + 3) / 3, secondSMAindicator.getValue(9));
+        assertNumEquals((3.5 + 3 + 3.5) / 3, secondSMAindicator.getValue(10));
+        assertNumEquals((3 + 3.5 + 3.5) / 3, secondSMAindicator.getValue(11));
+        assertNumEquals((3.5 + 3.5 + 2.5) / 3, secondSMAindicator.getValue(12));
+    }
+
+    @Test
     public void usingBarCount3UsingClosePrice() {
         Indicator<Num> indicator = getIndicator(new ClosePriceIndicator(data), 3);
 


### PR DESCRIPTION
- the SMA indicator (calculating on another indicator) should return the unstable bars of the indicator the sma is calculating on plus its own unstable bars


Fixes #.

Changes proposed in this pull request:
- 
- 
- 

- [ ] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
