### PR TITLE
**Trade-sampled Sharpe/Sortino**: Added `SamplingFrequency.TRADE` support to `SharpeRatioCriterion` and `SortinoRatioCriterion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Added
+- **Trade-sampled Sharpe/Sortino**: Added `SamplingFrequency.TRADE` support to `SharpeRatioCriterion` and `SortinoRatioCriterion`.
+
 ### Fixed
 - **Publish-release manual dispatch inputs**: `publish-release.yml` now reads `workflow_dispatch` metadata from event inputs so manual reruns correctly receive `releaseVersion`/`releaseCommit`.
 - **Prepare-release metadata guard**: Added a Maven Central metadata validation gate in `prepare-release.yml` (including dry-run mode) to fail early when required POM metadata (including developers) is missing.

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/SamplingFrequency.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/SamplingFrequency.java
@@ -9,5 +9,5 @@ package org.ta4j.core.analysis.frequency;
  * @since 0.22.2
  */
 public enum SamplingFrequency {
-    BAR, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH
+    BAR, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, TRADE
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/SamplingFrequencyIndexes.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/SamplingFrequencyIndexes.java
@@ -57,6 +57,9 @@ public final class SamplingFrequencyIndexes {
      * @since 0.22.2
      */
     public Stream<IndexPair> sample(BarSeries series, int anchorIndex, int start, int end) {
+        if (samplingFrequency == SamplingFrequency.TRADE) {
+            throw new IllegalArgumentException("SamplingFrequency.TRADE is not supported by SamplingFrequencyIndexes");
+        }
         if (start > end || end - start < 1) {
             return Stream.empty();
         }
@@ -96,6 +99,8 @@ public final class SamplingFrequencyIndexes {
         case WEEK -> !sameIsoWeek(now, next);
         case MONTH -> !YearMonth.from(now).equals(YearMonth.from(next));
         case BAR -> true;
+        case TRADE ->
+            throw new IllegalStateException("SamplingFrequency.TRADE is not supported by time-based period detection");
         };
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/RatioSampleSupport.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/RatioSampleSupport.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.ta4j.core.*;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.analysis.ExcessReturns;
+import org.ta4j.core.analysis.OpenPositionHandling;
+import org.ta4j.core.analysis.cost.CostModel;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.analysis.frequency.IndexPair;
+import org.ta4j.core.analysis.frequency.Sample;
+import org.ta4j.core.analysis.frequency.SamplingFrequency;
+import org.ta4j.core.analysis.frequency.SamplingFrequencyIndexes;
+import org.ta4j.core.utils.BarSeriesUtils;
+
+/**
+ * Generates ratio-criterion samples for time-based and trade-based sampling.
+ *
+ * <p>
+ * Time-based sampling uses {@link SamplingFrequencyIndexes} to group bar
+ * indices by period boundaries. Trade-based sampling emits one sample per
+ * position interval (entry to exit, or entry to final index for included open
+ * positions). For {@link LiveTradingRecord}, open lots are expanded into
+ * independent positions so mark-to-market trade sampling mirrors lot-level
+ * analysis behavior.
+ *
+ * @since 0.22.2
+ */
+final class RatioSampleSupport {
+
+    private RatioSampleSupport() {
+    }
+
+    /**
+     * Builds ratio samples according to the selected sampling frequency.
+     *
+     * @param series               the bar series
+     * @param tradingRecord        the trading record
+     * @param samplingFrequency    the sampling mode
+     * @param groupingZoneId       the grouping time zone for time-based sampling
+     * @param excessReturns        excess-return calculator
+     * @param openPositionHandling controls inclusion of open positions for trade
+     *                             sampling
+     * @return a stream of generated samples
+     */
+    static Stream<Sample> samples(BarSeries series, TradingRecord tradingRecord, SamplingFrequency samplingFrequency,
+            ZoneId groupingZoneId, ExcessReturns excessReturns, OpenPositionHandling openPositionHandling) {
+        Objects.requireNonNull(series, "series must not be null");
+        Objects.requireNonNull(tradingRecord, "tradingRecord must not be null");
+        Objects.requireNonNull(samplingFrequency, "samplingFrequency must not be null");
+        Objects.requireNonNull(groupingZoneId, "groupingZoneId must not be null");
+        Objects.requireNonNull(excessReturns, "excessReturns must not be null");
+        Objects.requireNonNull(openPositionHandling, "openPositionHandling must not be null");
+
+        if (samplingFrequency == SamplingFrequency.TRADE) {
+            return tradeSamples(series, tradingRecord, excessReturns, openPositionHandling);
+        }
+        return timeBasedSamples(series, samplingFrequency, groupingZoneId, excessReturns);
+    }
+
+    private static Stream<Sample> timeBasedSamples(BarSeries series, SamplingFrequency samplingFrequency,
+            ZoneId groupingZoneId, ExcessReturns excessReturns) {
+        var beginIndex = series.getBeginIndex();
+        var startIndex = beginIndex + 1;
+        var endIndex = series.getEndIndex();
+        var samplingFrequencyIndexes = new SamplingFrequencyIndexes(samplingFrequency, groupingZoneId);
+        return samplingFrequencyIndexes.sample(series, beginIndex, startIndex, endIndex)
+                .map(indexPair -> toSample(series, indexPair, excessReturns));
+    }
+
+    private static Stream<Sample> tradeSamples(BarSeries series, TradingRecord tradingRecord,
+            ExcessReturns excessReturns, OpenPositionHandling openPositionHandling) {
+        var finalIndex = series.getEndIndex();
+        return tradePairs(tradingRecord, finalIndex, openPositionHandling)
+                .map(indexPair -> toSample(series, indexPair, excessReturns));
+    }
+
+    private static Stream<IndexPair> tradePairs(TradingRecord tradingRecord, int finalIndex,
+            OpenPositionHandling openPositionHandling) {
+        return positionsForTradeSampling(tradingRecord, finalIndex, openPositionHandling)
+                .map(position -> toTradePair(position, finalIndex))
+                .filter(Objects::nonNull);
+    }
+
+    private static IndexPair toTradePair(Position position, int finalIndex) {
+        var entry = position.getEntry();
+        if (entry == null) {
+            return null;
+        }
+        var entryIndex = entry.getIndex();
+        var currentIndex = finalIndex;
+        var exit = position.getExit();
+        if (exit != null) {
+            currentIndex = Math.min(exit.getIndex(), finalIndex);
+        }
+        if (currentIndex < entryIndex) {
+            return null;
+        }
+        return new IndexPair(entryIndex, currentIndex);
+    }
+
+    private static Stream<Position> positionsForTradeSampling(TradingRecord tradingRecord, int finalIndex,
+            OpenPositionHandling openPositionHandling) {
+        var recordPositions = tradingRecord.getPositions()
+                .stream()
+                .filter(position -> shouldIncludePosition(position, finalIndex, openPositionHandling));
+        if (shouldIncludeOpenPositions(openPositionHandling)) {
+            return recordPositions;
+        }
+        var openPositions = openPositions(tradingRecord, finalIndex).stream();
+        return Stream.concat(recordPositions, openPositions);
+    }
+
+    private static boolean shouldIncludePosition(Position position, int finalIndex,
+            OpenPositionHandling openPositionHandling) {
+        if (position == null || position.getEntry() == null) {
+            return false;
+        }
+        var entryIndex = position.getEntry().getIndex();
+        if (entryIndex > finalIndex) {
+            return false;
+        }
+        if (shouldIncludeOpenPositions(openPositionHandling)) {
+            var exit = position.getExit();
+            var isOpenAtFinalIndex = exit == null || exit.getIndex() > finalIndex;
+            return !isOpenAtFinalIndex;
+        }
+        return true;
+    }
+
+    private static boolean shouldIncludeOpenPositions(OpenPositionHandling openPositionHandling) {
+        return openPositionHandling != OpenPositionHandling.MARK_TO_MARKET;
+    }
+
+    private static List<Position> openPositions(TradingRecord tradingRecord, int finalIndex) {
+        if (tradingRecord instanceof LiveTradingRecord liveTradingRecord) {
+            return openPositionsFromLiveRecord(liveTradingRecord, finalIndex);
+        }
+        var positions = new ArrayList<Position>();
+        var currentPosition = tradingRecord.getCurrentPosition();
+        if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null
+                && currentPosition.getEntry().getIndex() <= finalIndex) {
+            positions.add(currentPosition);
+        }
+        return positions;
+    }
+
+    private static List<Position> openPositionsFromLiveRecord(LiveTradingRecord record, int finalIndex) {
+        var positions = new ArrayList<Position>();
+        var transactionCostModel = defaultCostModel(record.getTransactionCostModel());
+        var holdingCostModel = defaultCostModel(record.getHoldingCostModel());
+        var startingType = record.getStartingType();
+        var entrySide = startingType == TradeType.BUY ? ExecutionSide.BUY : ExecutionSide.SELL;
+        for (var openPosition : record.getOpenPositions()) {
+            for (var lot : openPosition.lots()) {
+                if (lot.entryIndex() > finalIndex) {
+                    continue;
+                }
+                var entryTrade = new LiveTrade(lot.entryIndex(), lot.entryTime(), lot.entryPrice(), lot.amount(),
+                        lot.fee(), entrySide, lot.orderId(), lot.correlationId());
+                var position = new Position(entryTrade, transactionCostModel, holdingCostModel);
+                positions.add(position);
+            }
+        }
+        return positions;
+    }
+
+    private static CostModel defaultCostModel(CostModel costModel) {
+        return costModel == null ? new ZeroCostModel() : costModel;
+    }
+
+    private static Sample toSample(BarSeries series, IndexPair indexPair, ExcessReturns excessReturns) {
+        var previousIndex = indexPair.previousIndex();
+        var currentIndex = indexPair.currentIndex();
+        return new Sample(excessReturns.excessReturn(previousIndex, currentIndex),
+                BarSeriesUtils.deltaYears(series, previousIndex, currentIndex));
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/SortinoRatioCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/SortinoRatioCriterion.java
@@ -15,15 +15,12 @@ import org.ta4j.core.analysis.CashFlow;
 import org.ta4j.core.analysis.ExcessReturns;
 import org.ta4j.core.analysis.ExcessReturns.CashReturnPolicy;
 import org.ta4j.core.analysis.OpenPositionHandling;
-import org.ta4j.core.analysis.frequency.IndexPair;
 import org.ta4j.core.analysis.frequency.Sample;
 import org.ta4j.core.analysis.frequency.SampleSummary;
 import org.ta4j.core.analysis.frequency.SamplingFrequency;
-import org.ta4j.core.analysis.frequency.SamplingFrequencyIndexes;
 import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
-import org.ta4j.core.utils.BarSeriesUtils;
 
 /**
  * Computes the Sortino Ratio.
@@ -54,13 +51,20 @@ import org.ta4j.core.utils.BarSeriesUtils;
  * returns are computed between period endpoints detected from bar
  * {@code endTime} after converting it to {@link #groupingZoneId}. Period
  * boundaries follow ISO week semantics for {@code WEEKLY}.</li>
+ * <li>{@link SamplingFrequency#TRADE}: one return per position interval
+ * (entry-to-exit), with open positions included only when
+ * {@link OpenPositionHandling#MARK_TO_MARKET} is enabled.</li>
  * </ul>
- * The first sampled return is anchored at the series begin index, even when
- * evaluating a single {@link Position}, so the first period return spans from
- * the series start to the first period end. Pre-entry intervals are handled by
- * {@link CashReturnPolicy}: {@link CashReturnPolicy#CASH_EARNS_RISK_FREE} keeps
- * flat pre-entry equity neutral, while {@link CashReturnPolicy#CASH_EARNS_ZERO}
- * treats flat pre-entry equity as underperforming cash.
+ * For time-based sampling ({@link SamplingFrequency#BAR},
+ * {@link SamplingFrequency#SECOND}, {@link SamplingFrequency#MINUTE},
+ * {@link SamplingFrequency#HOUR}, {@link SamplingFrequency#DAY},
+ * {@link SamplingFrequency#WEEK}, {@link SamplingFrequency#MONTH}), the first
+ * sampled return is anchored at the series begin index, even when evaluating a
+ * single {@link Position}. Trade sampling uses each position interval directly.
+ * Pre-entry intervals are handled by {@link CashReturnPolicy}:
+ * {@link CashReturnPolicy#CASH_EARNS_RISK_FREE} keeps flat pre-entry equity
+ * neutral, while {@link CashReturnPolicy#CASH_EARNS_ZERO} treats flat pre-entry
+ * equity as underperforming cash.
  *
  * <p>
  * <b>Risk-free rate.</b> {@link #annualRiskFreeRate} is interpreted as an
@@ -100,7 +104,7 @@ import org.ta4j.core.utils.BarSeriesUtils;
  */
 public class SortinoRatioCriterion extends AbstractAnalysisCriterion {
 
-    private final SamplingFrequencyIndexes samplingFrequencyIndexes;
+    private final SamplingFrequency samplingFrequency;
     private final Annualization annualization;
     private final CashReturnPolicy cashReturnPolicy;
     private final double annualRiskFreeRate;
@@ -184,8 +188,7 @@ public class SortinoRatioCriterion extends AbstractAnalysisCriterion {
         this.cashReturnPolicy = Objects.requireNonNull(cashReturnPolicy, "cashReturnPolicy must not be null");
         this.openPositionHandling = Objects.requireNonNull(openPositionHandling,
                 "openPositionHandling must not be null");
-        Objects.requireNonNull(samplingFrequency, "samplingFrequency must not be null");
-        this.samplingFrequencyIndexes = new SamplingFrequencyIndexes(samplingFrequency, this.groupingZoneId);
+        this.samplingFrequency = Objects.requireNonNull(samplingFrequency, "samplingFrequency must not be null");
     }
 
     @Override
@@ -203,18 +206,11 @@ public class SortinoRatioCriterion extends AbstractAnalysisCriterion {
         if (tradingRecord == null) {
             return zero;
         }
-        int beginIndex = series.getBeginIndex();
-        int start = beginIndex + 1;
-        int end = series.getEndIndex();
-        if (end - start + 1 < 2) {
-            return zero;
-        }
-
         Num annualRiskFreeRateNum = numFactory.numOf(annualRiskFreeRate);
         ExcessReturns excessReturns = new ExcessReturns(series, annualRiskFreeRateNum, cashReturnPolicy, tradingRecord,
                 openPositionHandling);
-        List<Sample> samples = samplingFrequencyIndexes.sample(series, beginIndex, start, end)
-                .map(pair -> getSample(series, pair, excessReturns))
+        List<Sample> samples = RatioSampleSupport
+                .samples(series, tradingRecord, samplingFrequency, groupingZoneId, excessReturns, openPositionHandling)
                 .toList();
         SampleSummary summary = SampleSummary.fromSamples(samples.stream(), numFactory);
 
@@ -252,13 +248,6 @@ public class SortinoRatioCriterion extends AbstractAnalysisCriterion {
 
         Num variance = downsideSumSquares.dividedBy(numFactory.numOf(samples.size()));
         return variance.sqrt();
-    }
-
-    private Sample getSample(BarSeries series, IndexPair pair, ExcessReturns excessReturns) {
-        int previousIndex = pair.previousIndex();
-        Num excessReturn = excessReturns.excessReturn(previousIndex, pair.currentIndex());
-        Num deltaYears = BarSeriesUtils.deltaYears(series, previousIndex, pair.currentIndex());
-        return new Sample(excessReturn, deltaYears);
     }
 
     @Override

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/sampling/SamplingFrequencyIndexesTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/sampling/SamplingFrequencyIndexesTest.java
@@ -12,6 +12,7 @@ import org.ta4j.core.BaseBarSeriesBuilder;
 import org.ta4j.core.BarSeries;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import org.ta4j.core.analysis.frequency.IndexPair;
 import org.ta4j.core.analysis.frequency.SamplingFrequencyIndexes;
 import org.ta4j.core.analysis.frequency.SamplingFrequency;
@@ -84,6 +85,14 @@ public class SamplingFrequencyIndexesTest {
         var pairs = sampler.sample(series, 0, 3, 1).toList();
 
         assertEquals(List.of(), pairs);
+    }
+
+    @Test
+    public void sampleTradeThrowsIllegalArgumentException() {
+        var series = buildDailySeries();
+        var sampler = new SamplingFrequencyIndexes(SamplingFrequency.TRADE, ZoneOffset.UTC);
+
+        assertThrows(IllegalArgumentException.class, () -> sampler.sample(series, 0, 1, 3));
     }
 
     private static BarSeries buildDailySeries() {

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/RatioSampleSupportTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/RatioSampleSupportTest.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import static org.junit.Assert.assertEquals;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.ExecutionMatchPolicy;
+import org.ta4j.core.ExecutionSide;
+import org.ta4j.core.LiveTrade;
+import org.ta4j.core.LiveTradingRecord;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.ExcessReturns;
+import org.ta4j.core.analysis.ExcessReturns.CashReturnPolicy;
+import org.ta4j.core.analysis.OpenPositionHandling;
+import org.ta4j.core.analysis.cost.ZeroCostModel;
+import org.ta4j.core.analysis.frequency.SamplingFrequency;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.NumFactory;
+import org.ta4j.core.utils.BarSeriesUtils;
+
+@RunWith(Parameterized.class)
+public class RatioSampleSupportTest {
+
+    private final NumFactory numFactory;
+
+    public RatioSampleSupportTest(NumFactory numFactory) {
+        this.numFactory = numFactory;
+    }
+
+    @Parameterized.Parameters(name = "NumFactory: {index} (0=DoubleNum, 1=DecimalNum)")
+    public static List<NumFactory> function() {
+        return List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance());
+    }
+
+    @Test
+    public void barSamplingReturnsExpectedValuesAndDeltaYears() {
+        var series = buildDailySeries("bar_sampling_series", new double[] { 100d, 110d, 99d, 108.9d });
+        var tradingRecord = RatioCriterionTestSupport.alwaysInvested(series);
+        var excessReturns = new ExcessReturns(series, numFactory.zero(), CashReturnPolicy.CASH_EARNS_RISK_FREE,
+                tradingRecord, OpenPositionHandling.MARK_TO_MARKET);
+
+        var samples = RatioSampleSupport
+                .samples(series, tradingRecord, SamplingFrequency.BAR, ZoneOffset.UTC, excessReturns,
+                        OpenPositionHandling.MARK_TO_MARKET)
+                .toList();
+
+        assertEquals(3, samples.size());
+        assertNumEquals(0.1d, samples.get(0).value());
+        assertNumEquals(-0.1d, samples.get(1).value());
+        assertNumEquals(0.1d, samples.get(2).value());
+
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 0, 1), samples.get(0).deltaYears(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 1, 2), samples.get(1).deltaYears(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 2, 3), samples.get(2).deltaYears(), 1e-12);
+    }
+
+    @Test
+    public void tradeSamplingIncludesOpenPositionForMarkToMarketAndExcludesForIgnore() {
+        var series = buildDailySeries("trade_sampling_series", new double[] { 100d, 110d, 99d, 120d });
+
+        var tradingRecord = buildRecordWithOneOpenPosition(series);
+        var markToMarketReturns = new ExcessReturns(series, numFactory.zero(), CashReturnPolicy.CASH_EARNS_RISK_FREE,
+                tradingRecord, OpenPositionHandling.MARK_TO_MARKET);
+        var ignoreReturns = new ExcessReturns(series, numFactory.zero(), CashReturnPolicy.CASH_EARNS_RISK_FREE,
+                tradingRecord, OpenPositionHandling.IGNORE);
+
+        var markToMarketSamples = RatioSampleSupport
+                .samples(series, tradingRecord, SamplingFrequency.TRADE, ZoneOffset.UTC, markToMarketReturns,
+                        OpenPositionHandling.MARK_TO_MARKET)
+                .toList();
+        var ignoreSamples = RatioSampleSupport
+                .samples(series, tradingRecord, SamplingFrequency.TRADE, ZoneOffset.UTC, ignoreReturns,
+                        OpenPositionHandling.IGNORE)
+                .toList();
+
+        assertEquals(3, markToMarketSamples.size());
+        assertEquals(2, ignoreSamples.size());
+
+        assertNumEquals(0.1d, markToMarketSamples.get(0).value());
+        assertNumEquals(-0.1d, markToMarketSamples.get(1).value());
+        assertNumEquals((120d / 99d) - 1d, markToMarketSamples.get(2).value());
+        assertNumEquals(0.1d, ignoreSamples.get(0).value());
+        assertNumEquals(-0.1d, ignoreSamples.get(1).value());
+
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 0, 1), markToMarketSamples.get(0).deltaYears(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 1, 2), markToMarketSamples.get(1).deltaYears(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 2, 3), markToMarketSamples.get(2).deltaYears(), 1e-12);
+    }
+
+    @Test
+    public void tradeSamplingExpandsLiveTradingRecordOpenLots() {
+        var series = buildDailySeries("trade_sampling_live_series", new double[] { 10d, 12d, 14d });
+
+        var liveTradingRecord = new LiveTradingRecord(TradeType.BUY, ExecutionMatchPolicy.FIFO, new ZeroCostModel(),
+                new ZeroCostModel(), null, null);
+        liveTradingRecord.recordFill(0, new LiveTrade(0, Instant.EPOCH, series.getBar(0).getClosePrice(),
+                numFactory.one(), null, ExecutionSide.BUY, null, null));
+        liveTradingRecord.recordFill(1, new LiveTrade(1, Instant.EPOCH, series.getBar(1).getClosePrice(),
+                numFactory.one(), null, ExecutionSide.BUY, null, null));
+
+        var markToMarketReturns = new ExcessReturns(series, numFactory.zero(), CashReturnPolicy.CASH_EARNS_RISK_FREE,
+                liveTradingRecord, OpenPositionHandling.MARK_TO_MARKET);
+        var ignoreReturns = new ExcessReturns(series, numFactory.zero(), CashReturnPolicy.CASH_EARNS_RISK_FREE,
+                liveTradingRecord, OpenPositionHandling.IGNORE);
+
+        var markToMarketSamples = RatioSampleSupport
+                .samples(series, liveTradingRecord, SamplingFrequency.TRADE, ZoneOffset.UTC, markToMarketReturns,
+                        OpenPositionHandling.MARK_TO_MARKET)
+                .toList();
+        var ignoreSamples = RatioSampleSupport
+                .samples(series, liveTradingRecord, SamplingFrequency.TRADE, ZoneOffset.UTC, ignoreReturns,
+                        OpenPositionHandling.IGNORE)
+                .toList();
+
+        assertEquals(2, markToMarketSamples.size());
+        assertEquals(0, ignoreSamples.size());
+        assertNumEquals(markToMarketReturns.excessReturn(0, 2), markToMarketSamples.get(0).value(), 1e-12);
+        assertNumEquals(markToMarketReturns.excessReturn(1, 2), markToMarketSamples.get(1).value(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 0, 2), markToMarketSamples.get(0).deltaYears(), 1e-12);
+        assertNumEquals(BarSeriesUtils.deltaYears(series, 1, 2), markToMarketSamples.get(1).deltaYears(), 1e-12);
+    }
+
+    private TradingRecord buildRecordWithOneOpenPosition(BarSeries series) {
+        var tradingRecord = new BaseTradingRecord();
+        tradingRecord.enter(0, series.getBar(0).getClosePrice(), series.numFactory().one());
+        tradingRecord.exit(1, series.getBar(1).getClosePrice(), series.numFactory().one());
+        tradingRecord.enter(1, series.getBar(1).getClosePrice(), series.numFactory().one());
+        tradingRecord.exit(2, series.getBar(2).getClosePrice(), series.numFactory().one());
+        tradingRecord.enter(2, series.getBar(2).getClosePrice(), series.numFactory().one());
+        return tradingRecord;
+    }
+
+    private BarSeries buildDailySeries(String name, double[] closes) {
+        var series = new BaseBarSeriesBuilder().withName(name).withNumFactory(numFactory).build();
+        return RatioCriterionTestSupport.buildDailySeries(series, closes, Instant.parse("2024-01-01T00:00:00Z"));
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- **Trade-sampled Sharpe/Sortino**: Added `SamplingFrequency.TRADE` support to `SharpeRatioCriterion` and `SortinoRatioCriterion` 

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 
