### PR TITLE
Skip headless chart example tests

### DIFF
--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/BuyAndSellSignalsToChartTest.java
@@ -23,11 +23,16 @@
  */
 package ta4jexamples.analysis;
 
+import java.awt.GraphicsEnvironment;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class BuyAndSellSignalsToChartTest {
     @Test
     public void test() {
+        Assume.assumeFalse("Graphics environment required", GraphicsEnvironment.isHeadless());
+
         BuyAndSellSignalsToChart.main(null);
     }
 

--- a/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/analysis/CashFlowToChartTest.java
@@ -23,12 +23,17 @@
  */
 package ta4jexamples.analysis;
 
+import java.awt.GraphicsEnvironment;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class CashFlowToChartTest {
 
     @Test
     public void test() {
+        Assume.assumeFalse("Graphics environment required", GraphicsEnvironment.isHeadless());
+
         CashFlowToChart.main(null);
     }
 }

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/CandlestickChartTest.java
@@ -23,12 +23,17 @@
  */
 package ta4jexamples.indicators;
 
+import java.awt.GraphicsEnvironment;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class CandlestickChartTest {
 
     @Test
     public void test() {
+        Assume.assumeFalse("Graphics environment required", GraphicsEnvironment.isHeadless());
+
         CandlestickChart.main(null);
     }
 }

--- a/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/indicators/IndicatorsToChartTest.java
@@ -23,12 +23,17 @@
  */
 package ta4jexamples.indicators;
 
+import java.awt.GraphicsEnvironment;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class IndicatorsToChartTest {
 
     @Test
     public void test() {
+        Assume.assumeFalse("Graphics environment required", GraphicsEnvironment.isHeadless());
+
         IndicatorsToChart.main(null);
     }
 }


### PR DESCRIPTION
## Summary
- skip chart example tests that require a GUI when the JVM is running headless
- ensure Maven test suite can pass in non-GUI build environments

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e2d587b5948326b2a056d48e706fae