### PR TITLE
Avoid duplicate GitHub Release asset uploads

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -245,7 +245,5 @@ jobs:
           body_path: ${{ steps.version.outputs.notes_file }}
           files: |
             **/target/*.jar
-            **/target/*-sources.jar
-            **/target/*-javadoc.jar
         env:
           GITHUB_TOKEN: ${{ env.GH_TA4J_REPO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - **GitHub Release artifacts**: Build now uses the production-release profile so javadoc jars are generated and artifact validation succeeds.
+- **GitHub Release asset uploads**: Removed overlapping upload patterns to prevent duplicate asset uploads from failing the release.
 
 
 ## 0.22.0 (2025-12-29)


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes failed github release workflow by avoiding uploading duplicate assests
- 
- 

- [X] added an entry with related ticket number(s) to the unreleased section of `CHANGES.md` 
