### PR TITLE
Update Doc Drift Part 2 & Automate Documentation Integrity Check During Release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -220,6 +220,13 @@ jobs:
           persist-credentials: true
           token: ${{ steps.token_preflight.outputs.use_repo_token == 'true' && secrets.GH_TA4J_REPO_TOKEN || github.token }}
 
+      - name: Validate documentation integrity
+        run: |
+          echo "::group::Validate documentation links and example references"
+          chmod +x scripts/docs-integrity-check.sh
+          scripts/docs-integrity-check.sh
+          echo "::endgroup::"
+
       # -----------------------
       # Version Detection
       # -----------------------

--- a/README.md
+++ b/README.md
@@ -798,6 +798,8 @@ See the [Elliott Wave Indicators wiki guide](https://ta4j.github.io/ta4j-wiki/El
 
 The `ta4j-examples` module includes runnable examples demonstrating common patterns and strategies:
 
+- **[Examples index and learning tracks](ta4j-examples/README.md)** - Recommended progression from first strategy to live-style workflows
+
 ### Strategy Examples
 - **[RSI2Strategy](ta4j-examples/src/main/java/ta4jexamples/strategies/RSI2Strategy.java)** - Mean reversion strategy using RSI with entry/exit rules
 - **[ADXStrategy](ta4j-examples/src/main/java/ta4jexamples/strategies/ADXStrategy.java)** - Trend-following strategy using ADX and DI indicators
@@ -826,7 +828,7 @@ The `ta4j-examples` module includes runnable examples demonstrating common patte
 - **[ElliottWaveTrendBacktest](ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/backtest/ElliottWaveTrendBacktest.java)** - Evaluates trend-bias directionality over backtest and walk-forward windows.
 - **[HighRewardElliottWaveBacktest](ta4j-examples/src/main/java/ta4jexamples/analysis/elliottwave/backtest/HighRewardElliottWaveBacktest.java)** - Backtests the high-reward Elliott Wave strategy presets.
 - **[WyckoffCycleIndicatorSuiteDemo](ta4j-examples/src/main/java/ta4jexamples/wyckoff/WyckoffCycleIndicatorSuiteDemo.java)** - Demonstrates the Wyckoff cycle entry points (`WyckoffCycleFacade`, `WyckoffCycleAnalysis`) and prints phase transitions on an ossified bar series dataset
-- **[MultiStrategyBacktest](ta4j-examples/src/main/java/ta4jexamples/backtesting/MultiStrategyBacktest.java)** - Compare multiple strategies side-by-side
+- **[SimpleMovingAverageRangeBacktest](ta4j-examples/src/main/java/ta4jexamples/backtesting/SimpleMovingAverageRangeBacktest.java)** - Compare and rank strategy parameter combinations with weighted criteria
 - **[TradeFillRecordingExample](ta4j-examples/src/main/java/ta4jexamples/backtesting/TradeFillRecordingExample.java)** - Walk through a live-style partial-fill workflow with `TradingRecord.operate(fill)`, inspect `getOpenPositions()` versus `getCurrentPosition()`, and compare `FIFO`, `LIFO`, `AVG_COST`, and `SPECIFIC_ID` partial-exit matching.
 - **[TradingRecordParityBacktest](ta4j-examples/src/main/java/ta4jexamples/backtesting/TradingRecordParityBacktest.java)** - Compare next-open, current-close, and slippage execution models side by side, then verify the same fills across default, provided, and factory-configured `BaseTradingRecord` runs.
 - **[BacktestPerformanceTuningHarness](ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java)** - Tune backtest performance (strategy count, bar count, cache window hints, heap sweeps)
@@ -840,15 +842,6 @@ The `ta4j-examples` module includes runnable examples demonstrating common patte
 
 ## Performance
 
-<!-- TODO: Add performance benchmarks and metrics -->
-<!-- Consider including:
-- Backtesting performance (strategies/second, bars/second)
-- Memory usage patterns
-- Comparison with other technical analysis libraries
-- Num type performance characteristics (DecimalNum vs DoubleNum)
-- Real-world usage statistics if available
--->
-
 Ta4j is designed for performance and scalability:
 
 - **Efficient calculations** - Optimized indicator implementations with minimal overhead
@@ -856,7 +849,11 @@ Ta4j is designed for performance and scalability:
 - **Memory-efficient** - Support for moving windows and sub-series to minimize memory footprint
 - **Parallel-friendly** - Strategies can be backtested independently for easy parallelization
 
-For detailed performance characteristics and benchmarks, see the [wiki's performance guide](https://ta4j.github.io/ta4j-wiki/) (TODO: add link when available).
+For performance tuning guidance, start with:
+
+- [Backtesting guide](https://ta4j.github.io/ta4j-wiki/Backtesting.html) for execution-model and batch-run tradeoffs
+- [Num guide](https://ta4j.github.io/ta4j-wiki/Num.html) for precision-vs-speed decisions (`DecimalNum` vs `DoubleNum`)
+- [`BacktestPerformanceTuningHarness`](ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java) for reproducible tuning runs
 
 ## Community & Support
 
@@ -866,26 +863,29 @@ Get help, share ideas, and connect with other Ta4j users:
 - **📖 [Documentation Wiki](https://ta4j.github.io/ta4j-wiki/)** - Comprehensive guides covering indicators, strategies, backtesting, and more
 - **📚 [Javadoc API Reference](https://ta4j.github.io/ta4j/)** - Complete API documentation with examples
 - **🐛 [GitHub Issues](https://github.com/ta4j/ta4j/issues)** - Report bugs, request features, or ask questions
-- **💡 [Usage Examples](https://github.com/ta4j/ta4j/tree/master/ta4j-examples/src/main/java/ta4jexamples)** - Browse runnable code examples in the repository
+- **💡 [Usage Examples](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/README.md)** - Follow curated learning tracks and runnable commands
 
 ## What's next?
 
 **New to technical analysis?**
-- Start with the [wiki's Getting Started guide](https://ta4j.github.io/ta4j-wiki/) to learn core concepts
+- Start with the [wiki's Getting Started guide](https://ta4j.github.io/ta4j-wiki/Getting-started.html) to learn core concepts
 - Explore the [`ta4j-examples`](ta4j-examples) module - each example is runnable and well-commented
 - Try modifying the quick start example above: change indicator parameters, add new rules, or test different exit conditions
 
 **Ready to go deeper?**
-- Browse [strategy recipes](https://ta4j.github.io/ta4j-wiki/) for Renko bricks, Ichimoku clouds, breakout strategies, and more
-- Learn about [portfolio metrics](https://ta4j.github.io/ta4j-wiki/) for multi-asset strategies
-- Check out [advanced backtesting patterns](https://ta4j.github.io/ta4j-wiki/) like walk-forward analysis
+- Browse [strategy recipes](https://ta4j.github.io/ta4j-wiki/Trading-strategies.html) for richer rule composition patterns
+- Learn about [portfolio metrics and risk criteria](https://ta4j.github.io/ta4j-wiki/Analysis-Criteria-and-Risk-Metrics.html)
+- Check out [advanced backtesting patterns](https://ta4j.github.io/ta4j-wiki/Walk-Forward-Research.html) like walk-forward analysis
+- Use the [backtesting realism checklist](https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html) before promoting strategies
+- Follow the [live trading runbook](https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html) for startup/recovery/reconciliation guidance
+- Troubleshoot with the [symptom-driven hub](https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html)
 
 **Need help?**
 - See the [Community & Support](#community--support) section above for all available resources
 
 ## Contributing
 
-- Scan the [roadmap](https://ta4j.github.io/ta4j-wiki/Roadmap-and-Tasks.html) and [how-to-contribute guide](https://ta4j.github.io/ta4j-wiki/How-to-contribute).
+- Scan the [roadmap](https://ta4j.github.io/ta4j-wiki/Roadmap-and-Tasks.html) and [how-to-contribute guide](https://github.com/ta4j/ta4j/blob/master/.github/CONTRIBUTING.md).
 - [Fork the repo](http://help.github.com/forking/), open pull requests, and join code discussions on Discord.
 - See the [contribution policy](.github/CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
 - Run `mvn verify` before opening or updating a pull request. It matches CI and includes advisory SpotBugs and JaCoCo reporting alongside the test suite.

--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ For performance tuning guidance, start with:
 - [Backtesting guide](https://ta4j.github.io/ta4j-wiki/Backtesting.html) for execution-model and batch-run tradeoffs
 - [Num guide](https://ta4j.github.io/ta4j-wiki/Num.html) for precision-vs-speed decisions (`DecimalNum` vs `DoubleNum`)
 - [`BacktestPerformanceTuningHarness`](ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java) for reproducible tuning runs
+- [Performance Characterization](https://ta4j.github.io/ta4j-wiki/Performance-Characterization.html) for methodology and interpretation
 
 ## Community & Support
 
@@ -893,6 +894,20 @@ Use this map when deciding where to read next:
 - Validation discipline: [Backtesting Realism Checklist](https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html)
 - Incident debugging: [Troubleshooting Hub](https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html)
 - Governance and freshness policy: [Documentation Governance](https://ta4j.github.io/ta4j-wiki/Documentation-Governance.html)
+- API migration and compatibility guidance: [Migration and Version Compatibility](https://ta4j.github.io/ta4j-wiki/Migration-and-Version-Compatibility.html)
+
+### Canonical onboarding lane (first 60 minutes)
+
+Follow this sequence if you are onboarding for production use:
+
+1. Install and first strategy: [Getting Started](https://ta4j.github.io/ta4j-wiki/Getting-started.html)
+2. Run maintained examples: [`ta4j-examples/README.md`](ta4j-examples/README.md)
+3. Choose execution model and validation flow: [Backtesting](https://ta4j.github.io/ta4j-wiki/Backtesting.html)
+4. Learn live integration boundaries: [Live Trading](https://ta4j.github.io/ta4j-wiki/Live-trading.html)
+5. Apply promotion and incident controls:
+   [Backtesting Realism Checklist](https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html),
+   [Live Trading Runbook](https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html),
+   [Troubleshooting Hub](https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html)
 
 ## What's next?
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,12 @@ while (true) {
 - **Deterministic**: Same inputs always produce same outputs - critical for testing and debugging
 - **Type-safe**: Compile-time checks catch errors before they cost money
 
+**Execution path references:**
+- Single strategy backtests: [`BarSeriesManager`](https://javadoc.io/doc/org.ta4j/ta4j-core/latest/org/ta4j/core/backtest/BarSeriesManager.html)
+- Large batch runs and ranking: [`BacktestExecutor`](https://javadoc.io/doc/org.ta4j/ta4j-core/latest/org/ta4j/core/backtest/BacktestExecutor.html)
+- Fill timing/slippage/stop-limit behavior: [`TradeExecutionModel`](https://javadoc.io/doc/org.ta4j/ta4j-core/latest/org/ta4j/core/backtest/TradeExecutionModel.html)
+- Fill-aware position state: [`BaseTradingRecord`](https://javadoc.io/doc/org.ta4j/ta4j-core/latest/org/ta4j/core/BaseTradingRecord.html)
+
 ### Migration note: Trade and TradingRecord surfaces
 
 Treat `Trade` and `TradingRecord` as the primary APIs. Stream single fills directly with
@@ -745,6 +751,16 @@ Notes:
 - See `TradeFillRecordingExample` in `ta4j-examples` for a runnable live-style walkthrough that streams fills with
   `TradingRecord.operate(fill)`, contrasts that with grouped `Trade.fromFills(...)` recording, and shows how
   `FIFO`, `LIFO`, `AVG_COST`, and `SPECIFIC_ID` change partial-exit matching.
+
+## Production readiness checklist
+
+Before promoting a strategy from research to live execution, verify:
+
+- Your execution assumptions match reality: [Backtesting](https://ta4j.github.io/ta4j-wiki/Backtesting.html)
+- You pass a realism gate: [Backtesting Realism Checklist](https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html)
+- You have startup/recovery/reconciliation procedures: [Live Trading Runbook](https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html)
+- You have symptom-first debug paths for incidents: [Troubleshooting Hub](https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html)
+- Your example and command links are valid in CI: [`scripts/docs-integrity-check.sh`](scripts/docs-integrity-check.sh)
 
 ## Streaming trade ingestion (gap handling)
 
@@ -864,6 +880,19 @@ Get help, share ideas, and connect with other Ta4j users:
 - **📚 [Javadoc API Reference](https://ta4j.github.io/ta4j/)** - Complete API documentation with examples
 - **🐛 [GitHub Issues](https://github.com/ta4j/ta4j/issues)** - Report bugs, request features, or ask questions
 - **💡 [Usage Examples](https://github.com/ta4j/ta4j/blob/master/ta4j-examples/README.md)** - Follow curated learning tracks and runnable commands
+
+## Canonical doc map
+
+Use this map when deciding where to read next:
+
+- Entry and quick orientation: this `README.md`
+- Core API decision entrypoints: [`ta4j-core/README.md`](ta4j-core/README.md)
+- Runnable progression and commands: [`ta4j-examples/README.md`](ta4j-examples/README.md)
+- End-to-end path from data to operations: [Canonical User Journey](https://ta4j.github.io/ta4j-wiki/Canonical-User-Journey.html)
+- Production operations: [Live Trading Runbook](https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html)
+- Validation discipline: [Backtesting Realism Checklist](https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html)
+- Incident debugging: [Troubleshooting Hub](https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html)
+- Governance and freshness policy: [Documentation Governance](https://ta4j.github.io/ta4j-wiki/Documentation-Governance.html)
 
 ## What's next?
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,13 +45,14 @@ Validation path (dry run):
 Code and docs:
 1. Update `CHANGELOG.md` under `Unreleased`.
 2. Keep README version references current.
-3. Ensure release notes can be generated cleanly (`release/<version>.md`).
-4. Confirm release PRs are visible to release owner:
+3. Run `scripts/docs-integrity-check.sh` and resolve failures before preparing a release.
+4. Ensure release notes can be generated cleanly (`release/<version>.md`).
+5. Confirm release PRs are visible to release owner:
    - release PR must be labeled `release`.
    - release PR is auto-assigned to `TheCookieLab`.
    - `TheCookieLab` is auto-requested as reviewer.
-5. While any labeled release PR is open, only that release PR can be merged.
-6. Open PRs will receive an automatic release-freeze notice comment while the freeze is active. The workflow removes that notice once no release PR remains open.
+6. While any labeled release PR is open, only that release PR can be merged.
+7. Open PRs will receive an automatic release-freeze notice comment while the freeze is active. The workflow removes that notice once no release PR remains open.
 
 Repository settings:
 1. Actions workflow permissions must allow write operations (dispatch, PR updates, tag push).
@@ -77,6 +78,7 @@ Secrets and variables:
 2. Review generated release PR
 - Confirm release commit + next snapshot commit are present.
 - Confirm release notes file exists (`release/<version>.md`).
+- Confirm docs delta is complete for changed APIs/examples (README/wiki/examples index/changelog consistency).
 - If a release PR is open, wait for it to merge before merging any non-release PRs to `master`.
 
 3. Merge release PR to `master`
@@ -123,7 +125,7 @@ Expected behavior:
 | Workflow | Trigger(s) | Primary responsibility | Critical guardrails |
 |---|---|---|---|
 | `release-scheduler.yml` | schedule, manual | decide whether/how to release | binary-impact gate, model catalog preflight, release dossier, semver safety, tag collision checks |
-| `prepare-release.yml` | manual (or scheduler dispatch) | generate release artifacts and release PR/direct-push commits | version validation, metadata validation, dry-run push capability probes |
+| `prepare-release.yml` | manual (or scheduler dispatch) | generate release artifacts and release PR/direct-push commits | docs-integrity checks, version validation, metadata validation, dry-run push capability probes |
 | `publish-release.yml` | merged release PR close, manual | release-candidate verification + tag + Maven Central deploy + snapshot dispatch + release summary | merge discipline + ancestry checks, artifact manifest checks, post-push tag integrity/reachability checks |
 | `release-health.yml` | push to `master`, publish workflow completion, snapshot workflow completion, schedule, manual | detect drift in release state | fails on tag reachability drift, snapshot version drift, missing snapshot publication once snapshot publication is authoritative, missing notes, stale release PRs |
 | `github-release.yml` | semver-like tag push, manual | GitHub release publication | semver tag validation, exact artifact manifest |

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -46,6 +46,7 @@ Code and docs:
 1. Update `CHANGELOG.md` under `Unreleased`.
 2. Keep README version references current.
 3. Run `scripts/docs-integrity-check.sh` and resolve failures before preparing a release.
+   - This gate verifies canonical docs presence, link validity, command references, and TODO-free user-facing entry docs.
 4. Ensure release notes can be generated cleanly (`release/<version>.md`).
 5. Confirm release PRs are visible to release owner:
    - release PR must be labeled `release`.
@@ -79,6 +80,7 @@ Secrets and variables:
 - Confirm release commit + next snapshot commit are present.
 - Confirm release notes file exists (`release/<version>.md`).
 - Confirm docs delta is complete for changed APIs/examples (README/wiki/examples index/changelog consistency).
+- Confirm canonical documentation artifacts are present and linked (`Home`, `Getting-started`, journey/runbook/checklist/troubleshooting, decision matrix, migration map, expected outputs, performance characterization).
 - If a release PR is open, wait for it to merge before merging any non-release PRs to `master`.
 
 3. Merge release PR to `master`

--- a/scripts/docs-integrity-check.sh
+++ b/scripts/docs-integrity-check.sh
@@ -23,7 +23,13 @@ docs_for_command_checks = [
     root / "ta4j-examples" / "README.md",
 ]
 if wiki_available:
-    docs_for_command_checks.append(wiki_root / "Usage-examples.md")
+    docs_for_command_checks.extend(
+        [
+            wiki_root / "Usage-examples.md",
+            wiki_root / "Examples-Expected-Outputs.md",
+            wiki_root / "Performance-Characterization.md",
+        ]
+    )
 
 todo_forbidden_docs = [
     root / "README.md",
@@ -36,6 +42,32 @@ if wiki_available:
             wiki_root / "Getting-started.md",
             wiki_root / "Backtesting.md",
             wiki_root / "Live-trading.md",
+            wiki_root / "Canonical-User-Journey.md",
+            wiki_root / "Execution-Decision-Matrix.md",
+            wiki_root / "Migration-and-Version-Compatibility.md",
+            wiki_root / "Examples-Expected-Outputs.md",
+            wiki_root / "Performance-Characterization.md",
+        ]
+    )
+
+required_canonical_docs = [
+    root / "README.md",
+    root / "ta4j-examples" / "README.md",
+    root / "ta4j-core" / "README.md",
+]
+if wiki_available:
+    required_canonical_docs.extend(
+        [
+            wiki_root / "Home.md",
+            wiki_root / "Getting-started.md",
+            wiki_root / "Canonical-User-Journey.md",
+            wiki_root / "Backtesting-Realism-Checklist.md",
+            wiki_root / "Live-Trading-Runbook.md",
+            wiki_root / "Troubleshooting-Hub.md",
+            wiki_root / "Execution-Decision-Matrix.md",
+            wiki_root / "Migration-and-Version-Compatibility.md",
+            wiki_root / "Examples-Expected-Outputs.md",
+            wiki_root / "Performance-Characterization.md",
         ]
     )
 
@@ -112,6 +144,10 @@ for doc_path in docs_for_command_checks:
 
 for doc_path in todo_forbidden_docs:
     check_for_todo_markers(doc_path)
+
+for doc_path in required_canonical_docs:
+    if not doc_path.exists():
+        errors.append(f"Missing canonical documentation artifact: {doc_path}")
 
 if errors:
     print("docs-integrity:fail")

--- a/scripts/docs-integrity-check.sh
+++ b/scripts/docs-integrity-check.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ROOT_DIR
+
+python3 <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"])
+wiki_root = root.parent / "ta4j-wiki"
+wiki_available = wiki_root.exists()
+
+docs_for_link_checks = [root / "README.md", root / "ta4j-examples" / "README.md"]
+if wiki_available:
+    docs_for_link_checks.extend(sorted(wiki_root.glob("*.md")))
+
+docs_for_command_checks = [
+    root / "README.md",
+    root / "ta4j-examples" / "README.md",
+]
+if wiki_available:
+    docs_for_command_checks.append(wiki_root / "Usage-examples.md")
+
+todo_forbidden_docs = [
+    root / "README.md",
+    root / "ta4j-examples" / "README.md",
+]
+if wiki_available:
+    todo_forbidden_docs.extend(
+        [
+            wiki_root / "Home.md",
+            wiki_root / "Getting-started.md",
+            wiki_root / "Backtesting.md",
+            wiki_root / "Live-trading.md",
+        ]
+    )
+
+link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+main_class_pattern = re.compile(r"-Dexec\.mainClass=([A-Za-z0-9_.]+)")
+
+errors = []
+
+
+def normalize_target(raw_target: str) -> str:
+    target = raw_target.strip()
+    if " " in target and target.startswith(("http://", "https://")):
+        target = target.split(" ", 1)[0]
+    if "#" in target:
+        target = target.split("#", 1)[0]
+    if "?" in target:
+        target = target.split("?", 1)[0]
+    return target.strip()
+
+
+def check_markdown_links(path: Path) -> None:
+    if not path.exists():
+        errors.append(f"Missing documentation file for link check: {path}")
+        return
+    content = path.read_text(encoding="utf-8")
+    for match in link_pattern.finditer(content):
+        raw_target = match.group(1).strip()
+        target = normalize_target(raw_target)
+        if not target:
+            continue
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        if target.startswith("#"):
+            continue
+        candidate = (path.parent / target).resolve()
+        if not candidate.exists():
+            errors.append(f"{path}: broken relative link target '{raw_target}'")
+
+
+def check_exec_main_classes(path: Path) -> None:
+    if not path.exists():
+        errors.append(f"Missing documentation file for command check: {path}")
+        return
+    content = path.read_text(encoding="utf-8")
+    for main_class in main_class_pattern.findall(content):
+        class_file = (
+            root
+            / "ta4j-examples"
+            / "src"
+            / "main"
+            / "java"
+            / Path(*main_class.split(".")).with_suffix(".java")
+        )
+        if not class_file.exists():
+            errors.append(
+                f"{path}: -Dexec.mainClass points to missing class '{main_class}' ({class_file})"
+            )
+
+
+def check_for_todo_markers(path: Path) -> None:
+    if not path.exists():
+        errors.append(f"Missing documentation file for TODO check: {path}")
+        return
+    content = path.read_text(encoding="utf-8")
+    if "TODO" in content:
+        errors.append(f"{path}: contains TODO marker in user-facing docs")
+
+
+for doc_path in docs_for_link_checks:
+    check_markdown_links(doc_path)
+
+for doc_path in docs_for_command_checks:
+    check_exec_main_classes(doc_path)
+
+for doc_path in todo_forbidden_docs:
+    check_for_todo_markers(doc_path)
+
+if errors:
+    print("docs-integrity:fail")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+if not wiki_available:
+    print("docs-integrity:note ta4j-wiki checkout not found; skipping wiki checks")
+print("docs-integrity:pass")
+PY

--- a/ta4j-core/README.md
+++ b/ta4j-core/README.md
@@ -1,0 +1,33 @@
+# ta4j-core
+
+`ta4j-core` contains the production API surface for strategy modeling, backtesting, analysis, and live-style record management.
+
+## Start here
+
+- Series model: `BarSeries`, `BaseBarSeries`, `ConcurrentBarSeries`
+- Strategy model: `Indicator`, `Rule`, `Strategy`
+- Execution model: `BarSeriesManager`, `BacktestExecutor`, `TradeExecutionModel`
+- Trade/fill model: `TradingRecord`, `BaseTradingRecord`, `Trade`, `TradeFill`
+- Analysis model: `AnalysisCriterion` and criteria packages
+
+## Choose the right execution path
+
+- Single strategy over one series: use `BarSeriesManager`
+- Many candidates, tuning, weighted ranking: use `BacktestExecutor`
+- Broker-confirmed/partial-fill replay: use manual evaluation loop + `BaseTradingRecord.operate(fill)`
+
+## Choose the right series type
+
+- Single-threaded backtests and deterministic local runs: `BaseBarSeries`
+- Concurrent ingestion/evaluation pipelines: `ConcurrentBarSeries`
+
+## Choose the right numeric model
+
+- Precision-first workflows: `DecimalNum`
+- Throughput-first workflows with accepted floating-point tradeoffs: `DoubleNum`
+
+## Companion user guides
+
+- Backtesting: https://ta4j.github.io/ta4j-wiki/Backtesting.html
+- Live trading: https://ta4j.github.io/ta4j-wiki/Live-trading.html
+- Risk/criteria: https://ta4j.github.io/ta4j-wiki/Analysis-Criteria-and-Risk-Metrics.html

--- a/ta4j-core/src/main/java/org/ta4j/core/BarBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarBuilder.java
@@ -8,8 +8,18 @@ import java.time.Instant;
 
 import org.ta4j.core.num.Num;
 
+/**
+ * Builder for one OHLCV bar.
+ *
+ * <p>
+ * Typical usage in backtests is to set period/time plus OHLCV fields and call
+ * {@link #add()}. For real-time trade ingestion, prefer series-level ingestion
+ * APIs such as
+ * {@link ConcurrentBarSeries#ingestTrade(java.time.Instant, Number, Number)}
+ * so rollover logic stays consistent.
+ * </p>
+ */
 public interface BarBuilder {
-
     /**
      * @param timePeriod the time period (optional if {@link #beginTime(Instant)}
      *                   and {@link #endTime(Instant)} are given)

--- a/ta4j-core/src/main/java/org/ta4j/core/BarBuilderFactory.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarBuilderFactory.java
@@ -7,6 +7,13 @@ import java.io.Serializable;
 
 /**
  * A factory that provides a builder for a bar.
+ *
+ * <p>
+ * Pair the factory with the bar semantics you need:
+ * time bars for clock-aligned candles, or alternative factories for
+ * volume/amount/tick driven aggregation. In most workflows, this is configured
+ * once at series construction time.
+ * </p>
  */
 public interface BarBuilderFactory extends Serializable {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeriesBuilder.java
@@ -4,7 +4,14 @@
 package org.ta4j.core;
 
 /**
- * Interface to build a bar series.
+ * Interface to build a {@link BarSeries}.
+ *
+ * <p>
+ * Use {@link org.ta4j.core.BaseBarSeriesBuilder} for deterministic
+ * single-threaded workflows, and
+ * {@link org.ta4j.core.ConcurrentBarSeriesBuilder} when ingestion and
+ * evaluation may happen concurrently.
+ * </p>
  */
 public interface BarSeriesBuilder {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -18,6 +18,12 @@ import java.util.Objects;
 
 /**
  * Base implementation of a {@link BarSeries}.
+ *
+ * <p>
+ * This is the default choice for single-threaded backtests and deterministic
+ * replay workflows. If your pipeline ingests bars/trades concurrently with
+ * strategy evaluation, prefer {@link ConcurrentBarSeries}.
+ * </p>
  */
 public class BaseBarSeries implements BarSeries {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseTradingRecord.java
@@ -39,6 +39,17 @@ import org.ta4j.core.num.NumFactory;
  * simulated and live execution behavior.
  * </p>
  *
+ * <p>
+ * Usage guidance:
+ * </p>
+ * <ul>
+ * <li>Backtests with synthetic fills: use index/price/amount operations through
+ * strategy runners.</li>
+ * <li>Broker-confirmed fills: use {@link #operate(TradeFill)} or
+ * {@link #operate(Trade)}.</li>
+ * <li>Lot matching behavior is controlled by {@link ExecutionMatchPolicy}.</li>
+ * </ul>
+ *
  * @since 0.22.2
  */
 public class BaseTradingRecord implements TradingRecord {

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -26,6 +26,12 @@ import java.util.List;
  * cases.
  *
  * <p>
+ * Choose this type only when ingestion and evaluation can overlap on different
+ * threads. For single-threaded backtests and deterministic replay pipelines,
+ * {@link BaseBarSeries} is usually simpler.
+ * </p>
+ *
+ * <p>
  * For real-time data feeds, prefer {@link #ingestTrade(Instant, Num, Num)} and
  * {@link #ingestTrade(Instant, Number, Number)} to let the configured
  * {@link BarBuilder} handle bar rollovers. Direct bar mutations remain

--- a/ta4j-core/src/main/java/org/ta4j/core/TradeFill.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/TradeFill.java
@@ -13,6 +13,12 @@ import org.ta4j.core.num.Num;
  * Immutable execution fill used to represent partial trade executions.
  *
  * <p>
+ * This is the preferred fill primitive for new integrations that need
+ * broker-confirmed execution recording through
+ * {@link TradingRecord#operate(TradeFill)}.
+ * </p>
+ *
+ * <p>
  * Metadata fields ({@code time}, {@code side}, IDs) are optional and may be
  * {@code null}. {@code fee} defaults to zero when omitted.
  * </p>

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Cost models for transaction and holding expense simulation.
+ *
+ * <p>
+ * Use these models to align backtest assumptions with venue fees,
+ * borrow costs, and recorded live execution fees.
+ * </p>
+ */
+package org.ta4j.core.analysis.cost;

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/frequency/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Sampling frequency utilities for analysis windows and aggregation.
+ *
+ * <p>
+ * Use this package to normalize return and risk calculations across
+ * intraday and multi-day horizons with explicit sampling semantics.
+ * </p>
+ */
+package org.ta4j.core.analysis.frequency;

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -26,6 +26,12 @@ import java.util.stream.IntStream;
 /**
  * Allows backtesting multiple strategies and comparing them to find out which
  * is the best.
+ *
+ * <p>
+ * Prefer this class when running many candidate strategies, parameter sweeps,
+ * or weighted ranking workflows. For one strategy over one series, use
+ * {@link BarSeriesManager} for lower setup overhead.
+ * </p>
  */
 public class BacktestExecutor {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BarSeriesManager.java
@@ -29,6 +29,12 @@ import org.ta4j.core.walkforward.WalkForwardConfig;
  * unchanged by default ({@link BaseTradingRecord}), while callers can inject a
  * custom record implementation for unified backtest/live execution paths.
  * </p>
+ *
+ * <p>
+ * Use this class as the default backtest entrypoint when you are evaluating one
+ * strategy over one series. For large strategy batches with ranking and runtime
+ * telemetry, switch to {@link BacktestExecutor}.
+ * </p>
  */
 public class BarSeriesManager {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/TradeExecutionModel.java
@@ -12,6 +12,16 @@ import org.ta4j.core.num.Num;
  *
  * Used for backtesting. Instructs {@link BarSeriesManager} on how to execute
  * trades.
+ *
+ * <p>
+ * Selection guidance:
+ * </p>
+ * <ul>
+ * <li>Use {@link TradeOnNextOpenModel} for conservative signal-at-close, fill-next-open simulation.</li>
+ * <li>Use {@link TradeOnCurrentCloseModel} when your strategy intentionally fills on bar close.</li>
+ * <li>Use {@link SlippageExecutionModel} when you need directional price-impact assumptions.</li>
+ * <li>Use {@link StopLimitExecutionModel} when pending-order lifecycle and partial fills matter.</li>
+ * </ul>
  */
 public interface TradeExecutionModel {
 

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Backtesting execution infrastructure.
+ *
+ * <p>
+ * This package defines how strategies are executed over historical series and how
+ * runs are ranked or compared.
+ * </p>
+ *
+ * <p>
+ * Choose by workload:
+ * </p>
+ * <ul>
+ * <li>{@link org.ta4j.core.backtest.BarSeriesManager} for one strategy over one series</li>
+ * <li>{@link org.ta4j.core.backtest.BacktestExecutor} for many strategies, telemetry, and ranking</li>
+ * <li>{@link org.ta4j.core.backtest.TradeExecutionModel} implementations to align fill semantics
+ * with your simulation assumptions</li>
+ * </ul>
+ */
+package org.ta4j.core.backtest;

--- a/ta4j-core/src/main/java/org/ta4j/core/bars/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/bars/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Bar builder factories and bar-shape construction utilities.
+ *
+ * <p>
+ * Use this package when configuring series aggregation behavior
+ * (time bars, and other factory-driven bar construction patterns).
+ * </p>
+ */
+package org.ta4j.core.bars;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/commissions/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Commission-focused analysis criteria.
+ *
+ * <p>
+ * Use these criteria to quantify fee drag and commission impact on
+ * strategy returns and trade efficiency.
+ * </p>
+ */
+package org.ta4j.core.criteria.commissions;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/drawdown/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/drawdown/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Drawdown-oriented risk criteria.
+ *
+ * <p>
+ * Use this package for capital preservation analysis, downside regime
+ * stress, and return-to-drawdown tradeoff evaluation.
+ * </p>
+ */
+package org.ta4j.core.criteria.drawdown;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/helpers/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Helper criteria and statistical support functions.
+ *
+ * <p>
+ * Use this package when composing custom criteria from common
+ * variance, averaging, and relative dispersion primitives.
+ * </p>
+ */
+package org.ta4j.core.criteria.helpers;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Profit-and-loss criteria for gross/net and return-oriented scoring.
+ *
+ * <p>
+ * Use this package for baseline profitability ranking, return normalization,
+ * and position-level profit/loss diagnostics.
+ * </p>
+ */
+package org.ta4j.core.criteria.pnl;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/risk/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/risk/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Position risk models and risk-unit evaluation criteria.
+ *
+ * <p>
+ * Use this package when sizing and evaluating strategies by risk per trade
+ * rather than only by nominal return.
+ * </p>
+ */
+package org.ta4j.core.criteria.risk;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/package-info.java
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of the 'Directional Movement System'
+ * Directional Movement System indicators (ADX/DI) for trend-strength filtering.
+ *
+ * <p>
+ * Use this package when your strategy needs to separate trend strength from
+ * trend direction and gate entries in low-conviction regimes.
+ * </p>
  */
 package org.ta4j.core.indicators.adx;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Aroon indicators for trend emergence and exhaustion timing.
+ *
+ * <p>
+ * Use this package to detect early trend transitions by measuring
+ * time since recent highs and lows.
+ * </p>
+ */
+package org.ta4j.core.indicators.aroon;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Moving-average and smoothing indicators.
+ *
+ * <p>
+ * Start here for trend baselines (SMA/EMA/WMA/HMA and variants)
+ * used throughout ta4j strategy examples.
+ * </p>
+ */
+package org.ta4j.core.indicators.averages;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/bollinger/package-info.java
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of the 'Bollinger Bands'
+ * Bollinger Band indicators for volatility envelopes and squeeze-style setups.
+ *
+ * <p>
+ * Use this package for mean-reversion or breakout systems that depend on
+ * standard-deviation-derived dynamic bands.
+ * </p>
  */
 package org.ta4j.core.indicators.bollinger;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Donchian channel indicators for breakout range logic.
+ *
+ * <p>
+ * Use this package when modeling trend breakouts using rolling
+ * high/low channels and channel-width context.
+ * </p>
+ */
+package org.ta4j.core.indicators.donchian;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/confidence/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/confidence/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Elliott Wave confidence scoring and profile components.
+ *
+ * <p>
+ * Use this package when comparing alternate Elliott interpretations and
+ * selecting scenario sets by confidence weighting.
+ * </p>
+ */
+package org.ta4j.core.indicators.elliott.confidence;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/swing/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/swing/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Elliott Wave swing detection and swing-structure utilities.
+ *
+ * <p>
+ * Use this package to configure swing extraction behavior before
+ * downstream Elliott scenario generation and validation.
+ * </p>
+ */
+package org.ta4j.core.indicators.elliott.swing;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/package-info.java
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators that can be helpful (for other indicators).
+ * Helper indicators and transforms used as building blocks.
+ *
+ * <p>
+ * Use this package to compose reusable primitives (price extracts, arithmetic
+ * transforms, and common derived values) before introducing custom indicators.
+ * </p>
  */
 package org.ta4j.core.indicators.helpers;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/package-info.java
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of the 'Ichimoku cloud trading strategy'.
+ * Ichimoku indicators for multi-component trend and support/resistance context.
+ *
+ * <p>
+ * Use this package when your strategy needs aligned baseline, conversion,
+ * cloud, and lagging-line structure instead of single-metric trend signals.
+ * </p>
  */
 package org.ta4j.core.indicators.ichimoku;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/keltner/package-info.java
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of the 'Keltner Channel'.
+ * Keltner Channel indicators for volatility-adjusted trend envelopes.
+ *
+ * <p>
+ * Use this package for channel breakouts and pullback strategies that require
+ * ATR-style adaptive band width.
+ * </p>
  */
 package org.ta4j.core.indicators.keltner;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/macd/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/macd/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * MACD-family indicators and related momentum-state variants.
+ *
+ * <p>
+ * Use this package for momentum/trend crossover systems and
+ * histogram-driven state filters.
+ * </p>
+ */
+package org.ta4j.core.indicators.macd;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/numeric/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Numeric utility indicators and number-domain transforms.
+ *
+ * <p>
+ * Use this package for low-level numeric composition in custom indicator
+ * pipelines where direct arithmetic helpers are needed.
+ * </p>
+ */
+package org.ta4j.core.indicators.numeric;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/pivotpoints/package-info.java
@@ -2,6 +2,12 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of different 'Pivot Points'.
+ * Pivot-point indicators for session-derived support and resistance levels.
+ *
+ * <p>
+ * Use this package when your strategy relies on prior-session level geometry
+ * (central pivot, supports, resistances). Typical usage pairs these levels
+ * with breakout filters or fade rules.
+ * </p>
  */
 package org.ta4j.core.indicators.pivotpoints;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/package-info.java
@@ -2,6 +2,13 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of statistical analysis.
+ * Statistical indicators for dispersion, smoothing, and normalization.
+ *
+ * <p>
+ * Use this package when you need volatility-aware or distribution-aware signal
+ * shaping. Common entry points include
+ * {@link org.ta4j.core.indicators.statistics.StandardDeviationIndicator} and
+ * {@link org.ta4j.core.indicators.statistics.SimpleLinearRegressionIndicator}.
+ * </p>
  */
 package org.ta4j.core.indicators.statistics;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Support/resistance and level-projection indicators.
+ *
+ * <p>
+ * Use this package for structure-aware level analysis and strategy
+ * overlays that depend on dynamic support/resistance context.
+ * </p>
+ */
+package org.ta4j.core.indicators.supportresistance;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Trend-phase and trend-bias indicators.
+ *
+ * <p>
+ * Use this package for directional regime detection and trend-strength-aware
+ * gating before entry/exit rules are applied.
+ * </p>
+ */
+package org.ta4j.core.indicators.trend;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/package-info.java
@@ -2,6 +2,14 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * Indicators for the realization of volume based analysis.
+ * Volume-based indicators for participation and pressure analysis.
+ *
+ * <p>
+ * Use this package when signal quality depends on how much volume supports
+ * price moves.
+ * Start with {@link org.ta4j.core.indicators.volume.OnBalanceVolumeIndicator}
+ * and {@link org.ta4j.core.indicators.volume.MoneyFlowIndexIndicator}, then
+ * combine with trend indicators for regime confirmation.
+ * </p>
  */
 package org.ta4j.core.indicators.volume;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * ZigZag and swing-segmentation indicators.
+ *
+ * <p>
+ * Use this package to compress price action into structural swing points
+ * for pattern and trendline workflows.
+ * </p>
+ */
+package org.ta4j.core.indicators.zigzag;

--- a/ta4j-core/src/main/java/org/ta4j/core/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/package-info.java
@@ -2,6 +2,27 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * The core module of the ta4j library.
+ * Core domain model and execution surface for ta4j.
+ *
+ * <p>
+ * This package provides the central contracts for:
+ * </p>
+ * <ul>
+ * <li>market state ({@link org.ta4j.core.BarSeries}, {@link org.ta4j.core.Bar})</li>
+ * <li>signal generation ({@link org.ta4j.core.Indicator}, {@link org.ta4j.core.Rule},
+ * {@link org.ta4j.core.Strategy})</li>
+ * <li>execution state ({@link org.ta4j.core.TradingRecord}, {@link org.ta4j.core.Trade},
+ * {@link org.ta4j.core.TradeFill})</li>
+ * <li>strategy evaluation ({@link org.ta4j.core.AnalysisCriterion})</li>
+ * </ul>
+ *
+ * <p>
+ * Entrypoint choices:
+ * </p>
+ * <ul>
+ * <li>Use {@link org.ta4j.core.backtest.BarSeriesManager} for single-strategy runs.</li>
+ * <li>Use {@link org.ta4j.core.backtest.BacktestExecutor} for large candidate sets and ranking.</li>
+ * <li>Use {@link org.ta4j.core.BaseTradingRecord} with fill operations for broker-confirmed live workflows.</li>
+ * </ul>
  */
 package org.ta4j.core;

--- a/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/reports/package-info.java
@@ -2,8 +2,21 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * This package can be used to generate
- * {@link org.ta4j.core.reports.BasePerformanceReport performance} and
- * {@link org.ta4j.core.reports.BaseTradingStatement trading} reports.
+ * Report and statement types for backtest and live-style evaluation output.
+ *
+ * <p>
+ * Use this package to turn {@link org.ta4j.core.TradingRecord} results into
+ * structured summaries for strategy comparison, regression checks, and
+ * operational dashboards.
+ * </p>
+ *
+ * <p>
+ * Start with:
+ * </p>
+ * <ul>
+ * <li>{@link org.ta4j.core.reports.TradingStatementGenerator} for per-run statements</li>
+ * <li>{@link org.ta4j.core.reports.BaseTradingStatement} for position/criteria summaries</li>
+ * <li>{@link org.ta4j.core.reports.BasePerformanceReport} for aggregate performance views</li>
+ * </ul>
  */
 package org.ta4j.core.reports;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/elliott/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/elliott/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Elliott-aware rule primitives.
+ *
+ * <p>
+ * Use this package when strategy entry/exit logic depends on Elliott
+ * scenario phase, confidence, or invalidation context.
+ * </p>
+ */
+package org.ta4j.core.rules.elliott;

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/helper/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/helper/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Helper abstractions for composing reusable rule logic.
+ *
+ * <p>
+ * Use this package to keep complex rule trees readable and to share
+ * helper behavior across multiple strategy definitions.
+ * </p>
+ */
+package org.ta4j.core.rules.helper;

--- a/ta4j-core/src/main/java/org/ta4j/core/serialization/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/serialization/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Serialization support for indicators, rules, and strategies.
+ *
+ * <p>
+ * Use this package to persist and restore composable ta4j components
+ * through descriptor-based JSON contracts.
+ * </p>
+ */
+package org.ta4j.core.serialization;

--- a/ta4j-core/src/main/java/org/ta4j/core/strategy/named/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/strategy/named/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Named and parameterized strategy descriptors.
+ *
+ * <p>
+ * Use this package when you need repeatable, serializable strategy
+ * identities for configuration-driven execution workflows.
+ * </p>
+ */
+package org.ta4j.core.strategy.named;

--- a/ta4j-core/src/main/java/org/ta4j/core/utils/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/utils/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+/**
+ * Utility helpers supporting cross-cutting core behavior.
+ *
+ * <p>
+ * This package contains shared low-level helpers that are not
+ * strategy-facing APIs but support stable core operations.
+ * </p>
+ */
+package org.ta4j.core.utils;

--- a/ta4j-examples/README.md
+++ b/ta4j-examples/README.md
@@ -70,9 +70,23 @@ If chart windows do not appear, you are likely in a headless environment; switch
 5. `ta4jexamples.backtesting.YahooFinanceBacktest` or `ta4jexamples.backtesting.CoinbaseBacktest`
 6. `ta4jexamples.bots.TradingBotOnMovingBarSeries`
 
+## Canonical onboarding lane alignment
+
+Use this with the main docs in order:
+
+1. Wiki install and building blocks: https://ta4j.github.io/ta4j-wiki/Getting-started.html
+2. Run this module's progression (section above)
+3. Validate assumptions: https://ta4j.github.io/ta4j-wiki/Backtesting.html
+4. Prepare live operations: https://ta4j.github.io/ta4j-wiki/Live-trading.html
+5. Apply readiness and incident controls:
+   https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html and
+   https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html
+
 ## Troubleshooting and companion guides
 
 - Troubleshooting: https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html
 - Backtesting realism gate: https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html
 - Live operations runbook: https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html
 - Canonical end-to-end path: https://ta4j.github.io/ta4j-wiki/Canonical-User-Journey.html
+- Expected example output signatures: https://ta4j.github.io/ta4j-wiki/Examples-Expected-Outputs.html
+- API migration compatibility map: https://ta4j.github.io/ta4j-wiki/Migration-and-Version-Compatibility.html

--- a/ta4j-examples/README.md
+++ b/ta4j-examples/README.md
@@ -3,6 +3,12 @@
 `ta4j-examples` is the runnable companion module for `ta4j-core`.
 It is organized as progressive learning tracks so production-minded Java developers can move from first run to robust execution workflows.
 
+## Prerequisites
+
+- JDK 21+
+- Maven 3.9+
+- Build from the repository root where `ta4j-core` and `ta4j-examples` are both available
+
 ## Run an example
 
 From the repository root:
@@ -12,6 +18,16 @@ mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
 ```
 
 Replace `ta4jexamples.Quickstart` with any class listed below.
+
+## Verify your run succeeded
+
+Use these quick checks before moving to the next track:
+
+- `ta4jexamples.Quickstart`: prints step-by-step run stages and trade/return metrics
+- `ta4jexamples.backtesting.TradingRecordParityBacktest`: logs execution-model comparison and parity check success
+- `ta4jexamples.backtesting.TradeFillRecordingExample`: logs streamed-vs-grouped fill handling and lot-matching outcomes
+
+If chart windows do not appear, you are likely in a headless environment; switch to chart file output or run on a GUI-enabled machine.
 
 ## Learning tracks
 
@@ -53,3 +69,10 @@ Replace `ta4jexamples.Quickstart` with any class listed below.
 4. `ta4jexamples.backtesting.SimpleMovingAverageRangeBacktest`
 5. `ta4jexamples.backtesting.YahooFinanceBacktest` or `ta4jexamples.backtesting.CoinbaseBacktest`
 6. `ta4jexamples.bots.TradingBotOnMovingBarSeries`
+
+## Troubleshooting and companion guides
+
+- Troubleshooting: https://ta4j.github.io/ta4j-wiki/Troubleshooting-Hub.html
+- Backtesting realism gate: https://ta4j.github.io/ta4j-wiki/Backtesting-Realism-Checklist.html
+- Live operations runbook: https://ta4j.github.io/ta4j-wiki/Live-Trading-Runbook.html
+- Canonical end-to-end path: https://ta4j.github.io/ta4j-wiki/Canonical-User-Journey.html

--- a/ta4j-examples/README.md
+++ b/ta4j-examples/README.md
@@ -1,0 +1,55 @@
+# ta4j-examples
+
+`ta4j-examples` is the runnable companion module for `ta4j-core`.
+It is organized as progressive learning tracks so production-minded Java developers can move from first run to robust execution workflows.
+
+## Run an example
+
+From the repository root:
+
+```bash
+mvn -pl ta4j-examples exec:java -Dexec.mainClass=ta4jexamples.Quickstart
+```
+
+Replace `ta4jexamples.Quickstart` with any class listed below.
+
+## Learning tracks
+
+### 1) First strategy and metrics
+
+- `ta4jexamples.Quickstart`
+- `ta4jexamples.analysis.StrategyAnalysis`
+
+### 2) Data sourcing and normalization
+
+- `ta4jexamples.backtesting.YahooFinanceBacktest`
+- `ta4jexamples.backtesting.CoinbaseBacktest`
+- `ta4jexamples.datasources.YahooFinanceHttpBarSeriesDataSource`
+- `ta4jexamples.datasources.CoinbaseHttpBarSeriesDataSource`
+
+### 3) Execution semantics and performance
+
+- `ta4jexamples.backtesting.TradingRecordParityBacktest`
+- `ta4jexamples.backtesting.TradeFillRecordingExample`
+- `ta4jexamples.backtesting.SimpleMovingAverageRangeBacktest`
+- `ta4jexamples.backtesting.BacktestPerformanceTuningHarness`
+
+### 4) Live-style workflows
+
+- `ta4jexamples.bots.TradingBotOnMovingBarSeries`
+- `ta4jexamples.backtesting.TradeFillRecordingExample`
+
+### 5) Charting and diagnostics
+
+- `ta4jexamples.indicators.IndicatorsToChart`
+- `ta4jexamples.indicators.CandlestickChart`
+- `ta4jexamples.analysis.CashFlowToChart`
+
+## Suggested progression
+
+1. `ta4jexamples.Quickstart`
+2. `ta4jexamples.backtesting.TradingRecordParityBacktest`
+3. `ta4jexamples.backtesting.TradeFillRecordingExample`
+4. `ta4jexamples.backtesting.SimpleMovingAverageRangeBacktest`
+5. `ta4jexamples.backtesting.YahooFinanceBacktest` or `ta4jexamples.backtesting.CoinbaseBacktest`
+6. `ta4jexamples.bots.TradingBotOnMovingBarSeries`


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix doc drift w/ ta4j-wiki
- Add automated doc link integrity check during release flow
- 

- [ ] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive package-level documentation across all core modules for improved navigation and guidance
  * Enhanced README files with production readiness checklists, learning tracks, and canonical documentation maps
  * Expanded class-level Javadoc guidance for execution models, bar series management, trading workflows, and cost analysis
  * Introduced documentation integrity validation to maintain consistency and quality

* **Chores**
  * Integrated documentation integrity checks into the release preparation workflow

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ta4j/ta4j/pull/1521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->