### PR TITLE
Add Elliott phase detection and invalidation indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog for `ta4j`, roughly following [keepachangelog.com](http://keepachangel
 
 - Added `ElliottRatioIndicator`, `ElliottChannelIndicator`, and
   `ElliottConfluenceIndicator` to analyze swing-based Fibonacci confluence (#0000)
+- Added `ElliottPhaseIndicator` and `ElliottInvalidationIndicator` to track wave
+  state and surface invalidations for swing-based strategies (#0000)
 
 
 ## 0.19

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/AGENTS.md
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/AGENTS.md
@@ -11,3 +11,8 @@
 - Expose helper methods (such as `ElliottRatioIndicator#isNearLevel` and
   `ElliottConfluenceIndicator#isConfluent`) so tests and downstream rules can
   interrogate intermediate state without duplicating calculations.
+- Keep Elliott phase logic pure and metadata-driven: prefer `ElliottSwingMetadata`
+  for slicing swing windows and `ElliottFibonacciValidator` for ratio checks so
+  recursive indicators remain side-effect free.
+- When signalling invalidations prefer boolean indicators that reuse existing
+  validators (for example see `ElliottInvalidationIndicator`).

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottFibonacciValidator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottFibonacciValidator.java
@@ -1,0 +1,169 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import java.util.Objects;
+
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+/**
+ * Validates Elliott swing amplitudes against common Fibonacci retracement and
+ * extension ranges.
+ *
+ * @since 0.19
+ */
+public class ElliottFibonacciValidator {
+
+    private final NumFactory numFactory;
+    private final Num tolerance;
+
+    private final Num waveTwoMinRetracement;
+    private final Num waveTwoMaxRetracement;
+    private final Num waveThreeMinExtension;
+    private final Num waveThreeMaxExtension;
+    private final Num waveFourMinRetracement;
+    private final Num waveFourMaxRetracement;
+    private final Num waveFiveMinProjection;
+    private final Num waveFiveMaxProjection;
+    private final Num waveBMinRetracement;
+    private final Num waveBMaxRetracement;
+    private final Num waveCMinExtension;
+    private final Num waveCMaxExtension;
+
+    /**
+     * Builds a validator with the default {@code 0.05} tolerance.
+     *
+     * @param numFactory series factory used for all ratio math
+     * @since 0.19
+     */
+    public ElliottFibonacciValidator(final NumFactory numFactory) {
+        this(numFactory, numFactory.numOf(0.05));
+    }
+
+    /**
+     * Builds a validator with a caller supplied tolerance.
+     *
+     * @param numFactory series factory used for all ratio math
+     * @param tolerance  symmetric tolerance applied to each Fibonacci band
+     * @since 0.19
+     */
+    public ElliottFibonacciValidator(final NumFactory numFactory, final Num tolerance) {
+        this.numFactory = Objects.requireNonNull(numFactory, "numFactory");
+        this.tolerance = Objects.requireNonNull(tolerance, "tolerance");
+        this.waveTwoMinRetracement = numFactory.numOf(0.382);
+        this.waveTwoMaxRetracement = numFactory.numOf(0.786);
+        this.waveThreeMinExtension = numFactory.numOf(1.0);
+        this.waveThreeMaxExtension = numFactory.numOf(2.618);
+        this.waveFourMinRetracement = numFactory.numOf(0.236);
+        this.waveFourMaxRetracement = numFactory.numOf(0.786);
+        this.waveFiveMinProjection = numFactory.numOf(0.618);
+        this.waveFiveMaxProjection = numFactory.numOf(1.618);
+        this.waveBMinRetracement = numFactory.numOf(0.382);
+        this.waveBMaxRetracement = numFactory.numOf(0.886);
+        this.waveCMinExtension = numFactory.numOf(1.0);
+        this.waveCMaxExtension = numFactory.numOf(1.618);
+    }
+
+    /**
+     * @param wave1 first impulse swing
+     * @param wave2 second impulse swing retracement
+     * @return {@code true} when wave two retraces the first swing within the
+     *         canonical Fibonacci band
+     * @since 0.19
+     */
+    public boolean isWaveTwoRetracementValid(final ElliottSwing wave1, final ElliottSwing wave2) {
+        return ratioBetween(wave2.amplitude(), wave1.amplitude(), waveTwoMinRetracement, waveTwoMaxRetracement);
+    }
+
+    /**
+     * @param wave1 first impulse swing
+     * @param wave3 third impulse swing
+     * @return {@code true} when wave three extends the first swing by at least one
+     *         full unit and stays below common blow-off extremes
+     * @since 0.19
+     */
+    public boolean isWaveThreeExtensionValid(final ElliottSwing wave1, final ElliottSwing wave3) {
+        return ratioBetween(wave3.amplitude(), wave1.amplitude(), waveThreeMinExtension, waveThreeMaxExtension);
+    }
+
+    /**
+     * @param wave3 third impulse swing
+     * @param wave4 fourth impulse swing
+     * @return {@code true} when wave four retraces the third swing within tolerance
+     * @since 0.19
+     */
+    public boolean isWaveFourRetracementValid(final ElliottSwing wave3, final ElliottSwing wave4) {
+        return ratioBetween(wave4.amplitude(), wave3.amplitude(), waveFourMinRetracement, waveFourMaxRetracement);
+    }
+
+    /**
+     * @param wave1 first impulse swing
+     * @param wave5 final impulse swing
+     * @return {@code true} when wave five projects a typical Fibonacci expansion of
+     *         wave one
+     * @since 0.19
+     */
+    public boolean isWaveFiveProjectionValid(final ElliottSwing wave1, final ElliottSwing wave5) {
+        return ratioBetween(wave5.amplitude(), wave1.amplitude(), waveFiveMinProjection, waveFiveMaxProjection);
+    }
+
+    /**
+     * @param waveA first corrective swing
+     * @param waveB second corrective swing
+     * @return {@code true} when wave B retraces wave A within the common range
+     * @since 0.19
+     */
+    public boolean isWaveBRetracementValid(final ElliottSwing waveA, final ElliottSwing waveB) {
+        return ratioBetween(waveB.amplitude(), waveA.amplitude(), waveBMinRetracement, waveBMaxRetracement);
+    }
+
+    /**
+     * @param waveA first corrective swing
+     * @param waveC third corrective swing
+     * @return {@code true} when wave C extends beyond wave A by a common Fibonacci
+     *         factor
+     * @since 0.19
+     */
+    public boolean isWaveCExtensionValid(final ElliottSwing waveA, final ElliottSwing waveC) {
+        return ratioBetween(waveC.amplitude(), waveA.amplitude(), waveCMinExtension, waveCMaxExtension);
+    }
+
+    private boolean ratioBetween(final Num numerator, final Num denominator, final Num lower, final Num upper) {
+        if (!isFinite(numerator) || !isFinite(denominator)) {
+            return false;
+        }
+        if (denominator.isZero()) {
+            return false;
+        }
+        final Num ratio = numerator.dividedBy(denominator).abs();
+        final Num lowerBound = lower.minus(tolerance);
+        final Num upperBound = upper.plus(tolerance);
+        return !ratio.isLessThan(lowerBound) && !ratio.isGreaterThan(upperBound);
+    }
+
+    private boolean isFinite(final Num value) {
+        return value != null && !value.isNaN();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottInvalidationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottInvalidationIndicator.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.ta4j.core.indicators.CachedIndicator;
+
+/**
+ * Flags when the current Elliott wave count breaks canonical invalidation
+ * levels.
+ *
+ * <p>
+ * Typical invalidations include wave two exceeding the start of wave one or
+ * wave four overlapping wave one territory. Downstream consumers can reset
+ * their state when this indicator returns {@code true}.
+ *
+ * @since 0.19
+ */
+public class ElliottInvalidationIndicator extends CachedIndicator<Boolean> {
+
+    private final ElliottPhaseIndicator phaseIndicator;
+
+    /**
+     * @param phaseIndicator phase indicator providing the current wave state
+     * @since 0.19
+     */
+    public ElliottInvalidationIndicator(final ElliottPhaseIndicator phaseIndicator) {
+        super(Objects.requireNonNull(phaseIndicator, "phaseIndicator"));
+        this.phaseIndicator = phaseIndicator;
+    }
+
+    @Override
+    protected Boolean calculate(final int index) {
+        final ElliottSwingMetadata metadata = phaseIndicator.metadata(index);
+        if (!metadata.isValid()) {
+            return Boolean.FALSE;
+        }
+
+        final ElliottPhaseIndicator.ImpulseAssessment impulse = phaseIndicator.assessImpulse(metadata);
+        final List<ElliottSwing> swings = impulse.segment;
+        if (swings.isEmpty()) {
+            return Boolean.FALSE;
+        }
+
+        boolean invalid = false;
+        if (swings.size() >= 2) {
+            invalid = !phaseIndicator.isWaveTwoValid(swings.get(0), swings.get(1), impulse.rising);
+        }
+        if (!invalid && swings.size() >= 3) {
+            invalid = !phaseIndicator.isWaveThreeValid(swings.get(0), swings.get(1), swings.get(2), impulse.rising);
+        }
+        if (!invalid && swings.size() >= 4) {
+            invalid = !phaseIndicator.isWaveFourValid(swings.get(0), swings.get(2), swings.get(3), impulse.rising);
+        }
+        if (!invalid && swings.size() >= 5) {
+            invalid = !phaseIndicator.isWaveFiveValid(swings.get(0), swings.get(2), swings.get(4), impulse.rising);
+        }
+        return Boolean.valueOf(invalid);
+    }
+
+    @Override
+    public int getCountOfUnstableBars() {
+        return phaseIndicator.getCountOfUnstableBars();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottPhase.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottPhase.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+/**
+ * Enumerates the sequential phases of an Elliott wave structure.
+ *
+ * @since 0.19
+ */
+public enum ElliottPhase {
+
+    /** No qualifying swing structure detected. */
+    NONE,
+    /** First impulsive wave. */
+    WAVE1,
+    /** Second impulsive wave retracement. */
+    WAVE2,
+    /** Third impulsive wave extension. */
+    WAVE3,
+    /** Fourth impulsive wave consolidation. */
+    WAVE4,
+    /** Fifth impulsive wave completion. */
+    WAVE5,
+    /** First corrective swing (wave A). */
+    CORRECTIVE_A,
+    /** Second corrective swing (wave B). */
+    CORRECTIVE_B,
+    /** Third corrective swing (wave C). */
+    CORRECTIVE_C;
+
+    /**
+     * @return {@code true} when the phase represents an impulsive leg (waves 1-5)
+     * @since 0.19
+     */
+    public boolean isImpulse() {
+        return impulseIndex() > 0;
+    }
+
+    /**
+     * @return {@code true} when the phase represents a corrective leg (waves A-C)
+     * @since 0.19
+     */
+    public boolean isCorrective() {
+        return correctiveIndex() > 0;
+    }
+
+    /**
+     * @return {@code true} when the phase completes its respective structure
+     * @since 0.19
+     */
+    public boolean completesStructure() {
+        return this == WAVE5 || this == CORRECTIVE_C;
+    }
+
+    /**
+     * @return zero when the phase is not impulsive otherwise the 1-based impulse
+     *         ordinal
+     * @since 0.19
+     */
+    public int impulseIndex() {
+        return switch (this) {
+        case WAVE1 -> 1;
+        case WAVE2 -> 2;
+        case WAVE3 -> 3;
+        case WAVE4 -> 4;
+        case WAVE5 -> 5;
+        default -> 0;
+        };
+    }
+
+    /**
+     * @return zero when the phase is not corrective otherwise the 1-based
+     *         corrective ordinal
+     * @since 0.19
+     */
+    public int correctiveIndex() {
+        return switch (this) {
+        case CORRECTIVE_A -> 1;
+        case CORRECTIVE_B -> 2;
+        case CORRECTIVE_C -> 3;
+        default -> 0;
+        };
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottPhaseIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottPhaseIndicator.java
@@ -1,0 +1,441 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import static org.ta4j.core.num.NaN.NaN;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.ta4j.core.indicators.RecursiveCachedIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+/**
+ * Tracks the current Elliott wave phase by reusing cached swing history.
+ *
+ * <p>
+ * The indicator produces {@link ElliottPhase} values representing the latest
+ * impulsive or corrective wave. Helper accessors expose the impulse and
+ * corrective segments so that trading rules can assert higher level structure
+ * before acting.
+ *
+ * @since 0.19
+ */
+public class ElliottPhaseIndicator extends RecursiveCachedIndicator<ElliottPhase> {
+
+    private final ElliottSwingIndicator swingIndicator;
+    private final ElliottFibonacciValidator fibonacciValidator;
+    private final NumFactory numFactory;
+
+    /**
+     * @param swingIndicator swing source used for detecting Elliott phases
+     * @since 0.19
+     */
+    public ElliottPhaseIndicator(final ElliottSwingIndicator swingIndicator) {
+        this(swingIndicator, new ElliottFibonacciValidator(requireFactory(swingIndicator)));
+    }
+
+    /**
+     * @param swingIndicator     swing source used for detecting Elliott phases
+     * @param fibonacciValidator validator responsible for Fibonacci conformance
+     * @since 0.19
+     */
+    public ElliottPhaseIndicator(final ElliottSwingIndicator swingIndicator,
+            final ElliottFibonacciValidator fibonacciValidator) {
+        super(Objects.requireNonNull(swingIndicator, "swingIndicator"));
+        this.swingIndicator = swingIndicator;
+        this.fibonacciValidator = Objects.requireNonNull(fibonacciValidator, "fibonacciValidator");
+        this.numFactory = requireFactory(swingIndicator);
+    }
+
+    private static NumFactory requireFactory(final ElliottSwingIndicator swingIndicator) {
+        final NumFactory factory = Objects.requireNonNull(swingIndicator, "swingIndicator").getBarSeries().numFactory();
+        if (factory == null) {
+            throw new IllegalArgumentException("Swing indicator must expose a backing series factory");
+        }
+        return factory;
+    }
+
+    @Override
+    protected ElliottPhase calculate(final int index) {
+        final ElliottSwingMetadata metadata = metadata(index);
+        if (!metadata.isValid() || metadata.isEmpty()) {
+            return ElliottPhase.NONE;
+        }
+
+        final ImpulseAssessment impulse = assessImpulse(metadata);
+        if (!impulse.phase.isImpulse()) {
+            return ElliottPhase.NONE;
+        }
+
+        if (impulse.phase != ElliottPhase.WAVE5) {
+            return impulse.phase;
+        }
+
+        if (metadata.size() <= impulse.startIndex + impulse.segment.size()) {
+            return ElliottPhase.WAVE5;
+        }
+
+        final ElliottPhase correctivePhase = evaluateCorrective(metadata,
+                metadata.subList(impulse.startIndex + impulse.segment.size(), metadata.size()), impulse.rising);
+        if (correctivePhase.isCorrective()) {
+            return correctivePhase;
+        }
+        return ElliottPhase.WAVE5;
+    }
+
+    @Override
+    public int getCountOfUnstableBars() {
+        return swingIndicator.getCountOfUnstableBars();
+    }
+
+    /**
+     * @param index bar index
+     * @return immutable impulse swings considered for the phase at {@code index}
+     * @since 0.19
+     */
+    public List<ElliottSwing> impulseSwings(final int index) {
+        final ElliottSwingMetadata metadata = metadata(index);
+        if (!metadata.isValid()) {
+            return List.of();
+        }
+        return List.copyOf(assessImpulse(metadata).segment);
+    }
+
+    /**
+     * @param index bar index
+     * @return immutable corrective swings considered for the phase at {@code index}
+     * @since 0.19
+     */
+    public List<ElliottSwing> correctiveSwings(final int index) {
+        final ElliottSwingMetadata metadata = metadata(index);
+        if (!metadata.isValid()) {
+            return List.of();
+        }
+        final ImpulseAssessment impulse = assessImpulse(metadata);
+        if (impulse.phase != ElliottPhase.WAVE5) {
+            return List.of();
+        }
+        final List<ElliottSwing> corrective = metadata.subList(impulse.startIndex + impulse.segment.size(),
+                metadata.size());
+        return List.copyOf(corrective);
+    }
+
+    /**
+     * @param index bar index
+     * @return {@code true} once five waves are confirmed
+     * @since 0.19
+     */
+    public boolean isImpulseConfirmed(final int index) {
+        final ElliottSwingMetadata metadata = metadata(index);
+        if (!metadata.isValid()) {
+            return false;
+        }
+        return assessImpulse(metadata).phase == ElliottPhase.WAVE5;
+    }
+
+    /**
+     * @param index bar index
+     * @return {@code true} once the corrective sequence satisfies A-B-C
+     *         requirements
+     * @since 0.19
+     */
+    public boolean isCorrectiveConfirmed(final int index) {
+        final ElliottSwingMetadata metadata = metadata(index);
+        if (!metadata.isValid()) {
+            return false;
+        }
+        final ImpulseAssessment impulse = assessImpulse(metadata);
+        if (impulse.phase != ElliottPhase.WAVE5) {
+            return false;
+        }
+        final ElliottPhase corrective = evaluateCorrective(metadata,
+                metadata.subList(impulse.startIndex + impulse.segment.size(), metadata.size()), impulse.rising);
+        return corrective == ElliottPhase.CORRECTIVE_C;
+    }
+
+    /**
+     * @return underlying swing indicator used for phase detection
+     * @since 0.19
+     */
+    public ElliottSwingIndicator getSwingIndicator() {
+        return swingIndicator;
+    }
+
+    ElliottSwingMetadata metadata(final int index) {
+        final List<ElliottSwing> swings = swingIndicator.getValue(index);
+        return ElliottSwingMetadata.of(swings, numFactory);
+    }
+
+    ImpulseAssessment assessImpulse(final ElliottSwingMetadata metadata) {
+        if (!metadata.isValid() || metadata.isEmpty()) {
+            return new ImpulseAssessment(ElliottPhase.NONE, List.of(), 0, true);
+        }
+        List<ElliottSwing> segment = metadata.leading(5);
+        ElliottPhase phase = evaluateImpulse(segment);
+        boolean rising = !segment.isEmpty() && segment.get(0).isRising();
+        int startIndex = 0;
+
+        if (phase != ElliottPhase.WAVE5 && metadata.size() > 5) {
+            final List<ElliottSwing> trailing = metadata.trailing(5);
+            final ElliottPhase trailingPhase = evaluateImpulse(trailing);
+            if (compareImpulse(trailingPhase, phase) > 0) {
+                segment = trailing;
+                phase = trailingPhase;
+                rising = !segment.isEmpty() && segment.get(0).isRising();
+                startIndex = metadata.size() - segment.size();
+            }
+        }
+
+        return new ImpulseAssessment(phase, segment, startIndex, rising);
+    }
+
+    private ElliottPhase evaluateImpulse(final List<ElliottSwing> swings) {
+        if (swings.isEmpty()) {
+            return ElliottPhase.NONE;
+        }
+        final ElliottSwing wave1 = swings.get(0);
+        if (!isFinite(wave1)) {
+            return ElliottPhase.NONE;
+        }
+        final boolean rising = wave1.isRising();
+        ElliottPhase phase = ElliottPhase.WAVE1;
+
+        if (swings.size() < 2) {
+            return phase;
+        }
+
+        final ElliottSwing wave2 = swings.get(1);
+        if (!isWaveTwoValid(wave1, wave2, rising)) {
+            return phase;
+        }
+        phase = ElliottPhase.WAVE2;
+
+        if (swings.size() < 3) {
+            return phase;
+        }
+
+        final ElliottSwing wave3 = swings.get(2);
+        if (!isWaveThreeValid(wave1, wave2, wave3, rising)) {
+            return phase;
+        }
+        phase = ElliottPhase.WAVE3;
+
+        if (swings.size() < 4) {
+            return phase;
+        }
+
+        final ElliottSwing wave4 = swings.get(3);
+        if (!isWaveFourValid(wave1, wave3, wave4, rising)) {
+            return phase;
+        }
+        phase = ElliottPhase.WAVE4;
+
+        if (swings.size() < 5) {
+            return phase;
+        }
+
+        final ElliottSwing wave5 = swings.get(4);
+        if (!isWaveFiveValid(wave1, wave3, wave5, rising)) {
+            return phase;
+        }
+        return ElliottPhase.WAVE5;
+    }
+
+    ElliottPhase evaluateCorrective(final ElliottSwingMetadata metadata, final List<ElliottSwing> correction,
+            final boolean impulseRising) {
+        if (correction.isEmpty()) {
+            return ElliottPhase.NONE;
+        }
+
+        final ElliottSwing waveA = correction.get(0);
+        if (!isFinite(waveA)) {
+            return ElliottPhase.NONE;
+        }
+        if (waveA.isRising() == impulseRising) {
+            return ElliottPhase.NONE;
+        }
+
+        ElliottPhase phase = ElliottPhase.CORRECTIVE_A;
+        if (correction.size() < 2) {
+            return phase;
+        }
+
+        final ElliottSwing waveB = correction.get(1);
+        if (!isWaveBValid(waveA, waveB, impulseRising)) {
+            return phase;
+        }
+        phase = ElliottPhase.CORRECTIVE_B;
+
+        if (correction.size() < 3) {
+            return phase;
+        }
+
+        final ElliottSwing waveC = correction.get(2);
+        if (!isWaveCValid(waveA, waveC, impulseRising)) {
+            return phase;
+        }
+        return ElliottPhase.CORRECTIVE_C;
+    }
+
+    boolean isWaveTwoValid(final ElliottSwing wave1, final ElliottSwing wave2, final boolean impulseRising) {
+        if (!isFinite(wave2)) {
+            return false;
+        }
+        if (wave1.isRising() == wave2.isRising()) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveTwoRetracementValid(wave1, wave2)) {
+            return false;
+        }
+        final Num boundary = wave1.fromPrice();
+        final Num candidate = wave2.toPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? !candidate.isLessThan(boundary) : !candidate.isGreaterThan(boundary);
+    }
+
+    boolean isWaveThreeValid(final ElliottSwing wave1, final ElliottSwing wave2, final ElliottSwing wave3,
+            final boolean impulseRising) {
+        if (!isFinite(wave3)) {
+            return false;
+        }
+        if (wave3.isRising() != impulseRising) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveThreeExtensionValid(wave1, wave3)) {
+            return false;
+        }
+        final Num candidate = wave3.toPrice();
+        final Num boundary = wave1.toPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? candidate.isGreaterThan(boundary) : candidate.isLessThan(boundary);
+    }
+
+    boolean isWaveFourValid(final ElliottSwing wave1, final ElliottSwing wave3, final ElliottSwing wave4,
+            final boolean impulseRising) {
+        if (!isFinite(wave4)) {
+            return false;
+        }
+        if (wave4.isRising() == impulseRising) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveFourRetracementValid(wave3, wave4)) {
+            return false;
+        }
+        final Num candidate = wave4.toPrice();
+        final Num boundary = wave1.toPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? !candidate.isLessThan(boundary) : !candidate.isGreaterThan(boundary);
+    }
+
+    boolean isWaveFiveValid(final ElliottSwing wave1, final ElliottSwing wave3, final ElliottSwing wave5,
+            final boolean impulseRising) {
+        if (!isFinite(wave5)) {
+            return false;
+        }
+        if (wave5.isRising() != impulseRising) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveFiveProjectionValid(wave1, wave5)) {
+            return false;
+        }
+        final Num candidate = wave5.toPrice();
+        final Num boundary = wave3.toPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? candidate.isGreaterThan(boundary) : candidate.isLessThan(boundary);
+    }
+
+    boolean isWaveBValid(final ElliottSwing waveA, final ElliottSwing waveB, final boolean impulseRising) {
+        if (!isFinite(waveB)) {
+            return false;
+        }
+        if (waveB.isRising() != impulseRising) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveBRetracementValid(waveA, waveB)) {
+            return false;
+        }
+        final Num candidate = waveB.toPrice();
+        final Num boundary = waveA.fromPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? !candidate.isGreaterThan(boundary) : !candidate.isLessThan(boundary);
+    }
+
+    boolean isWaveCValid(final ElliottSwing waveA, final ElliottSwing waveC, final boolean impulseRising) {
+        if (!isFinite(waveC)) {
+            return false;
+        }
+        if (waveC.isRising() == impulseRising) {
+            return false;
+        }
+        if (!fibonacciValidator.isWaveCExtensionValid(waveA, waveC)) {
+            return false;
+        }
+        final Num candidate = waveC.toPrice();
+        final Num boundary = waveA.toPrice();
+        if (candidate == null || boundary == null || candidate.isNaN() || boundary.isNaN()) {
+            return false;
+        }
+        return impulseRising ? candidate.isLessThan(boundary) : candidate.isGreaterThan(boundary);
+    }
+
+    private boolean isFinite(final ElliottSwing swing) {
+        if (swing == null) {
+            return false;
+        }
+        final Num from = swing.fromPrice();
+        final Num to = swing.toPrice();
+        return from != null && to != null && !from.isNaN() && !to.isNaN() && !from.equals(NaN) && !to.equals(NaN);
+    }
+
+    private int compareImpulse(final ElliottPhase left, final ElliottPhase right) {
+        return Integer.compare(left.impulseIndex(), right.impulseIndex());
+    }
+
+    static final class ImpulseAssessment {
+        final ElliottPhase phase;
+        final List<ElliottSwing> segment;
+        final int startIndex;
+        final boolean rising;
+
+        ImpulseAssessment(final ElliottPhase phase, final List<ElliottSwing> segment, final int startIndex,
+                final boolean rising) {
+            this.phase = phase;
+            this.segment = segment;
+            this.startIndex = startIndex;
+            this.rising = rising;
+        }
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottSwingMetadata.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottSwingMetadata.java
@@ -1,0 +1,197 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+/**
+ * Immutable snapshot of swing statistics helpful for Elliott wave validation.
+ *
+ * @since 0.19
+ */
+public final class ElliottSwingMetadata {
+
+    private final List<ElliottSwing> swings;
+    private final boolean valid;
+    private final Num highestPrice;
+    private final Num lowestPrice;
+
+    private ElliottSwingMetadata(final List<ElliottSwing> swings, final boolean valid, final Num highestPrice,
+            final Num lowestPrice) {
+        this.swings = swings;
+        this.valid = valid;
+        this.highestPrice = highestPrice;
+        this.lowestPrice = lowestPrice;
+    }
+
+    /**
+     * Builds metadata around the provided swing history.
+     *
+     * @param swings     ordered swing list produced by
+     *                   {@link ElliottSwingIndicator}
+     * @param numFactory number factory backing the swings
+     * @return immutable metadata view
+     * @since 0.19
+     */
+    public static ElliottSwingMetadata of(final List<ElliottSwing> swings, final NumFactory numFactory) {
+        Objects.requireNonNull(numFactory, "numFactory");
+        if (swings == null || swings.isEmpty()) {
+            return new ElliottSwingMetadata(List.of(), true, numFactory.zero(), numFactory.zero());
+        }
+        final List<ElliottSwing> copy = List.copyOf(swings);
+        boolean valid = true;
+        Num highest = null;
+        Num lowest = null;
+        for (final ElliottSwing swing : copy) {
+            if (swing == null) {
+                valid = false;
+                break;
+            }
+            final Num from = swing.fromPrice();
+            final Num to = swing.toPrice();
+            if (from == null || to == null || from.isNaN() || to.isNaN()) {
+                valid = false;
+                break;
+            }
+            final Num swingHigh = from.max(to);
+            final Num swingLow = from.min(to);
+            highest = highest == null ? swingHigh : highest.max(swingHigh);
+            lowest = lowest == null ? swingLow : lowest.min(swingLow);
+        }
+        if (!valid) {
+            highest = numFactory.zero();
+            lowest = numFactory.zero();
+        }
+        return new ElliottSwingMetadata(copy, valid, highest, lowest);
+    }
+
+    /**
+     * @return whether the snapshot contains finite prices for each swing
+     * @since 0.19
+     */
+    public boolean isValid() {
+        return valid;
+    }
+
+    /**
+     * @return number of swings represented
+     * @since 0.19
+     */
+    public int size() {
+        return swings.size();
+    }
+
+    /**
+     * @return {@code true} when no swings are present
+     * @since 0.19
+     */
+    public boolean isEmpty() {
+        return swings.isEmpty();
+    }
+
+    /**
+     * @return highest price touched by any swing or {@code zero()} when invalid
+     * @since 0.19
+     */
+    public Num highestPrice() {
+        return highestPrice;
+    }
+
+    /**
+     * @return lowest price touched by any swing or {@code zero()} when invalid
+     * @since 0.19
+     */
+    public Num lowestPrice() {
+        return lowestPrice;
+    }
+
+    /**
+     * @param length requested prefix length
+     * @return immutable leading portion of the swing list (trimmed to available
+     *         size)
+     * @since 0.19
+     */
+    public List<ElliottSwing> leading(final int length) {
+        if (swings.isEmpty() || length <= 0) {
+            return emptyList();
+        }
+        final int toIndex = Math.min(length, swings.size());
+        return List.copyOf(swings.subList(0, toIndex));
+    }
+
+    /**
+     * @param length requested suffix length
+     * @return immutable trailing portion of the swing list (trimmed to available
+     *         size)
+     * @since 0.19
+     */
+    public List<ElliottSwing> trailing(final int length) {
+        if (swings.isEmpty() || length <= 0) {
+            return emptyList();
+        }
+        final int fromIndex = Math.max(0, swings.size() - length);
+        return List.copyOf(swings.subList(fromIndex, swings.size()));
+    }
+
+    /**
+     * @param fromIndex inclusive starting index
+     * @param toIndex   exclusive ending index
+     * @return immutable sub-list bounded to the available range
+     * @since 0.19
+     */
+    public List<ElliottSwing> subList(final int fromIndex, final int toIndex) {
+        if (swings.isEmpty()) {
+            return emptyList();
+        }
+        final int safeFrom = Math.max(0, Math.min(fromIndex, swings.size()));
+        final int safeTo = Math.max(safeFrom, Math.min(toIndex, swings.size()));
+        if (safeFrom == safeTo) {
+            return emptyList();
+        }
+        return List.copyOf(swings.subList(safeFrom, safeTo));
+    }
+
+    /**
+     * @param index index within the swing list
+     * @return swing at the requested index
+     * @since 0.19
+     */
+    public ElliottSwing swing(final int index) {
+        return swings.get(index);
+    }
+
+    /**
+     * @return immutable copy of all swings
+     * @since 0.19
+     */
+    public List<ElliottSwing> swings() {
+        return swings;
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottInvalidationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottInvalidationIndicatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+
+class ElliottInvalidationIndicatorTest {
+
+    @Test
+    void shouldRemainFalseForValidImpulse() {
+        var series = new MockBarSeriesBuilder().build();
+        var swings = ElliottPhaseIndicatorTest.impulseAndCorrectionSwings(series.numFactory());
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var phaseIndicator = new ElliottPhaseIndicator(swingIndicator);
+        var invalidation = new ElliottInvalidationIndicator(phaseIndicator);
+
+        for (int i = 0; i <= 5; i++) {
+            phaseIndicator.getValue(i);
+            assertThat(invalidation.getValue(i)).isFalse();
+        }
+    }
+
+    @Test
+    void shouldDetectWaveFourOverlap() {
+        var series = new MockBarSeriesBuilder().build();
+        var factory = series.numFactory();
+
+        var wave1 = new ElliottSwing(0, 3, factory.numOf(100), factory.numOf(110), ElliottDegree.MINOR);
+        var wave2 = new ElliottSwing(3, 5, factory.numOf(110), factory.numOf(104), ElliottDegree.MINOR);
+        var wave3 = new ElliottSwing(5, 9, factory.numOf(104), factory.numOf(130), ElliottDegree.MINOR);
+        var wave4 = new ElliottSwing(9, 11, factory.numOf(130), factory.numOf(109.6), ElliottDegree.MINOR);
+
+        var swings = new ArrayList<List<ElliottSwing>>();
+        swings.add(List.<ElliottSwing>of());
+        swings.add(List.of(wave1));
+        swings.add(List.of(wave1, wave2));
+        swings.add(List.of(wave1, wave2, wave3));
+        swings.add(List.of(wave1, wave2, wave3, wave4));
+
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var phaseIndicator = new ElliottPhaseIndicator(swingIndicator);
+        var invalidation = new ElliottInvalidationIndicator(phaseIndicator);
+
+        phaseIndicator.getValue(3);
+        assertThat(invalidation.getValue(4)).isTrue();
+    }
+
+    private static final class StubSwingIndicator extends ElliottSwingIndicator {
+
+        private final List<List<ElliottSwing>> swingsByIndex;
+
+        private StubSwingIndicator(final BarSeries series, final List<List<ElliottSwing>> swingsByIndex) {
+            super(series, 1, ElliottDegree.MINOR);
+            this.swingsByIndex = swingsByIndex;
+        }
+
+        @Override
+        protected List<ElliottSwing> calculate(final int index) {
+            if (index < swingsByIndex.size()) {
+                return swingsByIndex.get(index);
+            }
+            return swingsByIndex.get(swingsByIndex.size() - 1);
+        }
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottPhaseIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottPhaseIndicatorTest.java
@@ -1,0 +1,154 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2025 Ta4j Organization & respective
+ * authors (see AUTHORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ta4j.core.indicators.elliott;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ta4j.core.num.NaN.NaN;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+class ElliottPhaseIndicatorTest {
+
+    @Test
+    void shouldProgressThroughImpulsePhases() {
+        var series = new MockBarSeriesBuilder().build();
+        var swings = impulseAndCorrectionSwings(series.numFactory());
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var indicator = new ElliottPhaseIndicator(swingIndicator);
+
+        assertThat(indicator.getValue(0)).isEqualTo(ElliottPhase.NONE);
+        assertThat(indicator.getValue(1)).isEqualTo(ElliottPhase.WAVE1);
+        assertThat(indicator.getValue(2)).isEqualTo(ElliottPhase.WAVE2);
+        assertThat(indicator.getValue(3)).isEqualTo(ElliottPhase.WAVE3);
+        assertThat(indicator.getValue(4)).isEqualTo(ElliottPhase.WAVE4);
+        assertThat(indicator.getValue(5)).isEqualTo(ElliottPhase.WAVE5);
+        assertThat(indicator.isImpulseConfirmed(5)).isTrue();
+        assertThat(indicator.isCorrectiveConfirmed(5)).isFalse();
+    }
+
+    @Test
+    void shouldIdentifyCorrectiveStructure() {
+        var series = new MockBarSeriesBuilder().build();
+        var swings = impulseAndCorrectionSwings(series.numFactory());
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var indicator = new ElliottPhaseIndicator(swingIndicator);
+
+        // Prime cache up to wave five
+        indicator.getValue(5);
+
+        assertThat(indicator.getValue(6)).isEqualTo(ElliottPhase.CORRECTIVE_A);
+        assertThat(indicator.getValue(7)).isEqualTo(ElliottPhase.CORRECTIVE_B);
+        assertThat(indicator.getValue(8)).isEqualTo(ElliottPhase.CORRECTIVE_C);
+        assertThat(indicator.isCorrectiveConfirmed(8)).isTrue();
+
+        assertThat(indicator.impulseSwings(8)).hasSize(5);
+        assertThat(indicator.correctiveSwings(8)).hasSize(3);
+    }
+
+    @Test
+    void shouldReturnNoneWhenSwingPricesContainNaN() {
+        var series = new MockBarSeriesBuilder().build();
+        var factory = series.numFactory();
+        var swings = new ArrayList<List<ElliottSwing>>();
+        swings.add(List.of());
+        swings.add(List.of(new ElliottSwing(0, 1, factory.numOf(100), NaN, ElliottDegree.MINOR)));
+        swings.add(List.of(new ElliottSwing(0, 1, factory.numOf(100), NaN, ElliottDegree.MINOR),
+                new ElliottSwing(1, 2, factory.numOf(110), factory.numOf(103), ElliottDegree.MINOR)));
+
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var indicator = new ElliottPhaseIndicator(swingIndicator);
+
+        assertThat(indicator.getValue(1)).isEqualTo(ElliottPhase.NONE);
+        assertThat(indicator.isImpulseConfirmed(2)).isFalse();
+    }
+
+    @Test
+    void shouldTrackBearishImpulse() {
+        var series = new MockBarSeriesBuilder().build();
+        var factory = series.numFactory();
+
+        var wave1 = new ElliottSwing(0, 2, factory.numOf(100), factory.numOf(90), ElliottDegree.MINOR);
+        var wave2 = new ElliottSwing(2, 4, factory.numOf(90), factory.numOf(95), ElliottDegree.MINOR);
+        var wave3 = new ElliottSwing(4, 7, factory.numOf(95), factory.numOf(74), ElliottDegree.MINOR);
+        var wave4 = new ElliottSwing(7, 9, factory.numOf(74), factory.numOf(81), ElliottDegree.MINOR);
+        var wave5 = new ElliottSwing(9, 12, factory.numOf(81), factory.numOf(65), ElliottDegree.MINOR);
+
+        var swings = List.of(List.<ElliottSwing>of(), List.of(wave1), List.of(wave1, wave2),
+                List.of(wave1, wave2, wave3), List.of(wave1, wave2, wave3, wave4),
+                List.of(wave1, wave2, wave3, wave4, wave5));
+
+        var swingIndicator = new StubSwingIndicator(series, swings);
+        var indicator = new ElliottPhaseIndicator(swingIndicator);
+
+        assertThat(indicator.getValue(5)).isEqualTo(ElliottPhase.WAVE5);
+        assertThat(indicator.isImpulseConfirmed(5)).isTrue();
+    }
+
+    static List<List<ElliottSwing>> impulseAndCorrectionSwings(final NumFactory factory) {
+        var wave1 = new ElliottSwing(0, 3, factory.numOf(100), factory.numOf(110), ElliottDegree.MINOR);
+        var wave2 = new ElliottSwing(3, 5, factory.numOf(110), factory.numOf(104), ElliottDegree.MINOR);
+        var wave3 = new ElliottSwing(5, 9, factory.numOf(104), factory.numOf(120), ElliottDegree.MINOR);
+        var wave4 = new ElliottSwing(9, 11, factory.numOf(120), factory.numOf(114), ElliottDegree.MINOR);
+        var wave5 = new ElliottSwing(11, 15, factory.numOf(114), factory.numOf(125), ElliottDegree.MINOR);
+        var waveA = new ElliottSwing(15, 18, factory.numOf(125), factory.numOf(113), ElliottDegree.MINOR);
+        var waveB = new ElliottSwing(18, 20, factory.numOf(113), factory.numOf(121), ElliottDegree.MINOR);
+        var waveC = new ElliottSwing(20, 24, factory.numOf(121), factory.numOf(108), ElliottDegree.MINOR);
+
+        var swings = new ArrayList<List<ElliottSwing>>();
+        swings.add(List.<ElliottSwing>of());
+        swings.add(List.of(wave1));
+        swings.add(List.of(wave1, wave2));
+        swings.add(List.of(wave1, wave2, wave3));
+        swings.add(List.of(wave1, wave2, wave3, wave4));
+        swings.add(List.of(wave1, wave2, wave3, wave4, wave5));
+        swings.add(List.of(wave1, wave2, wave3, wave4, wave5, waveA));
+        swings.add(List.of(wave1, wave2, wave3, wave4, wave5, waveA, waveB));
+        swings.add(List.of(wave1, wave2, wave3, wave4, wave5, waveA, waveB, waveC));
+        return swings;
+    }
+
+    private static final class StubSwingIndicator extends ElliottSwingIndicator {
+
+        private final List<List<ElliottSwing>> swingsByIndex;
+
+        private StubSwingIndicator(final BarSeries series, final List<List<ElliottSwing>> swingsByIndex) {
+            super(series, 1, ElliottDegree.MINOR);
+            this.swingsByIndex = swingsByIndex;
+        }
+
+        @Override
+        protected List<ElliottSwing> calculate(final int index) {
+            if (index < swingsByIndex.size()) {
+                return swingsByIndex.get(index);
+            }
+            return swingsByIndex.get(swingsByIndex.size() - 1);
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `ElliottPhaseIndicator` and `ElliottPhase` enum with metadata-driven helpers to confirm impulse/corrective structure 
- Introduce `ElliottInvalidationIndicator` plus Fibonacci validator and swing metadata utilities for wave rule enforcement
- Expand indicator documentation and tests to cover the new wave analysis APIs

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGELOG.md`
