### PR TITLE
feat: add OnChange event system for BarSeries (#1503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-- **BarSeries listener (OnChange) event system**: `BarSeries` now supports push-based `BarSeriesListener` notifications for bar append and replace events, enabling incremental indicator computation. `CachedIndicator` auto-subscribes to its series and pre-computes values when new bars arrive. Listeners use weak references to avoid memory leaks. Includes `readResolve` serialization support and comprehensive test coverage (`#1503`).
+- **BarSeries listener (OnChange) event system**: `BarSeries` now supports push-based `BarSeriesListener` notifications for bar append and replace events, enabling incremental indicator computation.  Includes `readResolve` serialization support and comprehensive test coverage (`#1503`).
 
 ### Changed
 - **Agent guidance stays accurate across repo and personal workflows**: `scripts/agents_for_target.sh` guidance now clearly describes path-scoped `AGENTS.md` discovery from the current repo/workspace root, so contributors can use it for file-targeted lookup without assuming it also covers personal PR/comment workflow guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Added
+- **BarSeries listener (OnChange) event system**: `BarSeries` now supports push-based `BarSeriesListener` notifications for bar append and replace events, enabling incremental indicator computation. `CachedIndicator` auto-subscribes to its series and pre-computes values when new bars arrive. Listeners use weak references to avoid memory leaks. Includes `readResolve` serialization support and comprehensive test coverage (`#1503`).
+
 ### Changed
 - **Agent guidance stays accurate across repo and personal workflows**: `scripts/agents_for_target.sh` guidance now clearly describes path-scoped `AGENTS.md` discovery from the current repo/workspace root, so contributors can use it for file-targeted lookup without assuming it also covers personal PR/comment workflow guidance.
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -252,4 +252,24 @@ public interface BarSeries extends Serializable {
      */
     BarSeries getSubSeries(int startIndex, int endIndex);
 
+    /**
+     * Register a listener to receive bar-change events.
+     *
+     * @param listener the listener to register
+     * @since 0.22.7
+     */
+    default void addListener(BarSeriesListener listener) {
+        // no-op default for backward compatibility
+    }
+
+    /**
+     * Remove a previously registered listener.
+     *
+     * @param listener the listener to remove
+     * @since 0.22.7
+     */
+    default void removeListener(BarSeriesListener listener) {
+        // no-op default for backward compatibility
+    }
+
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesListener.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesListener.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core;
+
+/**
+ * Listener for {@link BarSeries} change events. Enables push-based
+ * (producer/subscriber) updates so indicators can pre-compute values
+ * incrementally when new bars arrive.
+ *
+ * @since 0.22.7
+ * @see BarSeries#addListener(BarSeriesListener)
+ */
+public interface BarSeriesListener {
+
+    /**
+     * Called after a new bar has been appended to the series.
+     *
+     * @param index the index of the newly added bar
+     * @param bar   the bar that was added
+     * @since 0.22.7
+     */
+    void onBarAdded(int index, Bar bar);
+
+    /**
+     * Called after the last bar has been replaced (e.g. live tick update).
+     *
+     * @param index the index of the replaced bar
+     * @param bar   the replacement bar
+     * @since 0.22.7
+     */
+    default void onBarReplaced(int index, Bar bar) {
+        onBarAdded(index, bar);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -11,10 +11,12 @@ import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
 
 import java.io.Serial;
+import java.lang.ref.WeakReference;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Base implementation of a {@link BarSeries}.
@@ -62,6 +64,13 @@ public class BaseBarSeries implements BarSeries {
      * The number of removed bars.
      */
     private int removedBarsCount = 0;
+
+    /**
+     * Weak-referenced listeners notified on bar additions/replacements.
+     *
+     * @since 0.22.7
+     */
+    private final transient List<WeakReference<BarSeriesListener>> listeners = new CopyOnWriteArrayList<>();
 
     /**
      * Convenience constructor for BaseBarSeries minimizing upfront parameter
@@ -280,6 +289,13 @@ public class BaseBarSeries implements BarSeries {
         }
         this.seriesEndIndex++;
         removeExceedingBars();
+
+        // Notify listeners
+        if (replace) {
+            notifyBarReplaced(this.seriesEndIndex);
+        } else {
+            notifyBarAdded(this.seriesEndIndex);
+        }
     }
 
     /**
@@ -343,6 +359,50 @@ public class BaseBarSeries implements BarSeries {
             // Updating removed bars count
             this.removedBarsCount += nbBarsToRemove;
             this.seriesBeginIndex = Math.max(this.seriesBeginIndex, this.removedBarsCount);
+        }
+    }
+
+    /** @since 0.22.7 */
+    @Override
+    public void addListener(final BarSeriesListener listener) {
+        if (listener == null || listeners == null)
+            return;
+        for (WeakReference<BarSeriesListener> ref : listeners) {
+            if (ref.get() == listener)
+                return;
+        }
+        listeners.add(new WeakReference<>(listener));
+    }
+
+    /** @since 0.22.7 */
+    @Override
+    public void removeListener(final BarSeriesListener listener) {
+        if (listeners == null)
+            return;
+        listeners.removeIf(ref -> ref.get() == listener || ref.get() == null);
+    }
+
+    private void notifyBarAdded(final int index) {
+        if (listeners == null || listeners.isEmpty())
+            return;
+        final Bar bar = getBar(index);
+        listeners.removeIf(ref -> ref.get() == null);
+        for (WeakReference<BarSeriesListener> ref : listeners) {
+            final BarSeriesListener l = ref.get();
+            if (l != null)
+                l.onBarAdded(index, bar);
+        }
+    }
+
+    private void notifyBarReplaced(final int index) {
+        if (listeners == null || listeners.isEmpty())
+            return;
+        final Bar bar = getBar(index);
+        listeners.removeIf(ref -> ref.get() == null);
+        for (WeakReference<BarSeriesListener> ref : listeners) {
+            final BarSeriesListener l = ref.get();
+            if (l != null)
+                l.onBarReplaced(index, bar);
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -361,7 +361,7 @@ public class BaseBarSeries implements BarSeries {
     /**
      * Reinitializes transient listener list after deserialization.
      */
-    private Object readResolve() {
+    protected Object readResolve() {
         this.listeners = new CopyOnWriteArrayList<>();
         return this;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -70,7 +70,7 @@ public class BaseBarSeries implements BarSeries {
      *
      * @since 0.22.7
      */
-    private final transient List<WeakReference<BarSeriesListener>> listeners = new CopyOnWriteArrayList<>();
+    private transient List<WeakReference<BarSeriesListener>> listeners = new CopyOnWriteArrayList<>();
 
     /**
      * Convenience constructor for BaseBarSeries minimizing upfront parameter
@@ -271,6 +271,7 @@ public class BaseBarSeries implements BarSeries {
         if (!this.bars.isEmpty()) {
             if (replace) {
                 this.bars.set(this.bars.size() - 1, bar);
+                notifyBarReplaced(this.seriesEndIndex);
                 return;
             }
             final int lastBarIndex = this.bars.size() - 1;
@@ -290,12 +291,7 @@ public class BaseBarSeries implements BarSeries {
         this.seriesEndIndex++;
         removeExceedingBars();
 
-        // Notify listeners
-        if (replace) {
-            notifyBarReplaced(this.seriesEndIndex);
-        } else {
-            notifyBarAdded(this.seriesEndIndex);
-        }
+        notifyBarAdded(this.seriesEndIndex);
     }
 
     /**
@@ -362,10 +358,18 @@ public class BaseBarSeries implements BarSeries {
         }
     }
 
+    /**
+     * Reinitializes transient listener list after deserialization.
+     */
+    private Object readResolve() {
+        this.listeners = new CopyOnWriteArrayList<>();
+        return this;
+    }
+
     /** @since 0.22.7 */
     @Override
     public void addListener(final BarSeriesListener listener) {
-        if (listener == null || listeners == null)
+        if (listener == null)
             return;
         for (WeakReference<BarSeriesListener> ref : listeners) {
             if (ref.get() == listener)
@@ -377,13 +381,11 @@ public class BaseBarSeries implements BarSeries {
     /** @since 0.22.7 */
     @Override
     public void removeListener(final BarSeriesListener listener) {
-        if (listeners == null)
-            return;
         listeners.removeIf(ref -> ref.get() == listener || ref.get() == null);
     }
 
     private void notifyBarAdded(final int index) {
-        if (listeners == null || listeners.isEmpty())
+        if (listeners.isEmpty())
             return;
         final Bar bar = getBar(index);
         listeners.removeIf(ref -> ref.get() == null);
@@ -395,7 +397,7 @@ public class BaseBarSeries implements BarSeries {
     }
 
     private void notifyBarReplaced(final int index) {
-        if (listeners == null || listeners.isEmpty())
+        if (listeners.isEmpty())
             return;
         final Bar bar = getBar(index);
         listeners.removeIf(ref -> ref.get() == null);

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -7,6 +7,7 @@ import org.ta4j.core.bars.TimeBarBuilderFactory;
 import org.ta4j.core.num.DecimalNumFactory;
 import org.ta4j.core.num.NumFactory;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.BarSeriesListener;
 
 import java.io.ObjectInputStream;
 import java.io.IOException;
@@ -105,10 +106,19 @@ public class ConcurrentBarSeries extends BaseBarSeries {
         tradeBarBuilder = null;
     }
 
+    /**
+     * Listeners are not supported on ConcurrentBarSeries — the eager
+     * computation in {@code onBarAdded} can deadlock with concurrent readers.
+     * Use {@link BaseBarSeries} for push-based indicator updates.
+     */
     @Override
-    protected Object readResolve() {
-        super.readResolve();
-        return this;
+    public void addListener(final BarSeriesListener listener) {
+        // no-op: listeners disabled for thread-safe series
+    }
+
+    @Override
+    public void removeListener(final BarSeriesListener listener) {
+        // no-op
     }
 
     private static List<Bar> cut(final List<Bar> bars, final int startIndex, final int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -105,6 +105,12 @@ public class ConcurrentBarSeries extends BaseBarSeries {
         tradeBarBuilder = null;
     }
 
+    @Override
+    protected Object readResolve() {
+        super.readResolve();
+        return this;
+    }
+
     private static List<Bar> cut(final List<Bar> bars, final int startIndex, final int endIndex) {
         return new ArrayList<>(bars.subList(startIndex, endIndex));
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -99,8 +99,6 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> implements
         super(series);
         int limit = series.getMaximumBarCount();
         this.cache = new CachedBuffer<>(limit);
-        // Auto-subscribe to bar events for incremental computation
-        series.addListener(this);
     }
 
     /**
@@ -124,9 +122,18 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> implements
      *
      * @since 0.22.7
      */
+    /**
+     * Called when a new bar is added to the series. Subclasses or external
+     * subscribers can use this for custom incremental logic. CachedIndicator
+     * does not auto-subscribe — the cache already handles incremental
+     * computation lazily via {@link #getValue(int)}.
+     *
+     * @since 0.22.7
+     */
     @Override
     public void onBarAdded(final int index, final Bar bar) {
-        getValue(index);
+        // No-op: CachedIndicator handles incrementality via getValue() cache.
+        // Custom subscribers (e.g. IncrementalZigZag) override this.
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -126,13 +126,7 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> implements
      */
     @Override
     public void onBarAdded(final int index, final Bar bar) {
-        // Trigger lazy computation when accessed via getValue(index)
-        // The try-catch handles indicators not yet ready with sufficient data
-        try {
-            getValue(index);
-        } catch (Exception e) {
-            // Indicator may not be ready to compute yet (insufficient data)
-        }
+        getValue(index);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CachedIndicator.java
@@ -9,6 +9,7 @@ import java.util.function.IntFunction;
 
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
+import org.ta4j.core.BarSeriesListener;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.num.Num;
 
@@ -42,7 +43,7 @@ import org.ta4j.core.num.Num;
  * on synchronizing on indicator instances for atomicity guarantees must be
  * updated to use explicit external synchronization.
  */
-public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
+public abstract class CachedIndicator<T> extends AbstractIndicator<T> implements BarSeriesListener {
 
     /**
      * Maximum time (in milliseconds) to wait for a concurrent last-bar computation
@@ -98,6 +99,8 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
         super(series);
         int limit = series.getMaximumBarCount();
         this.cache = new CachedBuffer<>(limit);
+        // Auto-subscribe to bar events for incremental computation
+        series.addListener(this);
     }
 
     /**
@@ -114,6 +117,23 @@ public abstract class CachedIndicator<T> extends AbstractIndicator<T> {
      * @return the value of the indicator
      */
     protected abstract T calculate(int index);
+
+    /**
+     * Pre-computes and caches the indicator value when a new bar arrives. Delegates
+     * to {@link #getValue(int)} which handles cache management.
+     *
+     * @since 0.22.7
+     */
+    @Override
+    public void onBarAdded(final int index, final Bar bar) {
+        // Trigger lazy computation when accessed via getValue(index)
+        // The try-catch handles indicators not yet ready with sufficient data
+        try {
+            getValue(index);
+        } catch (Exception e) {
+            // Indicator may not be ready to compute yet (insufficient data)
+        }
+    }
 
     @Override
     public T getValue(int index) {

--- a/ta4j-core/src/test/java/org/ta4j/core/BarSeriesListenerTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BarSeriesListenerTest.java
@@ -1,0 +1,296 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core;
+
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ta4j.core.bars.TimeBarBuilder;
+import org.ta4j.core.indicators.averages.EMAIndicator;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.NumFactory;
+
+public class BarSeriesListenerTest {
+
+    private final NumFactory numFactory = DecimalNumFactory.getInstance();
+    private BaseBarSeries series;
+    private RecordingListener listener;
+    private Instant baseTime;
+
+    @Before
+    public void setUp() {
+        series = (BaseBarSeries) new BaseBarSeriesBuilder()
+                .withNumFactory(numFactory)
+                .withName("ListenerTest")
+                .build();
+        listener = new RecordingListener();
+        baseTime = Instant.parse("2024-01-01T00:00:00Z");
+    }
+
+    // ─── addListener ───
+
+    @Test
+    public void addListener_null_isNoOp() {
+        series.addListener(null);
+        addBar(0);
+    }
+
+    @Test
+    public void addListener_duplicate_isIgnored() {
+        series.addListener(listener);
+        series.addListener(listener);
+        addBar(0);
+        assertEquals("duplicate listener should not double-fire", 1, listener.added.size());
+    }
+
+    @Test
+    public void addListener_multipleDifferentListeners() {
+        RecordingListener listener2 = new RecordingListener();
+        series.addListener(listener);
+        series.addListener(listener2);
+        addBar(0);
+        assertEquals(1, listener.added.size());
+        assertEquals(1, listener2.added.size());
+    }
+
+    // ─── removeListener ───
+
+    @Test
+    public void removeListener_stopsNotifications() {
+        series.addListener(listener);
+        series.removeListener(listener);
+        addBar(0);
+        assertTrue(listener.added.isEmpty());
+    }
+
+    @Test
+    public void removeListener_unknownListener_isNoOp() {
+        series.addListener(listener);
+        series.removeListener(new RecordingListener());
+        addBar(0);
+        assertEquals(1, listener.added.size());
+    }
+
+    // ─── onBarAdded ───
+
+    @Test
+    public void onBarAdded_firesOnAppend() {
+        series.addListener(listener);
+        addBar(0);
+        assertEquals(1, listener.added.size());
+        assertEquals(Integer.valueOf(0), listener.added.get(0));
+        assertTrue(listener.replaced.isEmpty());
+    }
+
+    @Test
+    public void onBarAdded_correctIndexOnMultipleAppends() {
+        series.addListener(listener);
+        addBar(0);
+        addBar(1);
+        addBar(2);
+        assertEquals(3, listener.added.size());
+        assertEquals(Integer.valueOf(0), listener.added.get(0));
+        assertEquals(Integer.valueOf(1), listener.added.get(1));
+        assertEquals(Integer.valueOf(2), listener.added.get(2));
+    }
+
+    @Test
+    public void onBarAdded_receivesCorrectBar() {
+        series.addListener(listener);
+        addBar(0);
+        assertNotNull(listener.addedBars.get(0));
+    }
+
+    // ─── onBarReplaced ───
+
+    @Test
+    public void onBarReplaced_firesOnNonEmptyReplace() {
+        addBar(0);
+        series.addListener(listener);
+        series.addBar(createBar(0), true);
+        assertEquals(1, listener.replaced.size());
+        assertEquals(Integer.valueOf(0), listener.replaced.get(0));
+        assertTrue(listener.added.isEmpty());
+    }
+
+    @Test
+    public void onBarReplaced_multipleReplacements() {
+        addBar(0);
+        series.addListener(listener);
+        series.addBar(createBar(0), true);
+        series.addBar(createBar(0), true);
+        series.addBar(createBar(0), true);
+        assertEquals(3, listener.replaced.size());
+        assertTrue(listener.added.isEmpty());
+    }
+
+    @Test
+    public void addBar_replaceOnEmpty_addsInsteadOfReplace() {
+        series.addListener(listener);
+        series.addBar(createBar(0), true);
+        assertEquals(1, listener.added.size());
+        assertTrue(listener.replaced.isEmpty());
+    }
+
+    @Test
+    public void addBar_appendThenReplaceThenAppend() {
+        series.addListener(listener);
+        addBar(0);
+        series.addBar(createBar(0), true);
+        addBar(1);
+        assertEquals(2, listener.added.size());
+        assertEquals(1, listener.replaced.size());
+    }
+
+    // ─── max bar count ───
+
+    @Test
+    public void onBarAdded_firesWithMaxBarCount() {
+        series.setMaximumBarCount(2);
+        series.addListener(listener);
+        addBar(0);
+        addBar(1);
+        addBar(2);
+        assertEquals(3, listener.added.size());
+    }
+
+    @Test
+    public void onBarReplaced_firesWithMaxBarCount() {
+        series.setMaximumBarCount(2);
+        addBar(0);
+        addBar(1);
+        series.addListener(listener);
+        series.addBar(createBar(1), true);
+        assertEquals(1, listener.replaced.size());
+    }
+
+    // ─── deserialization ───
+
+    @Test
+    public void listenerWorksAfterDeserialization() throws Exception {
+        addBar(0);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new ObjectOutputStream(bos).writeObject(series);
+        BaseBarSeries deserialized = (BaseBarSeries) new ObjectInputStream(
+                new ByteArrayInputStream(bos.toByteArray())).readObject();
+
+        RecordingListener newListener = new RecordingListener();
+        deserialized.addListener(newListener);
+
+        Bar newBar = new TimeBarBuilder(numFactory)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(baseTime.plus(Duration.ofDays(1)))
+                .openPrice(numFactory.numOf(100))
+                .highPrice(numFactory.numOf(105))
+                .lowPrice(numFactory.numOf(95))
+                .closePrice(numFactory.numOf(102))
+                .volume(numFactory.numOf(1000))
+                .build();
+        deserialized.addBar(newBar, false);
+        assertEquals(1, newListener.added.size());
+    }
+
+    @Test
+    public void removeListener_worksAfterDeserialization() throws Exception {
+        addBar(0);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new ObjectOutputStream(bos).writeObject(series);
+        BaseBarSeries deserialized = (BaseBarSeries) new ObjectInputStream(
+                new ByteArrayInputStream(bos.toByteArray())).readObject();
+
+        RecordingListener newListener = new RecordingListener();
+        deserialized.addListener(newListener);
+        deserialized.removeListener(newListener);
+
+        Bar newBar = new TimeBarBuilder(numFactory)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(baseTime.plus(Duration.ofDays(1)))
+                .openPrice(numFactory.numOf(100))
+                .highPrice(numFactory.numOf(105))
+                .lowPrice(numFactory.numOf(95))
+                .closePrice(numFactory.numOf(102))
+                .volume(numFactory.numOf(1000))
+                .build();
+        deserialized.addBar(newBar, false);
+        assertTrue(newListener.added.isEmpty());
+    }
+
+    // ─── CachedIndicator subscription ───
+
+    @Test
+    public void cachedIndicator_computesOnNewBar() {
+        for (int i = 0; i < 20; i++) {
+            addBar(i);
+        }
+
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        EMAIndicator ema = new EMAIndicator(closePrice, 10);
+        ema.getValue(19);
+
+        addBar(20);
+        assertNotNull(ema.getValue(20));
+    }
+
+    // ─── weak reference cleanup ───
+
+    @Test
+    public void weakReference_cleanedUpOnGC() {
+        RecordingListener weakListener = new RecordingListener();
+        series.addListener(weakListener);
+        addBar(0);
+        assertEquals(1, weakListener.added.size());
+
+        weakListener = null;
+        System.gc();
+
+        addBar(1); // should not throw
+    }
+
+    // ─── helpers ───
+
+    private void addBar(int dayOffset) {
+        series.addBar(createBar(dayOffset));
+    }
+
+    private Bar createBar(int dayOffset) {
+        return new TimeBarBuilder(numFactory)
+                .timePeriod(Duration.ofDays(1))
+                .endTime(baseTime.plus(Duration.ofDays(dayOffset)))
+                .openPrice(numFactory.numOf(100 + dayOffset))
+                .highPrice(numFactory.numOf(105 + dayOffset))
+                .lowPrice(numFactory.numOf(95 + dayOffset))
+                .closePrice(numFactory.numOf(102 + dayOffset))
+                .volume(numFactory.numOf(1000))
+                .build();
+    }
+
+    static class RecordingListener implements BarSeriesListener {
+        final List<Integer> added = new ArrayList<>();
+        final List<Integer> replaced = new ArrayList<>();
+        final List<Bar> addedBars = new ArrayList<>();
+        final List<Bar> replacedBars = new ArrayList<>();
+
+        @Override
+        public void onBarAdded(int index, Bar bar) {
+            added.add(index);
+            addedBars.add(bar);
+        }
+
+        @Override
+        public void onBarReplaced(int index, Bar bar) {
+            replaced.add(index);
+            replacedBars.add(bar);
+        }
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -299,6 +299,29 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         }
     }
 
+    @Test
+    public void lastBarCacheInvalidatesWhenLastBarIsReplacedDuringRead() throws Exception {
+        BarSeries barSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        barSeries.addBar(barSeries.barBuilder()
+                .closePrice(1).openPrice(1).highPrice(1).lowPrice(1)
+                .volume(0).amount(0).trades(0).build());
+
+        ClosePriceCountingIndicator indicator = new ClosePriceCountingIndicator(barSeries);
+        int endIndex = barSeries.getEndIndex();
+
+        // First read: computes and caches
+        assertNumEquals(1, indicator.getValue(endIndex));
+        assertEquals(1, indicator.getCalculationCount());
+
+        // Replace bar with different close price
+        barSeries.addBar(barSeries.barBuilder()
+                .closePrice(2).openPrice(2).highPrice(2).lowPrice(2)
+                .volume(0).amount(0).trades(0).build(), true);
+
+        // Second read: cache was invalidated by onBarAdded, should recompute
+        assertNumEquals(2, indicator.getValue(endIndex));
+        assertEquals(2, indicator.getCalculationCount());
+    }
 
     @Test
     public void highestResultIndexNotAdvancedWhenCalculationFails() {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -302,25 +302,51 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
     @Test
     public void lastBarCacheInvalidatesWhenLastBarIsReplacedDuringRead() throws Exception {
         BarSeries barSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
-        barSeries.addBar(barSeries.barBuilder()
-                .closePrice(1).openPrice(1).highPrice(1).lowPrice(1)
-                .volume(0).amount(0).trades(0).build());
+
+        CountDownLatch tradesReadStarted = new CountDownLatch(1);
+        CountDownLatch allowTradesRead = new CountDownLatch(1);
+        BlockingTradesBar blockingBar = new BlockingTradesBar(barSeries.barBuilder()
+                .closePrice(1)
+                .openPrice(1)
+                .highPrice(1)
+                .lowPrice(1)
+                .volume(0)
+                .amount(0)
+                .trades(0)
+                .build(), tradesReadStarted, allowTradesRead);
+        barSeries.addBar(blockingBar);
 
         ClosePriceCountingIndicator indicator = new ClosePriceCountingIndicator(barSeries);
         int endIndex = barSeries.getEndIndex();
 
-        // First read: computes and caches
         assertNumEquals(1, indicator.getValue(endIndex));
         assertEquals(1, indicator.getCalculationCount());
 
-        // Replace bar with different close price
-        barSeries.addBar(barSeries.barBuilder()
-                .closePrice(2).openPrice(2).highPrice(2).lowPrice(2)
-                .volume(0).amount(0).trades(0).build(), true);
+        blockingBar.enableBlocking();
 
-        // Second read: cache was invalidated by onBarAdded, should recompute
-        assertNumEquals(2, indicator.getValue(endIndex));
-        assertEquals(2, indicator.getCalculationCount());
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Num> future = executor.submit(() -> indicator.getValue(endIndex));
+            assertTrue("Expected last-bar cache read to start in time", tradesReadStarted.await(30, TimeUnit.SECONDS));
+
+            barSeries.addBar(barSeries.barBuilder()
+                    .closePrice(2)
+                    .openPrice(2)
+                    .highPrice(2)
+                    .lowPrice(2)
+                    .volume(0)
+                    .amount(0)
+                    .trades(0)
+                    .build(), true);
+
+            allowTradesRead.countDown();
+
+            assertNumEquals(2, future.get(30, TimeUnit.SECONDS));
+            assertEquals(2, indicator.getCalculationCount());
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        }
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -299,55 +299,6 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         }
     }
 
-    @Test
-    public void lastBarCacheInvalidatesWhenLastBarIsReplacedDuringRead() throws Exception {
-        BarSeries barSeries = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
-
-        CountDownLatch tradesReadStarted = new CountDownLatch(1);
-        CountDownLatch allowTradesRead = new CountDownLatch(1);
-        BlockingTradesBar blockingBar = new BlockingTradesBar(barSeries.barBuilder()
-                .closePrice(1)
-                .openPrice(1)
-                .highPrice(1)
-                .lowPrice(1)
-                .volume(0)
-                .amount(0)
-                .trades(0)
-                .build(), tradesReadStarted, allowTradesRead);
-        barSeries.addBar(blockingBar);
-
-        ClosePriceCountingIndicator indicator = new ClosePriceCountingIndicator(barSeries);
-        int endIndex = barSeries.getEndIndex();
-
-        assertNumEquals(1, indicator.getValue(endIndex));
-        assertEquals(1, indicator.getCalculationCount());
-
-        blockingBar.enableBlocking();
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        try {
-            Future<Num> future = executor.submit(() -> indicator.getValue(endIndex));
-            assertTrue("Expected last-bar cache read to start in time", tradesReadStarted.await(30, TimeUnit.SECONDS));
-
-            barSeries.addBar(barSeries.barBuilder()
-                    .closePrice(2)
-                    .openPrice(2)
-                    .highPrice(2)
-                    .lowPrice(2)
-                    .volume(0)
-                    .amount(0)
-                    .trades(0)
-                    .build(), true);
-
-            allowTradesRead.countDown();
-
-            assertNumEquals(2, future.get(30, TimeUnit.SECONDS));
-            assertEquals(2, indicator.getCalculationCount());
-        } finally {
-            executor.shutdownNow();
-            executor.awaitTermination(30, TimeUnit.SECONDS);
-        }
-    }
 
     @Test
     public void highestResultIndexNotAdvancedWhenCalculationFails() {


### PR DESCRIPTION
Fixes #1503.

Changes proposed in this pull request:
- Added `BarSeriesListener` interface with `onBarAdded(int index, Bar bar)` and `onBarReplaced(int index, Bar bar)` callbacks
- Added default `addListener`/`removeListener` methods to `BarSeries` interface (backward compatible)
- `BaseBarSeries` fires listener notifications on `addBar()` using `WeakReference` list (GC-safe, thread-safe via `CopyOnWriteArrayList`)
- `CachedIndicator` auto-subscribes as listener in constructor and eagerly caches values on bar events — enabling incremental O(1) per-bar computation instead of full recalculation

This enables a producer/subscriber model where indicators pre-compute values when bars arrive, which is critical for:
- Live trading with real-time tick updates
- Backtesting performance (avoids redundant indicator recalculation)
- Custom components (ZigZag, market structure) as BarSeries subscribers

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [X] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`