### PR TITLE
Fix release scheduler production handoff

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -569,7 +569,6 @@ jobs:
         with:
           github-token: ${{ steps.token_preflight.outputs.use_repo_token == 'true' && secrets.GH_TA4J_REPO_TOKEN || github.token }}
           script: |
-            const core = require("@actions/core");
             const fs = require("fs");
 
             const reportPath = process.env.REPORT_JSON;

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -953,7 +953,7 @@ jobs:
           EOF
 
       - name: Post to Release Scheduler discussion
-        if: always() && needs.analyze.outputs.dryRun != 'true'
+        if: always() && needs.analyze.result != 'skipped' && needs.analyze.outputs.dryRun != 'true'
         uses: actions/github-script@v9
         env:
           RELEASE_SCHEDULER_DISCUSSION_NUMBER: ${{ vars.RELEASE_SCHEDULER_DISCUSSION_NUMBER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 - **PR validation stays fast while the Elliott replay suite remains runnable**: GitHub build CI now keeps `integration`, `analysis-demo`, and `elliott-macro-cycle-replay` excluded by default instead of running every tagged test on each PR, and contributors can still rerun the BTC macro-cycle replay suite through its dedicated tag when they need full validation.
+- **Scheduled release automation now stays on the production path**: `release-scheduler.yml` cron runs continue to dispatch `prepare-release.yml` with `dryRun=false`, skipped scheduled runs no longer post production summaries, and the prepare workflow no longer fails removal-ready issue sync by redeclaring GitHub Script's injected bindings.
 
 ## 0.22.6 (2026-04-01)
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -75,6 +75,7 @@ Secrets and variables:
 - Via scheduler or manual `workflow_dispatch`.
 - Inputs: `releaseVersion` (optional if auto-detected), `nextVersion` (optional), `dryRun`.
 - Manual runs default `dryRun=true`. Set `dryRun=false` only for an intentional mutating run after reviewing a dry-run. Scheduled release automation dispatches prepare with explicit `dryRun=false`.
+- For scheduled production runs, confirm `release-scheduler.yml` logs `audit:dry_run_normalized=false` and `audit:dispatch_workflow workflow=prepare-release.yml ... dryRun=false`, then confirm `prepare-release.yml` logs `audit:dry_run_input_raw='false'` and `audit:dry_run_normalized=false`.
 - If `nextVersion` is omitted and `releaseVersion` is a plain `X.Y.Z`, it is auto-generated as `<major>.<minor>.<patch+1>-SNAPSHOT` (for example `0.22.2` -> `0.22.3-SNAPSHOT`).
 - For RC/non-plain release versions, provide `nextVersion` explicitly.
 - Before the workflow commits the next snapshot version, it runs the Java-based `ta4jexamples.doc.RemovalReadyDeprecationScanner` against the release version and fails if any `@Deprecated(forRemoval = true)` symbols are due or overdue for removal. This read-only scan also runs in dry-run mode.
@@ -82,6 +83,7 @@ Secrets and variables:
 - The workflow uploads release-gate and next-snapshot removal-ready deprecation report artifacts with grouped findings, symbols, lifecycle status, replacement hints when available, and synced issue links when issue sync runs.
 - The scanner JSON is the stable handoff contract for future automation: it includes `schemaVersion`, `automationNamespace`, grouped issue `planKind`, and per-symbol `trackingKey` fields so a later AI-driven planner can split work into one issue per deprecated item while remaining restart-safe by searching managed markers before mutation.
 - The workflow auto-labels the PR with `release`, assigns it to `TheCookieLab`, and requests review from `TheCookieLab`.
+- In PR mode, the successful handoff is the release branch push plus release PR creation. In direct-push mode, the successful handoff is `prepare-release.yml` dispatching `publish-release.yml` with `dryRun=false`.
 - Opening a release PR automatically triggers freeze notices on other open PRs.
 
 2. Review generated release PR
@@ -117,7 +119,7 @@ Operator flow:
 1. Run the workflow manually and leave `dryRun=true`.
 2. Inspect the computed values in the workflow summary and audit artifacts: release version, next snapshot, tag, publish target, snapshot version, and planned mutation steps.
 3. If the computed values are correct and mutation is intended, rerun the same workflow with `dryRun=false`.
-4. If no manual mutation is needed, let the official scheduled, push, merge, or workflow-run trigger continue; those paths normalize to `dryRun=false`.
+4. If no manual mutation is needed, let the official scheduled, push, merge, tag-push, or workflow-run trigger continue; those paths normalize to `dryRun=false`.
 
 Prepare dry-runs may leave `releaseVersion` and `nextVersion` blank where auto-detection is supported. Publish dry-runs require `releaseVersion`; `releaseCommit` remains optional and can be auto-detected.
 

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -12,7 +12,7 @@ expect_file_contains() {
   local needle="$2"
   local msg="$3"
   if ! grep -Fq -- "$needle" "$file"; then
-    fail "$msg (missing: '$needle' in ${file#$ROOT/})"
+    fail "$msg (missing: '$needle' in ${file#"$ROOT"/})"
   fi
 }
 
@@ -23,7 +23,7 @@ line_of() {
   line="$(grep -nFm1 -- "$needle" "$file" || true)"
   line="${line%%:*}"
   if [[ -z "$line" ]]; then
-    fail "missing expected workflow line '$needle' in ${file#$ROOT/}"
+    fail "missing expected workflow line '$needle' in ${file#"$ROOT"/}"
   fi
   printf '%s\n' "$line"
 }
@@ -58,6 +58,29 @@ expect_section_contains() {
   fi
 }
 
+assert_no_github_script_injected_binding_redeclarations() {
+  local workflow="$1"
+  awk -v file="${workflow#"$ROOT"/}" '
+    /uses: actions\/github-script@/ {
+      pending_script = 1
+      in_script = 0
+      next
+    }
+    pending_script && /^[[:space:]]*script: \|/ {
+      in_script = 1
+      next
+    }
+    in_script && /^[[:space:]]{6}- name:/ {
+      pending_script = 0
+      in_script = 0
+    }
+    in_script && /^[[:space:]]*(const|let|var)[[:space:]]+(core|github|context|glob|io|exec)[[:space:]]*=/ {
+      printf("[FAIL] %s redeclares actions/github-script injected binding at line %d: %s\n", file, NR, $0) > "/dev/stderr"
+      exit 1
+    }
+  ' "$workflow"
+}
+
 test_maven_workflow_jobs_setup_jdk25_before_maven() {
   echo "Running test_maven_workflow_jobs_setup_jdk25_before_maven"
 
@@ -67,7 +90,7 @@ test_maven_workflow_jobs_setup_jdk25_before_maven() {
       continue
     fi
 
-    awk -v file="${workflow#$ROOT/}" '
+    awk -v file="${workflow#"$ROOT"/}" '
       /^jobs:/ { in_jobs = 1; next }
       in_jobs && /^  [A-Za-z0-9_-]+:$/ {
         job = $1
@@ -167,8 +190,8 @@ test_downstream_dispatches_explicitly_pass_dry_run() {
 test_mutating_steps_remain_dry_run_gated() {
   echo "Running test_mutating_steps_remain_dry_run_gated"
 
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "if: always() && needs.analyze.outputs.dryRun != 'true'" \
-    "release scheduler discussion mutation should skip dry-run"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "if: always() && needs.analyze.result != 'skipped' && needs.analyze.outputs.dryRun != 'true'" \
+    "release scheduler discussion mutation should skip dry-run and skipped scheduled runs"
 
   expect_file_contains "$WORKFLOWS/prepare-release.yml" "if: steps.dry_run.outputs.dryRun != 'true'" \
     "prepare-release mutations should be dry-run gated"
@@ -299,6 +322,47 @@ test_github_release_preserves_workflow_support_checkout() {
   pass "test_github_release_preserves_workflow_support_checkout"
 }
 
+test_github_script_blocks_do_not_redeclare_injected_bindings() {
+  echo "Running test_github_script_blocks_do_not_redeclare_injected_bindings"
+
+  local workflow
+  for workflow in "$WORKFLOWS"/*.yml; do
+    assert_no_github_script_injected_binding_redeclarations "$workflow"
+  done
+
+  pass "test_github_script_blocks_do_not_redeclare_injected_bindings"
+}
+
+test_github_script_binding_scan_rejects_bad_fixture() {
+  echo "Running test_github_script_binding_scan_rejects_bad_fixture"
+
+  local tmp
+  local output
+  tmp="$(mktemp "${TMPDIR:-/tmp}/release-workflow-safety.XXXXXX")"
+  cat > "$tmp" <<'YAML'
+name: Bad fixture
+jobs:
+  bad:
+    steps:
+      - name: Bad GitHub Script
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const core = require("@actions/core");
+YAML
+
+  if output="$(assert_no_github_script_injected_binding_redeclarations "$tmp" 2>&1)"; then
+    rm -f "$tmp"
+    fail "github-script injected binding scan should fail on a core redeclaration"
+  fi
+
+  rm -f "$tmp"
+  expect_section_contains "$output" "redeclares actions/github-script injected binding" \
+    "github-script injected binding scan should report the redeclaration"
+
+  pass "test_github_script_binding_scan_rejects_bad_fixture"
+}
+
 test_maven_workflow_jobs_setup_jdk25_before_maven
 test_mutating_manual_workflows_default_to_dry_run
 test_official_triggers_normalize_to_non_dry_run
@@ -309,3 +373,5 @@ test_snapshot_and_health_manual_dry_runs_do_not_mutate
 test_line_of_reports_missing_needles_cleanly
 test_publish_release_existing_tag_only_fails_real_runs
 test_github_release_preserves_workflow_support_checkout
+test_github_script_blocks_do_not_redeclare_injected_bindings
+test_github_script_binding_scan_rejects_bad_fixture


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- keep scheduled release-scheduler runs on the production handoff path while suppressing production discussion posts when scheduled analysis is skipped
- fix prepare-release removal-ready issue sync by using the GitHub Script injected `core` binding instead of redeclaring it
- add release workflow safety coverage for GitHub Script injected-binding redeclarations, including a failing fixture

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release automation to properly handle skipped scheduled runs without posting production summaries.
  * Resolved release workflow initialization issue preventing proper execution.

* **Documentation**
  * Updated release process runbook with explicit confirmation steps and clarified post-handoff behavior.
  * Added changelog entry documenting fixes to scheduled release automation.

* **Tests**
  * Added safety checks to validate release workflow configuration integrity across all automated processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ta4j/ta4j/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->