### PR TITLE
Add AGENTS guidelines for named strategies

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/strategy/named/AGENTS.md
+++ b/ta4j-core/src/main/java/org/ta4j/core/strategy/named/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS Instructions for `org.ta4j.core.strategy.named`
+
+## Constructors
+- Provide a constructor accepting `(BarSeries series, String... params)` alongside any main, fully-typed constructor.
+- The varargs constructor should delegate to the primary constructor after validating and parsing the `params` values.
+
+## Serialization format
+- Strategy names must serialize to `<SimpleName>_<param...>` (e.g., `MyStrategy_10_0.5`).
+- Ensure the serialization helper mirrors the argument order of the primary constructor and omits redundant whitespace.
+
+## Documentation and validation
+- Add `@since` tags to new public classes and constructors.
+- Validate inputs eagerly; surface informative `IllegalArgumentException`s for bad parameters before strategy execution begins.
+
+## Cross-cutting repository guidance
+- Follow the root `AGENTS.md` for changelog expectations and the Maven-driven formatting pipeline described there.

--- a/ta4j-core/src/test/java/org/ta4j/core/strategy/named/AGENTS.md
+++ b/ta4j-core/src/test/java/org/ta4j/core/strategy/named/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS Instructions for tests in `org.ta4j.core.strategy.named`
+
+## Coverage focus
+- Mirror the constructor contract: include tests for both the `(BarSeries, String...)` convenience constructor and the main, fully-typed constructor.
+- Validate that serialization helpers produce `<SimpleName>_<param...>` names and reject malformed parameter lists.
+
+## Documentation alignment
+- Ensure new strategy fixtures include `@since` annotations in the corresponding production code and assert validation rules where practical.
+
+## Cross-cutting repository guidance
+- Remember the root `AGENTS.md` requirements for updating the changelog and using the prescribed formatting commands when changes affect these strategies.


### PR DESCRIPTION
## Summary
- add contributor guidance for named strategies covering constructors, serialization, and validation expectations
- mirror the guidance in the corresponding test package and reference root formatting and changelog requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4e3c7b8748326a7c5d1b6d84c536e