### PR TITLE
Move ta4j to Java 25 LTS

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Before you submit
 
-- **Run this before every PR (Maven Wrapper recommended):** `./mvnw -B clean license:format formatter:format test install`  
-  On Windows, use `mvnw.cmd -B clean license:format formatter:format test install`. If you prefer system Maven, `mvn -B clean license:format formatter:format test install` is also supported.  
+- **Use Java 25+ and Maven 3.9+.** The build enforces these versions during Maven validation.
+
+- **Run this before every PR:** `mvn -B clean license:format formatter:format test install`
   CI will fail if your changes are not formatted or lack the project license header. First-time contributors almost always hit this; run the command locally first.
 
 - [Search existing issues](https://github.com/ta4j/ta4j/issues?q=is%3Aissue) before opening a new one.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
 
       - name: Check license headers

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -177,11 +177,11 @@ jobs:
       #   - *-javadoc.jar
       #   - *-sources.jar
       # ------------------------------------------------------------
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
 
       - name: Build all module artifacts

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -550,7 +550,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
 
       - name: Set up Java with publishing secrets
@@ -558,7 +558,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
           server-id: central
           server-username: ${{ secrets.MAVEN_CENTRAL_TOKEN_USER }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
           server-id: central
           server-username: ${{ secrets.MAVEN_CENTRAL_TOKEN_USER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
 
       - name: Build and run tests with Maven

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: maven
 
       - name: Validate source code formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@
 - **Monte Carlo drawdown criterion**: Reused shared statistics helper for simulated drawdown summaries.
 - **Dependencies**: update to latest versions
 - **CI concurrency**: Cancel in-progress runs for the primary PR/push validation workflows to reduce backlog.
+- **Java 25 LTS baseline**: [#1338](https://github.com/ta4j/ta4j/issues/1338) Ta4j now builds and publishes for Java 25+, matching the project policy of tracking Java LTS releases.
 
 ### Fixed
 - **Chart window focus stealing**: `ta4j-examples` chart display paths now set `setFocusableWindowState(false)` so chart-related test/example runs do not steal desktop focus.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ta4j  [![Build and Test](https://github.com/ta4j/ta4j/actions/workflows/test.yml/badge.svg)](https://github.com/ta4j/ta4j/actions/workflows/test.yml) [![Discord](https://img.shields.io/discord/745552125769023488.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/HX9MbWZ) [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) ![Maven Central](https://img.shields.io/maven-central/v/org.ta4j/ta4j-parent?color=blue&label=Version) ![JDK](https://img.shields.io/badge/JDK-21%2B-orange)
+# ta4j  [![Build and Test](https://github.com/ta4j/ta4j/actions/workflows/test.yml/badge.svg)](https://github.com/ta4j/ta4j/actions/workflows/test.yml) [![Discord](https://img.shields.io/discord/745552125769023488.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/HX9MbWZ) [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) ![Maven Central](https://img.shields.io/maven-central/v/org.ta4j/ta4j-parent?color=blue&label=Version) ![JDK](https://img.shields.io/badge/JDK-25%2B-orange)
 
 ***Technical Analysis for Java***
 
@@ -12,7 +12,7 @@ Build, test, and deploy trading bots in Java. With 200+ (and counting) technical
 
 - [Why Ta4j?](#why-ta4j)
 - [Install in seconds](#install-in-seconds)
-- [Build commands: Maven Wrapper or Maven](#build-commands-maven-wrapper-or-maven)
+- [Build commands: Maven](#build-commands-maven)
 - [Quick start: Your first strategy](#quick-start-your-first-strategy)
 - [Sourcing market data](#sourcing-market-data)
 - [Visualize and share strategies](#visualize-and-share-strategies)
@@ -50,7 +50,7 @@ Ta4j does not promise profitable strategies. It promises reproducible experiment
 
 ### Why Java developers choose Ta4j
 
-- **Pure Java, zero friction**: Works anywhere Java 21+ runs - cloud functions, desktop tools, microservices, or trading bots. No Python bridges or external dependencies.
+- **Pure Java, zero friction**: Works anywhere Java 25+ runs - cloud functions, desktop tools, microservices, or trading bots. No Python bridges or external dependencies.
 - **Type-safe, Production-ready**: Ta4j favors explicit models, strong typing, and predictable performance over exploratory scripting. Deterministic outputs, JSON serialization for strategies/indicators, and minimal dependencies make it easy to deploy.
 - **Huge indicator catalog**: Aroon, ATR, Ichimoku, MACD, RSI, Renko, Heikin-Ashi, and 190+ more ready to plug together. New indicators are added regularly based on community needs and contributions.
 - **Composable strategies**: Chain rules fluently using familiar Java patterns - no DSLs or configuration files required.
@@ -122,14 +122,9 @@ Like living on the edge? Use the snapshot version of ta4j-examples for the lates
 
 **💡 Tip**: The `ta4j-examples` module includes runnable demos, data loaders, and charting utilities. It's a great way to see Ta4j in action and learn by example.
 
-## Build commands: Maven Wrapper or Maven
+## Build commands: Maven
 
-Ta4j supports both approaches:
-
-- **Maven Wrapper (recommended):** Uses the repository-pinned Maven version and avoids requiring a global Maven installation.
-  Linux/macOS/Git Bash: `./mvnw ...`
-  Windows CMD/PowerShell: `mvnw.cmd ...`
-- **System Maven (optional):** Use `mvn ...` if you prefer your local Maven installation.
+Ta4j requires Java 25+ and Maven 3.9+. Use `mvn ...` from the repository root.
 
 ## Try it now
 
@@ -140,24 +135,16 @@ Ta4j supports both approaches:
 git clone https://github.com/ta4j/ta4j.git
 cd ta4j
 
-# Build the project first (Linux/macOS/Git Bash)
-./mvnw clean install -DskipTests
-# Windows CMD/PowerShell: mvnw.cmd clean install -DskipTests
+# Build the project first
+mvn clean install -DskipTests
 
 # Run the Quickstart example (Quickstart is configured as the default)
-./mvnw -pl ta4j-examples exec:java
-# Windows CMD/PowerShell: mvnw.cmd -pl ta4j-examples exec:java
+mvn -pl ta4j-examples exec:java
 ```
-
-Prefer system Maven? Use the same commands with `mvn` instead of `./mvnw` or `mvnw.cmd`.
 
 **Alternative:** To run a different example class:
 ```bash
-# On Linux/Mac/Git Bash
-./mvnw -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
-
-# On Windows CMD (use quotes)
-mvnw.cmd -pl ta4j-examples exec:java "-Dexec.mainClass=ta4jexamples.Quickstart"
+mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
 ```
 
 This will load historical Bitcoin data, run a complete trading strategy, display performance metrics, and show an interactive chart - all in one go!
@@ -172,7 +159,7 @@ Load price data, plug in indicators, and describe when to enter/exit. The API re
 
 **💡 Want to see this in action?** The [`Quickstart` example](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/src/main/java/ta4jexamples/Quickstart.java) includes this same pattern plus performance metrics and charting. Run it with:
 ```bash
-./mvnw -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
+mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
 ```
 
 **Key concepts:**
@@ -267,7 +254,7 @@ BarSeries series = YahooFinanceHttpBarSeriesDataSource.loadSeries("BTC-USD",
 
 **See it in action:** Run the complete example with:
 ```bash
-./mvnw -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.backtesting.YahooFinanceBacktest
+mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.backtesting.YahooFinanceBacktest
 ```
 
 This example demonstrates loading data from Yahoo Finance, building an advanced multi-indicator strategy (Bollinger Bands, RSI, ATR stops), running a backtest, and visualizing results.
@@ -302,7 +289,7 @@ BarSeries series = dataSource.loadSeriesInstance("ETH-USD",
 
 **See it in action:** Run the complete example with:
 ```bash
-./mvnw -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.backtesting.CoinbaseBacktest
+mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.backtesting.CoinbaseBacktest
 ```
 
 ### Other data sources
@@ -841,7 +828,7 @@ The `ta4j-examples` module includes runnable examples demonstrating common patte
 - **[CandlestickChart](ta4j-examples/src/main/java/ta4jexamples/indicators/CandlestickChart.java)** - Basic candlestick chart with trading signals
 - **[CashFlowToChart](ta4j-examples/src/main/java/ta4jexamples/analysis/CashFlowToChart.java)** - Visualize cash flow and equity curves
 
-**💡 Tip**: Run any example with `./mvnw -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart` (replace `Quickstart` with the class name; on Windows use `mvnw.cmd`).
+**💡 Tip**: Run any example with `mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart` (replace `Quickstart` with the class name).
 
 ## Performance
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Build -->
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <maven.surefire.version>3.5.4</maven.surefire.version>
         <ta4j.excludedTestTags>integration,slow</ta4j.excludedTestTags>
 
@@ -278,7 +278,7 @@
                                     <version>[3.9.0,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[21,)</version>
+                                    <version>[25,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/ta4j-examples/src/test/java/ta4jexamples/doc/ReadmeContentManagerTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/doc/ReadmeContentManagerTest.java
@@ -4,12 +4,17 @@
 package ta4jexamples.doc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -66,6 +71,37 @@ public class ReadmeContentManagerTest {
         assertTrue(counts.crlf() > 0);
         assertEquals(0, counts.lf());
         assertTrue(updatedContent.contains(snippetBlock("ema-crossover", "ema_crossover", 1, lineSeparator)));
+    }
+
+    @Test
+    public void testRepositoryJavaBaselineDocumentationAndWorkflowsStayAligned() throws IOException {
+        Path repositoryRoot = findRepositoryRoot();
+        String pom = readString(repositoryRoot.resolve("pom.xml"));
+        String readme = readString(repositoryRoot.resolve("README.md"));
+        String contributing = readString(repositoryRoot.resolve(".github").resolve("CONTRIBUTING.md"));
+        List<Path> setupJavaWorkflows = new ArrayList<>();
+
+        assertTrue(pom.contains("<maven.compiler.release>25</maven.compiler.release>"));
+        assertTrue(pom.contains("<requireJavaVersion>"));
+        assertTrue(pom.contains("<version>[25,)</version>"));
+        assertTrue(readme.contains("JDK-25%2B"));
+        assertTrue(readme.contains("Java 25+"));
+        assertFalse(readme.contains("./mvnw"));
+        assertFalse(readme.contains("mvnw.cmd"));
+        assertTrue(contributing.contains("Java 25+"));
+
+        try (Stream<Path> workflowPaths = Files.list(repositoryRoot.resolve(".github").resolve("workflows"))) {
+            workflowPaths.filter(path -> path.getFileName().toString().endsWith(".yml")).forEach(path -> {
+                String workflow = readString(path);
+                if (workflow.contains("actions/setup-java")) {
+                    setupJavaWorkflows.add(path);
+                    assertTrue(workflow.contains("java-version: 25"), path + " should set up Java 25");
+                    assertFalse(workflow.contains("java-version: 21"), path + " should not set up Java 21");
+                }
+            });
+        }
+
+        assertFalse(setupJavaWorkflows.isEmpty());
     }
 
     private static String buildSourceSnippets(String lineSeparator) {
@@ -125,6 +161,27 @@ public class ReadmeContentManagerTest {
             }
         }
         return new LineEndingCounts(crlf, lf);
+    }
+
+    private static Path findRepositoryRoot() throws IOException {
+        Path current = Path.of("").toAbsolutePath();
+        Path candidate = current;
+        while (candidate != null) {
+            if (Files.exists(candidate.resolve("pom.xml")) && Files.exists(candidate.resolve("README.md"))
+                    && Files.isDirectory(candidate.resolve(".github"))) {
+                return candidate;
+            }
+            candidate = candidate.getParent();
+        }
+        throw new IOException("Unable to locate repository root from " + current);
+    }
+
+    private static String readString(Path path) {
+        try {
+            return Files.readString(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private record LineEndingCounts(int crlf, int lf) {


### PR DESCRIPTION
Fixes #1338.
Supersedes #1421.

Changes proposed in this pull request:
- Move ta4j's Maven compiler release and build enforcer baseline to Java 25 LTS.
- Run CI, snapshot, and release workflow Java setup on Temurin 25.
- Refresh active contributor and README commands for Java 25+ and Maven.

Credit: thanks to @francescopeloi for the original Java 25 work in #1421. It's just easier to recreate this PR than to request changes, etc.

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`
