### PR TITLE
Fix NamedStrategy stack walker selection

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/strategy/named/NamedStrategy.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/strategy/named/NamedStrategy.java
@@ -25,6 +25,7 @@ package org.ta4j.core.strategy.named;
 
 import java.lang.StackWalker;
 import java.lang.StackWalker.Option;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -113,8 +114,9 @@ public abstract class NamedStrategy extends BaseStrategy {
     private static Class<? extends NamedStrategy> resolveConcreteType() {
         return StackWalker.getInstance(Option.RETAIN_CLASS_REFERENCE)
                 .walk(stream -> stream.map(StackWalker.StackFrame::getDeclaringClass)
-                        .filter(clazz -> NamedStrategy.class.isAssignableFrom(clazz) && clazz != NamedStrategy.class)
-                        .reduce((first, second) -> (Class<?>) second))
+                        .filter(clazz -> NamedStrategy.class.isAssignableFrom(clazz) && clazz != NamedStrategy.class
+                                && !Modifier.isAbstract(clazz.getModifiers()))
+                        .findFirst())
                 .map(clazz -> (Class<? extends NamedStrategy>) clazz)
                 .orElseThrow(() -> new IllegalStateException("Unable to determine named strategy subtype"));
     }


### PR DESCRIPTION
## Summary
- ensure the NamedStrategy stack walker picks the innermost concrete subclass during construction

## Testing
- mvn -B clean license:format formatter:format test install

------
https://chatgpt.com/codex/tasks/task_e_68f4e01bebf48326a3444ae4e63e62ea