### PR TITLE
[codex] Add triggered rule composition primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Updated project Java JDK from 21 to 25
 
 ### Added
+- **Staged rule composition for thesis-based exits**: Added `TriggeredRule` so strategies can keep invalidation and timeout rules active while trigger/delegate stages arm follow-on exits such as trailing stops. Stages support finite or unbounded activation windows, delegate priming, explicit reset rules, and position-change resets for reusable target, timeout, and risk-management workflows.
 - **Anchor-aware Elliott tuning harness**: You can now run `ElliottWaveAnchorCalibrationHarness` with the versioned `BTC-anchor-registry-v1.json` registry to replay major BTC tops and bottoms, compare the locked baseline against coarse challenger profiles on top-1/top-3 anchor hits plus `ECE`/`Brier`/`LogLoss`, and get a deterministic promote-or-retain bundle that also sanity-checks the selected profile on ETH/USD and S&P 500 data.
 - **Release automation audit artifacts**: Release workflows now emit structured release dossiers, model catalog preflight data, normalized AI decisions, exact artifact manifests, tag-resolution snapshots, full-build logs, and workflow summaries so release failures can be diagnosed from the exact step that produced them.
 - **Report-producing analysis demos can run on demand or on schedule**: The new standalone `analysis-demo` JUnit tag starts with a live Elliott Wave BTC/USD macro report backed by Coinbase daily candles, plus a dedicated GitHub Actions workflow that can be manually run for provider-qualified instruments like `coinbase:BTC-USD` and uploads the resulting JSON, chart, and cached data artifacts.
@@ -25,6 +26,7 @@
 - **Documentation surface area is now consolidated around canonical owners**: Overlapping execution-choice guidance was reduced to a single decision-matrix source, wiki navigation duplicates were removed, maintainer architecture index duplication was cleaned up, and onboarding/live/backtesting docs now route through clearer ownership boundaries while preserving deprecation-safe link compatibility.
 
 ### Fixed
+- **Stop and timeout rules are safer to compose**: Stop-loss, stop-gain, trailing stop, open-position timeout, and wait-for rules now validate invalid configuration up front, preserve touch-or-beyond boundary behavior, avoid pre-entry trailing-stop signals, and remove repeated trailing-stop helper allocation from hot exit paths.
 - **PR validation stays fast while the Elliott replay suite remains runnable**: GitHub build CI now keeps `integration`, `analysis-demo`, and `elliott-macro-cycle-replay` excluded by default instead of running every tagged test on each PR, and contributors can still rerun the BTC macro-cycle replay suite through its dedicated tag when they need full validation.
 - **Scheduled release automation now stays on the production path**: `release-scheduler.yml` cron runs continue to dispatch `prepare-release.yml` with `dryRun=false`, skipped scheduled runs no longer post production summaries, and the prepare workflow no longer fails removal-ready issue sync by redeclaring GitHub Script's injected bindings.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,34 @@ System.out.println("Number of trades: " + record.getTradeCount());
 System.out.println("Number of positions: " + record.getPositionCount());
 ```
 
+### Staged exit rules
+
+When an exit needs a thesis invalidation, a profit target, and a timeout, compose
+the always-active exits with `TriggeredRule` stages. This keeps the immediate
+stop and timeout live while a profit target can arm a second rule, such as a
+trailing stop, instead of exiting immediately.
+
+```java
+Rule invalidation = new StopLossRule(close, 10.0);              // touch at -10%
+Rule timeout = new OpenedPositionMinimumBarCountRule(5);        // 5 bars after entry
+Rule targetReached = new StopGainRule(close, 10.0);             // touch at +10%
+Rule trailingExit = new TrailingStopLossRule(close, series.numFactory().numOf(5));
+
+Rule exit = new TriggeredRule(
+        invalidation.or(timeout),
+        new TriggeredRule.Stage(
+                targetReached,
+                trailingExit,
+                TriggeredRule.UNBOUNDED_WINDOW,
+                false,
+                TriggeredRule.ResetPolicy.ON_POSITION_CHANGE));
+```
+
+Use `StopGainRule`, `StopLossRule`, `OverOrEqualIndicatorRule`, and
+`UnderOrEqualIndicatorRule` when a touch or beyond the boundary is enough. Use
+`CrossedUpIndicatorRule` or `CrossedDownIndicatorRule` when the signal must be a
+fresh cross from the previous bar.
+
 ## Sourcing market data
 
 **New to trading and not sure where to get historical price data?** You're not alone! Ta4j makes it easy to get started with real market data using the unified `BarSeriesDataSource` interface. All data sources work with the same domain-driven API using business concepts like ticker symbols, intervals, and date ranges.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ stop and timeout live while a profit target can arm a second rule, such as a
 trailing stop, instead of exiting immediately.
 
 ```java
-Rule invalidation = new StopLossRule(close, 10.0);              // touch at -10%
+Rule invalidation = new StopLossRule(close, 10.0);              // touches 10% loss threshold
 Rule timeout = new OpenedPositionMinimumBarCountRule(5);        // 5 bars after entry
 Rule targetReached = new StopGainRule(close, 10.0);             // touch at +10%
 Rule trailingExit = new TrailingStopLossRule(close, series.numFactory().numOf(5));

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ stop and timeout live while a profit target can arm a second rule, such as a
 trailing stop, instead of exiting immediately.
 
 ```java
+BarSeries series = ...;
+ClosePriceIndicator close = new ClosePriceIndicator(series);
+
 Rule invalidation = new StopLossRule(close, 10.0);              // touches 10% loss threshold
 Rule timeout = new OpenedPositionMinimumBarCountRule(5);        // 5 bars after entry
 Rule targetReached = new StopGainRule(close, 10.0);             // touch at +10%

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRule.java
@@ -3,6 +3,7 @@
  */
 package org.ta4j.core.rules;
 
+import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
 
 /**
@@ -13,7 +14,6 @@ import org.ta4j.core.TradingRecord;
  * Using this rule only makes sense for exit rules. For entry rules,
  * {@link OpenedPositionMinimumBarCountRule#isSatisfied(int, TradingRecord)}
  * always returns {@code false}.
- *
  *
  * <p>
  * This rule uses the {@code tradingRecord}.
@@ -46,12 +46,17 @@ public class OpenedPositionMinimumBarCountRule extends AbstractRule {
      */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        if (tradingRecord.getCurrentPosition().isOpened()) {
-            final int entryIndex = tradingRecord.getLastEntry().getIndex();
-            final int currentBarCount = index - entryIndex;
-            return currentBarCount >= barCount;
+        boolean satisfied = false;
+        if (tradingRecord != null) {
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null) {
+                int entryIndex = currentPosition.getEntry().getIndex();
+                int currentBarCount = index - entryIndex;
+                satisfied = currentBarCount >= barCount;
+            }
         }
-        return false;
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
     }
 
     /** @return the {@link #barCount} */

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -3,6 +3,8 @@
  */
 package org.ta4j.core.rules;
 
+import java.util.Objects;
+
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
@@ -13,7 +15,9 @@ import org.ta4j.core.num.Num;
  * A stop-gain rule.
  *
  * <p>
- * Satisfied when the close price reaches the gain threshold.
+ * Satisfied when the configured price indicator touches or moves beyond the
+ * gain threshold. Long positions trigger at or above the target price; short
+ * positions trigger at or below it.
  *
  * <p>
  * This rule uses the {@code tradingRecord}.
@@ -33,7 +37,7 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @param gainPercentage the gain percentage
      */
     public StopGainRule(Indicator<Num> priceIndicator, Number gainPercentage) {
-        this(priceIndicator, priceIndicator.getBarSeries().numFactory().numOf(gainPercentage));
+        this(priceIndicator, numOf(priceIndicator, gainPercentage, "gainPercentage"));
     }
 
     /**
@@ -43,7 +47,10 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @param gainPercentage the gain percentage
      */
     public StopGainRule(Indicator<Num> priceIndicator, Num gainPercentage) {
-        this.priceIndicator = priceIndicator;
+        this.priceIndicator = Objects.requireNonNull(priceIndicator, "priceIndicator");
+        if (Num.isNaNOrNull(gainPercentage) || gainPercentage.isNegative()) {
+            throw new IllegalArgumentException("gainPercentage must be >= 0");
+        }
         this.gainPercentage = gainPercentage;
     }
 
@@ -57,14 +64,14 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @since 0.22.3
      */
     public static Num stopGainPrice(Num entryPrice, Num gainPercentage, boolean isBuy) {
-        if (entryPrice == null) {
+        if (Num.isNaNOrNull(entryPrice)) {
             throw new IllegalArgumentException("entryPrice must not be null");
         }
-        if (gainPercentage == null) {
-            throw new IllegalArgumentException("gainPercentage must not be null");
+        if (Num.isNaNOrNull(gainPercentage) || gainPercentage.isNegative()) {
+            throw new IllegalArgumentException("gainPercentage must be >= 0");
         }
-        var hundred = entryPrice.getNumFactory().hundred();
-        var gainRatioThreshold = isBuy ? hundred.plus(gainPercentage).dividedBy(hundred)
+        Num hundred = entryPrice.getNumFactory().hundred();
+        Num gainRatioThreshold = isBuy ? hundred.plus(gainPercentage).dividedBy(hundred)
                 : hundred.minus(gainPercentage).dividedBy(hundred);
         return entryPrice.multipliedBy(gainRatioThreshold);
     }
@@ -80,11 +87,11 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @since 0.22.3
      */
     public static Num stopGainPriceFromDistance(Num entryPrice, Num gainDistance, boolean isBuy) {
-        if (entryPrice == null) {
+        if (Num.isNaNOrNull(entryPrice)) {
             throw new IllegalArgumentException("entryPrice must not be null");
         }
-        if (gainDistance == null) {
-            throw new IllegalArgumentException("gainDistance must not be null");
+        if (Num.isNaNOrNull(gainDistance) || gainDistance.isNegative()) {
+            throw new IllegalArgumentException("gainDistance must be >= 0");
         }
         return isBuy ? entryPrice.plus(gainDistance) : entryPrice.minus(gainDistance);
     }
@@ -101,14 +108,14 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @since 0.22.3
      */
     public static Num trailingStopGainPrice(Num favorablePrice, Num retracementPercentage, boolean isBuy) {
-        if (favorablePrice == null) {
+        if (Num.isNaNOrNull(favorablePrice)) {
             throw new IllegalArgumentException("favorablePrice must not be null");
         }
-        if (retracementPercentage == null) {
-            throw new IllegalArgumentException("retracementPercentage must not be null");
+        if (Num.isNaNOrNull(retracementPercentage) || retracementPercentage.isNegative()) {
+            throw new IllegalArgumentException("retracementPercentage must be >= 0");
         }
-        var hundred = favorablePrice.getNumFactory().hundred();
-        var retracementRatioThreshold = isBuy ? hundred.minus(retracementPercentage).dividedBy(hundred)
+        Num hundred = favorablePrice.getNumFactory().hundred();
+        Num retracementRatioThreshold = isBuy ? hundred.minus(retracementPercentage).dividedBy(hundred)
                 : hundred.plus(retracementPercentage).dividedBy(hundred);
         return favorablePrice.multipliedBy(retracementRatioThreshold);
     }
@@ -124,11 +131,11 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      * @since 0.22.3
      */
     public static Num trailingStopGainPriceFromDistance(Num favorablePrice, Num retracementDistance, boolean isBuy) {
-        if (favorablePrice == null) {
+        if (Num.isNaNOrNull(favorablePrice)) {
             throw new IllegalArgumentException("favorablePrice must not be null");
         }
-        if (retracementDistance == null) {
-            throw new IllegalArgumentException("retracementDistance must not be null");
+        if (Num.isNaNOrNull(retracementDistance) || retracementDistance.isNegative()) {
+            throw new IllegalArgumentException("retracementDistance must be >= 0");
         }
         return isBuy ? favorablePrice.minus(retracementDistance) : favorablePrice.plus(retracementDistance);
     }
@@ -156,18 +163,19 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
     /** This rule uses the {@code tradingRecord}. */
     @Override
     public boolean isSatisfied(int index, TradingRecord tradingRecord) {
-        var satisfied = false;
+        boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
             Position currentPosition = tradingRecord.getCurrentPosition();
-            if (currentPosition.isOpened()) {
+            if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null) {
 
-                var entryPrice = currentPosition.getEntry().getNetPrice();
-                var currentPrice = priceIndicator.getValue(index);
+                Num entryPrice = currentPosition.getEntry().getNetPrice();
+                Num currentPrice = priceIndicator.getValue(index);
 
-                if (currentPosition.getEntry().isBuy()) {
+                if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)
+                        && currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);
-                } else {
+                } else if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)) {
                     satisfied = isSellGainSatisfied(entryPrice, currentPrice);
                 }
             }
@@ -177,12 +185,18 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
     }
 
     private boolean isBuyGainSatisfied(Num entryPrice, Num currentPrice) {
-        var threshold = stopGainPrice(entryPrice, gainPercentage, true);
+        Num threshold = stopGainPrice(entryPrice, gainPercentage, true);
         return currentPrice.isGreaterThanOrEqual(threshold);
     }
 
     private boolean isSellGainSatisfied(Num entryPrice, Num currentPrice) {
-        var threshold = stopGainPrice(entryPrice, gainPercentage, false);
+        Num threshold = stopGainPrice(entryPrice, gainPercentage, false);
         return currentPrice.isLessThanOrEqual(threshold);
+    }
+
+    private static Num numOf(Indicator<Num> priceIndicator, Number value, String parameterName) {
+        Objects.requireNonNull(priceIndicator, "priceIndicator");
+        Objects.requireNonNull(value, parameterName);
+        return priceIndicator.getBarSeries().numFactory().numOf(value);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -65,7 +65,7 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      */
     public static Num stopGainPrice(Num entryPrice, Num gainPercentage, boolean isBuy) {
         if (Num.isNaNOrNull(entryPrice)) {
-            throw new IllegalArgumentException("entryPrice must not be null");
+            throw new IllegalArgumentException("entryPrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(gainPercentage) || gainPercentage.isNegative()) {
             throw new IllegalArgumentException("gainPercentage must be >= 0");
@@ -88,7 +88,7 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      */
     public static Num stopGainPriceFromDistance(Num entryPrice, Num gainDistance, boolean isBuy) {
         if (Num.isNaNOrNull(entryPrice)) {
-            throw new IllegalArgumentException("entryPrice must not be null");
+            throw new IllegalArgumentException("entryPrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(gainDistance) || gainDistance.isNegative()) {
             throw new IllegalArgumentException("gainDistance must be >= 0");
@@ -109,7 +109,7 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      */
     public static Num trailingStopGainPrice(Num favorablePrice, Num retracementPercentage, boolean isBuy) {
         if (Num.isNaNOrNull(favorablePrice)) {
-            throw new IllegalArgumentException("favorablePrice must not be null");
+            throw new IllegalArgumentException("favorablePrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(retracementPercentage) || retracementPercentage.isNegative()) {
             throw new IllegalArgumentException("retracementPercentage must be >= 0");
@@ -132,7 +132,7 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
      */
     public static Num trailingStopGainPriceFromDistance(Num favorablePrice, Num retracementDistance, boolean isBuy) {
         if (Num.isNaNOrNull(favorablePrice)) {
-            throw new IllegalArgumentException("favorablePrice must not be null");
+            throw new IllegalArgumentException("favorablePrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(retracementDistance) || retracementDistance.isNegative()) {
             throw new IllegalArgumentException("retracementDistance must be >= 0");

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopGainRule.java
@@ -171,11 +171,14 @@ public class StopGainRule extends AbstractRule implements StopGainPriceModel {
 
                 Num entryPrice = currentPosition.getEntry().getNetPrice();
                 Num currentPrice = priceIndicator.getValue(index);
+                if (Num.isNaNOrNull(entryPrice) || Num.isNaNOrNull(currentPrice)) {
+                    traceIsSatisfied(index, false);
+                    return false;
+                }
 
-                if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)
-                        && currentPosition.getEntry().isBuy()) {
+                if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyGainSatisfied(entryPrice, currentPrice);
-                } else if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)) {
+                } else {
                     satisfied = isSellGainSatisfied(entryPrice, currentPrice);
                 }
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -3,6 +3,8 @@
  */
 package org.ta4j.core.rules;
 
+import java.util.Objects;
+
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
@@ -13,7 +15,9 @@ import org.ta4j.core.num.Num;
  * A stop-loss rule.
  *
  * <p>
- * Satisfied when the close price reaches the loss threshold.
+ * Satisfied when the configured price indicator touches or moves beyond the
+ * loss threshold. Long positions trigger at or below the stop price; short
+ * positions trigger at or above it.
  *
  * <p>
  * This rule uses the {@code tradingRecord}.
@@ -33,7 +37,7 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @param lossPercentage the loss percentage
      */
     public StopLossRule(Indicator<Num> priceIndicator, Number lossPercentage) {
-        this(priceIndicator, priceIndicator.getBarSeries().numFactory().numOf(lossPercentage));
+        this(priceIndicator, numOf(priceIndicator, lossPercentage, "lossPercentage"));
     }
 
     /**
@@ -43,7 +47,10 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @param lossPercentage the loss percentage
      */
     public StopLossRule(Indicator<Num> priceIndicator, Num lossPercentage) {
-        this.priceIndicator = priceIndicator;
+        this.priceIndicator = Objects.requireNonNull(priceIndicator, "priceIndicator");
+        if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isNegative()) {
+            throw new IllegalArgumentException("lossPercentage must be >= 0");
+        }
         this.lossPercentage = lossPercentage;
     }
 
@@ -57,14 +64,14 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @since 0.22.3
      */
     public static Num stopLossPrice(Num entryPrice, Num lossPercentage, boolean isBuy) {
-        if (entryPrice == null) {
+        if (Num.isNaNOrNull(entryPrice)) {
             throw new IllegalArgumentException("entryPrice must not be null");
         }
-        if (lossPercentage == null) {
-            throw new IllegalArgumentException("lossPercentage must not be null");
+        if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isNegative()) {
+            throw new IllegalArgumentException("lossPercentage must be >= 0");
         }
-        var hundred = entryPrice.getNumFactory().hundred();
-        var lossRatioThreshold = isBuy ? hundred.minus(lossPercentage).dividedBy(hundred)
+        Num hundred = entryPrice.getNumFactory().hundred();
+        Num lossRatioThreshold = isBuy ? hundred.minus(lossPercentage).dividedBy(hundred)
                 : hundred.plus(lossPercentage).dividedBy(hundred);
         return entryPrice.multipliedBy(lossRatioThreshold);
     }
@@ -80,11 +87,11 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @since 0.22.3
      */
     public static Num stopLossPriceFromDistance(Num entryPrice, Num lossDistance, boolean isBuy) {
-        if (entryPrice == null) {
+        if (Num.isNaNOrNull(entryPrice)) {
             throw new IllegalArgumentException("entryPrice must not be null");
         }
-        if (lossDistance == null) {
-            throw new IllegalArgumentException("lossDistance must not be null");
+        if (Num.isNaNOrNull(lossDistance) || lossDistance.isNegative()) {
+            throw new IllegalArgumentException("lossDistance must be >= 0");
         }
         return isBuy ? entryPrice.minus(lossDistance) : entryPrice.plus(lossDistance);
     }
@@ -116,15 +123,16 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
         boolean satisfied = false;
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
-            var currentPosition = tradingRecord.getCurrentPosition();
-            if (currentPosition.isOpened()) {
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null) {
 
-                var entryPrice = currentPosition.getEntry().getNetPrice();
-                var currentPrice = priceIndicator.getValue(index);
+                Num entryPrice = currentPosition.getEntry().getNetPrice();
+                Num currentPrice = priceIndicator.getValue(index);
 
-                if (currentPosition.getEntry().isBuy()) {
+                if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)
+                        && currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
-                } else {
+                } else if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)) {
                     satisfied = isSellStopSatisfied(entryPrice, currentPrice);
                 }
             }
@@ -141,7 +149,7 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @return {@code true} when current price reaches long stop-loss threshold
      */
     private boolean isBuyStopSatisfied(Num entryPrice, Num currentPrice) {
-        var threshold = stopLossPrice(entryPrice, lossPercentage, true);
+        Num threshold = stopLossPrice(entryPrice, lossPercentage, true);
         return currentPrice.isLessThanOrEqual(threshold);
     }
 
@@ -153,7 +161,13 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      * @return {@code true} when current price reaches short stop-loss threshold
      */
     private boolean isSellStopSatisfied(Num entryPrice, Num currentPrice) {
-        var threshold = stopLossPrice(entryPrice, lossPercentage, false);
+        Num threshold = stopLossPrice(entryPrice, lossPercentage, false);
         return currentPrice.isGreaterThanOrEqual(threshold);
+    }
+
+    private static Num numOf(Indicator<Num> priceIndicator, Number value, String parameterName) {
+        Objects.requireNonNull(priceIndicator, "priceIndicator");
+        Objects.requireNonNull(value, parameterName);
+        return priceIndicator.getBarSeries().numFactory().numOf(value);
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -128,11 +128,14 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
 
                 Num entryPrice = currentPosition.getEntry().getNetPrice();
                 Num currentPrice = priceIndicator.getValue(index);
+                if (Num.isNaNOrNull(entryPrice) || Num.isNaNOrNull(currentPrice)) {
+                    traceIsSatisfied(index, false);
+                    return false;
+                }
 
-                if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)
-                        && currentPosition.getEntry().isBuy()) {
+                if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuyStopSatisfied(entryPrice, currentPrice);
-                } else if (!Num.isNaNOrNull(entryPrice) && !Num.isNaNOrNull(currentPrice)) {
+                } else {
                     satisfied = isSellStopSatisfied(entryPrice, currentPrice);
                 }
             }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/StopLossRule.java
@@ -65,7 +65,7 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      */
     public static Num stopLossPrice(Num entryPrice, Num lossPercentage, boolean isBuy) {
         if (Num.isNaNOrNull(entryPrice)) {
-            throw new IllegalArgumentException("entryPrice must not be null");
+            throw new IllegalArgumentException("entryPrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isNegative()) {
             throw new IllegalArgumentException("lossPercentage must be >= 0");
@@ -88,7 +88,7 @@ public class StopLossRule extends AbstractRule implements StopLossPriceModel {
      */
     public static Num stopLossPriceFromDistance(Num entryPrice, Num lossDistance, boolean isBuy) {
         if (Num.isNaNOrNull(entryPrice)) {
-            throw new IllegalArgumentException("entryPrice must not be null");
+            throw new IllegalArgumentException("entryPrice must not be null or NaN");
         }
         if (Num.isNaNOrNull(lossDistance) || lossDistance.isNegative()) {
             throw new IllegalArgumentException("lossDistance must be >= 0");

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
@@ -7,8 +7,6 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.helpers.HighestValueIndicator;
-import org.ta4j.core.indicators.helpers.LowestValueIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -72,10 +70,15 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
         boolean satisfied = false;
         if (tradingRecord != null) {
             Position currentPosition = tradingRecord.getCurrentPosition();
-            if (currentPosition.isOpened()) {
+            if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null) {
                 Num entryPrice = currentPosition.getEntry().getNetPrice();
                 Num currentPrice = priceIndicator.getValue(index);
                 int positionIndex = currentPosition.getEntry().getIndex();
+
+                if (index < positionIndex || Num.isNaNOrNull(entryPrice) || Num.isNaNOrNull(currentPrice)) {
+                    traceIsSatisfied(index, false);
+                    return false;
+                }
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuySatisfied(entryPrice, currentPrice, index, positionIndex);
@@ -89,9 +92,7 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
     }
 
     private boolean isBuySatisfied(Num entryPrice, Num currentPrice, int index, int positionIndex) {
-        HighestValueIndicator highest = new HighestValueIndicator(priceIndicator,
-                getValueIndicatorBarCount(index, positionIndex));
-        Num highestCloseNum = highest.getValue(index);
+        Num highestCloseNum = highestValue(windowStartIndex(index, positionIndex), index);
         Num gainActivationThreshold = StopGainRule.stopGainPrice(entryPrice, gainPercentage, true);
         if (highestCloseNum.isLessThan(gainActivationThreshold)) {
             return false;
@@ -101,9 +102,7 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
     }
 
     private boolean isSellSatisfied(Num entryPrice, Num currentPrice, int index, int positionIndex) {
-        LowestValueIndicator lowest = new LowestValueIndicator(priceIndicator,
-                getValueIndicatorBarCount(index, positionIndex));
-        Num lowestCloseNum = lowest.getValue(index);
+        Num lowestCloseNum = lowestValue(windowStartIndex(index, positionIndex), index);
         Num gainActivationThreshold = StopGainRule.stopGainPrice(entryPrice, gainPercentage, false);
         if (lowestCloseNum.isGreaterThan(gainActivationThreshold)) {
             return false;
@@ -127,19 +126,45 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
         }
         int entryIndex = position.getEntry().getIndex();
         // stopPrice models the initial trailing stop at entry time.
-        int lookback = 1;
         if (position.getEntry().isBuy()) {
-            HighestValueIndicator highest = new HighestValueIndicator(priceIndicator, lookback);
-            Num highestCloseNum = highest.getValue(entryIndex);
+            Num highestCloseNum = priceIndicator.getValue(entryIndex);
+            if (Num.isNaNOrNull(highestCloseNum)) {
+                return null;
+            }
             return StopGainRule.trailingStopGainPrice(highestCloseNum, gainPercentage, true);
         }
-        LowestValueIndicator lowest = new LowestValueIndicator(priceIndicator, lookback);
-        Num lowestCloseNum = lowest.getValue(entryIndex);
+        Num lowestCloseNum = priceIndicator.getValue(entryIndex);
+        if (Num.isNaNOrNull(lowestCloseNum)) {
+            return null;
+        }
         return StopGainRule.trailingStopGainPrice(lowestCloseNum, gainPercentage, false);
     }
 
-    private int getValueIndicatorBarCount(int index, int positionIndex) {
-        return Math.min(index - positionIndex + 1, this.barCount);
+    private int windowStartIndex(int index, int positionIndex) {
+        int activeBarCount = Math.min(index - positionIndex + 1, barCount);
+        return index - activeBarCount + 1;
+    }
+
+    private Num highestValue(int startIndex, int endIndex) {
+        Num highest = priceIndicator.getValue(startIndex);
+        for (int index = startIndex + 1; index <= endIndex; index++) {
+            Num candidate = priceIndicator.getValue(index);
+            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(highest) || candidate.isGreaterThan(highest))) {
+                highest = candidate;
+            }
+        }
+        return highest;
+    }
+
+    private Num lowestValue(int startIndex, int endIndex) {
+        Num lowest = priceIndicator.getValue(startIndex);
+        for (int index = startIndex + 1; index <= endIndex; index++) {
+            Num candidate = priceIndicator.getValue(index);
+            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(lowest) || candidate.isLessThan(lowest))) {
+                lowest = candidate;
+            }
+        }
+        return lowest;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
@@ -92,6 +92,9 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
 
     private boolean isBuySatisfied(Num entryPrice, Num currentPrice, int index, int positionIndex) {
         Num highestCloseNum = highestValue(windowStartIndex(index, positionIndex), index);
+        if (Num.isNaNOrNull(highestCloseNum)) {
+            return false;
+        }
         Num gainActivationThreshold = StopGainRule.stopGainPrice(entryPrice, gainPercentage, true);
         if (highestCloseNum.isLessThan(gainActivationThreshold)) {
             return false;
@@ -102,6 +105,9 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
 
     private boolean isSellSatisfied(Num entryPrice, Num currentPrice, int index, int positionIndex) {
         Num lowestCloseNum = lowestValue(windowStartIndex(index, positionIndex), index);
+        if (Num.isNaNOrNull(lowestCloseNum)) {
+            return false;
+        }
         Num gainActivationThreshold = StopGainRule.stopGainPrice(entryPrice, gainPercentage, false);
         if (lowestCloseNum.isGreaterThan(gainActivationThreshold)) {
             return false;
@@ -123,8 +129,9 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
+        // If the entry bar was evicted by max-bar-count retention, use the first
+        // retained bar as the anchor.
         int entryIndex = retainedStartIndex(position.getEntry().getIndex());
-        // stopPrice models the initial trailing stop at entry time.
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);
             if (Num.isNaNOrNull(highestCloseNum)) {
@@ -149,10 +156,10 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
     }
 
     private Num highestValue(int startIndex, int endIndex) {
-        Num highest = priceIndicator.getValue(startIndex);
-        for (int index = startIndex + 1; index <= endIndex; index++) {
+        Num highest = null;
+        for (int index = startIndex; index <= endIndex; index++) {
             Num candidate = priceIndicator.getValue(index);
-            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(highest) || candidate.isGreaterThan(highest))) {
+            if (!Num.isNaNOrNull(candidate) && (highest == null || candidate.isGreaterThan(highest))) {
                 highest = candidate;
             }
         }
@@ -160,10 +167,10 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
     }
 
     private Num lowestValue(int startIndex, int endIndex) {
-        Num lowest = priceIndicator.getValue(startIndex);
-        for (int index = startIndex + 1; index <= endIndex; index++) {
+        Num lowest = null;
+        for (int index = startIndex; index <= endIndex; index++) {
             Num candidate = priceIndicator.getValue(index);
-            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(lowest) || candidate.isLessThan(lowest))) {
+            if (!Num.isNaNOrNull(candidate) && (lowest == null || candidate.isLessThan(lowest))) {
                 lowest = candidate;
             }
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
@@ -3,6 +3,8 @@
  */
 package org.ta4j.core.rules;
 
+import java.util.Objects;
+
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
@@ -40,16 +42,13 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
      * @param barCount       the number of bars to look back for the calculation
      */
     public TrailingStopGainRule(Indicator<Num> indicator, Num gainPercentage, int barCount) {
-        if (indicator == null) {
-            throw new IllegalArgumentException("indicator must not be null");
-        }
-        if (Num.isNaNOrNull(gainPercentage) || gainPercentage.isZero() || gainPercentage.isNegative()) {
-            throw new IllegalArgumentException("gainPercentage must be positive");
+        this.priceIndicator = Objects.requireNonNull(indicator, "priceIndicator");
+        if (Num.isNaNOrNull(gainPercentage) || gainPercentage.isNegative()) {
+            throw new IllegalArgumentException("gainPercentage must be >= 0");
         }
         if (barCount <= 0) {
             throw new IllegalArgumentException("barCount must be positive");
         }
-        this.priceIndicator = indicator;
         this.barCount = barCount;
         this.gainPercentage = gainPercentage;
     }
@@ -124,7 +123,7 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
-        int entryIndex = position.getEntry().getIndex();
+        int entryIndex = retainedStartIndex(position.getEntry().getIndex());
         // stopPrice models the initial trailing stop at entry time.
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);
@@ -142,7 +141,11 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
 
     private int windowStartIndex(int index, int positionIndex) {
         int activeBarCount = Math.min(index - positionIndex + 1, barCount);
-        return index - activeBarCount + 1;
+        return retainedStartIndex(index - activeBarCount + 1);
+    }
+
+    private int retainedStartIndex(int requestedStartIndex) {
+        return Math.max(requestedStartIndex, priceIndicator.getBarSeries().getBeginIndex());
     }
 
     private Num highestValue(int startIndex, int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopGainRule.java
@@ -129,8 +129,8 @@ public class TrailingStopGainRule extends AbstractRule implements StopGainPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
-        // If the entry bar was evicted by max-bar-count retention, use the first
-        // retained bar as the anchor.
+        // If the entry bar was evicted by max-bar-count retention, fall back to
+        // the first retained bar as the anchor (an approximation of entry-time stop).
         int entryIndex = retainedStartIndex(position.getEntry().getIndex());
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -7,8 +7,6 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
-import org.ta4j.core.indicators.helpers.HighestValueIndicator;
-import org.ta4j.core.indicators.helpers.LowestValueIndicator;
 import org.ta4j.core.num.Num;
 
 /**
@@ -39,6 +37,15 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
      * @param barCount       the number of bars to look back for the calculation
      */
     public TrailingStopLossRule(Indicator<Num> indicator, Num lossPercentage, int barCount) {
+        if (indicator == null) {
+            throw new IllegalArgumentException("indicator must not be null");
+        }
+        if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isZero() || lossPercentage.isNegative()) {
+            throw new IllegalArgumentException("lossPercentage must be positive");
+        }
+        if (barCount <= 0) {
+            throw new IllegalArgumentException("barCount must be positive");
+        }
         this.priceIndicator = indicator;
         this.barCount = barCount;
         this.lossPercentage = lossPercentage;
@@ -61,9 +68,14 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
         // No trading history or no position opened, no loss
         if (tradingRecord != null) {
             Position currentPosition = tradingRecord.getCurrentPosition();
-            if (currentPosition.isOpened()) {
+            if (currentPosition != null && currentPosition.isOpened() && currentPosition.getEntry() != null) {
                 Num currentPrice = priceIndicator.getValue(index);
                 int positionIndex = currentPosition.getEntry().getIndex();
+
+                if (index < positionIndex || Num.isNaNOrNull(currentPrice)) {
+                    traceIsSatisfied(index, false);
+                    return false;
+                }
 
                 if (currentPosition.getEntry().isBuy()) {
                     satisfied = isBuySatisfied(currentPrice, index, positionIndex);
@@ -77,17 +89,13 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
     }
 
     private boolean isBuySatisfied(Num currentPrice, int index, int positionIndex) {
-        HighestValueIndicator highest = new HighestValueIndicator(priceIndicator,
-                getValueIndicatorBarCount(index, positionIndex));
-        Num highestCloseNum = highest.getValue(index);
+        Num highestCloseNum = highestValue(windowStartIndex(index, positionIndex), index);
         Num currentStopLossLimitActivation = StopLossRule.stopLossPrice(highestCloseNum, lossPercentage, true);
         return currentPrice.isLessThanOrEqual(currentStopLossLimitActivation);
     }
 
     private boolean isSellSatisfied(Num currentPrice, int index, int positionIndex) {
-        LowestValueIndicator lowest = new LowestValueIndicator(priceIndicator,
-                getValueIndicatorBarCount(index, positionIndex));
-        Num lowestCloseNum = lowest.getValue(index);
+        Num lowestCloseNum = lowestValue(windowStartIndex(index, positionIndex), index);
         Num currentStopLossLimitActivation = StopLossRule.stopLossPrice(lowestCloseNum, lossPercentage, false);
         return currentPrice.isGreaterThanOrEqual(currentStopLossLimitActivation);
     }
@@ -106,19 +114,45 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
             return null;
         }
         int entryIndex = position.getEntry().getIndex();
-        int barCount = getValueIndicatorBarCount(entryIndex, entryIndex);
         if (position.getEntry().isBuy()) {
-            HighestValueIndicator highest = new HighestValueIndicator(priceIndicator, barCount);
-            Num highestCloseNum = highest.getValue(entryIndex);
+            Num highestCloseNum = priceIndicator.getValue(entryIndex);
+            if (Num.isNaNOrNull(highestCloseNum)) {
+                return null;
+            }
             return StopLossRule.stopLossPrice(highestCloseNum, lossPercentage, true);
         }
-        LowestValueIndicator lowest = new LowestValueIndicator(priceIndicator, barCount);
-        Num lowestCloseNum = lowest.getValue(entryIndex);
+        Num lowestCloseNum = priceIndicator.getValue(entryIndex);
+        if (Num.isNaNOrNull(lowestCloseNum)) {
+            return null;
+        }
         return StopLossRule.stopLossPrice(lowestCloseNum, lossPercentage, false);
     }
 
-    private int getValueIndicatorBarCount(int index, int positionIndex) {
-        return Math.min(index - positionIndex + 1, this.barCount);
+    private int windowStartIndex(int index, int positionIndex) {
+        int activeBarCount = Math.min(index - positionIndex + 1, barCount);
+        return index - activeBarCount + 1;
+    }
+
+    private Num highestValue(int startIndex, int endIndex) {
+        Num highest = priceIndicator.getValue(startIndex);
+        for (int index = startIndex + 1; index <= endIndex; index++) {
+            Num candidate = priceIndicator.getValue(index);
+            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(highest) || candidate.isGreaterThan(highest))) {
+                highest = candidate;
+            }
+        }
+        return highest;
+    }
+
+    private Num lowestValue(int startIndex, int endIndex) {
+        Num lowest = priceIndicator.getValue(startIndex);
+        for (int index = startIndex + 1; index <= endIndex; index++) {
+            Num candidate = priceIndicator.getValue(index);
+            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(lowest) || candidate.isLessThan(lowest))) {
+                lowest = candidate;
+            }
+        }
+        return lowest;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -89,12 +89,18 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
 
     private boolean isBuySatisfied(Num currentPrice, int index, int positionIndex) {
         Num highestCloseNum = highestValue(windowStartIndex(index, positionIndex), index);
+        if (Num.isNaNOrNull(highestCloseNum)) {
+            return false;
+        }
         Num currentStopLossLimitActivation = StopLossRule.stopLossPrice(highestCloseNum, lossPercentage, true);
         return currentPrice.isLessThanOrEqual(currentStopLossLimitActivation);
     }
 
     private boolean isSellSatisfied(Num currentPrice, int index, int positionIndex) {
         Num lowestCloseNum = lowestValue(windowStartIndex(index, positionIndex), index);
+        if (Num.isNaNOrNull(lowestCloseNum)) {
+            return false;
+        }
         Num currentStopLossLimitActivation = StopLossRule.stopLossPrice(lowestCloseNum, lossPercentage, false);
         return currentPrice.isGreaterThanOrEqual(currentStopLossLimitActivation);
     }
@@ -112,6 +118,8 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
+        // If the entry bar was evicted by max-bar-count retention, use the first
+        // retained bar as the anchor.
         int entryIndex = retainedStartIndex(position.getEntry().getIndex());
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);
@@ -137,10 +145,10 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
     }
 
     private Num highestValue(int startIndex, int endIndex) {
-        Num highest = priceIndicator.getValue(startIndex);
-        for (int index = startIndex + 1; index <= endIndex; index++) {
+        Num highest = null;
+        for (int index = startIndex; index <= endIndex; index++) {
             Num candidate = priceIndicator.getValue(index);
-            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(highest) || candidate.isGreaterThan(highest))) {
+            if (!Num.isNaNOrNull(candidate) && (highest == null || candidate.isGreaterThan(highest))) {
                 highest = candidate;
             }
         }
@@ -148,10 +156,10 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
     }
 
     private Num lowestValue(int startIndex, int endIndex) {
-        Num lowest = priceIndicator.getValue(startIndex);
-        for (int index = startIndex + 1; index <= endIndex; index++) {
+        Num lowest = null;
+        for (int index = startIndex; index <= endIndex; index++) {
             Num candidate = priceIndicator.getValue(index);
-            if (!Num.isNaNOrNull(candidate) && (Num.isNaNOrNull(lowest) || candidate.isLessThan(lowest))) {
+            if (!Num.isNaNOrNull(candidate) && (lowest == null || candidate.isLessThan(lowest))) {
                 lowest = candidate;
             }
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -3,6 +3,8 @@
  */
 package org.ta4j.core.rules;
 
+import java.util.Objects;
+
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.Position;
@@ -37,16 +39,13 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
      * @param barCount       the number of bars to look back for the calculation
      */
     public TrailingStopLossRule(Indicator<Num> indicator, Num lossPercentage, int barCount) {
-        if (indicator == null) {
-            throw new IllegalArgumentException("indicator must not be null");
-        }
-        if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isZero() || lossPercentage.isNegative()) {
-            throw new IllegalArgumentException("lossPercentage must be positive");
+        this.priceIndicator = Objects.requireNonNull(indicator, "priceIndicator");
+        if (Num.isNaNOrNull(lossPercentage) || lossPercentage.isNegative()) {
+            throw new IllegalArgumentException("lossPercentage must be >= 0");
         }
         if (barCount <= 0) {
             throw new IllegalArgumentException("barCount must be positive");
         }
-        this.priceIndicator = indicator;
         this.barCount = barCount;
         this.lossPercentage = lossPercentage;
     }
@@ -113,7 +112,7 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
-        int entryIndex = position.getEntry().getIndex();
+        int entryIndex = retainedStartIndex(position.getEntry().getIndex());
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);
             if (Num.isNaNOrNull(highestCloseNum)) {
@@ -130,7 +129,11 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
 
     private int windowStartIndex(int index, int positionIndex) {
         int activeBarCount = Math.min(index - positionIndex + 1, barCount);
-        return index - activeBarCount + 1;
+        return retainedStartIndex(index - activeBarCount + 1);
+    }
+
+    private int retainedStartIndex(int requestedStartIndex) {
+        return Math.max(requestedStartIndex, priceIndicator.getBarSeries().getBeginIndex());
     }
 
     private Num highestValue(int startIndex, int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TrailingStopLossRule.java
@@ -118,8 +118,8 @@ public class TrailingStopLossRule extends AbstractRule implements StopLossPriceM
         if (position == null || position.getEntry() == null) {
             return null;
         }
-        // If the entry bar was evicted by max-bar-count retention, use the first
-        // retained bar as the anchor.
+        // If the entry bar was evicted by max-bar-count retention, fall back to
+        // the first retained bar as the anchor (an approximation of entry-time stop).
         int entryIndex = retainedStartIndex(position.getEntry().getIndex());
         if (position.getEntry().isBuy()) {
             Num highestCloseNum = priceIndicator.getValue(entryIndex);

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
@@ -1,0 +1,491 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.rules;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+import org.ta4j.core.Position;
+import org.ta4j.core.Rule;
+import org.ta4j.core.Trade;
+import org.ta4j.core.TradingRecord;
+
+/**
+ * Keeps an always-active rule live while allowing one or more trigger/delegate
+ * stages to arm and evaluate later bars.
+ *
+ * <p>
+ * This rule is useful for staged exits and other lifecycle-based rule
+ * compositions. A stage becomes active when its trigger rule is satisfied. Once
+ * active, the stage delegates satisfaction checks to its delegate rule until
+ * the stage expires or is reset by its configured {@link ResetPolicy}.
+ * </p>
+ *
+ * <p>
+ * Triggered state is tied to one sequential rule evaluation pass. Reusing the
+ * same rule with a different {@link TradingRecord}, or evaluating an earlier
+ * bar index after a later one, resets all armed stages to avoid leaking staged
+ * state across backtest runs.
+ * </p>
+ *
+ * @since 0.22.7
+ */
+public class TriggeredRule extends AbstractRule {
+
+    /**
+     * Sentinel activation window for stages that should stay active until they
+     * explicitly satisfy or reset.
+     *
+     * @since 0.22.7
+     */
+    public static final int UNBOUNDED_WINDOW = Integer.MAX_VALUE;
+
+    /**
+     * Reset policies supported by {@link TriggeredRule} stages.
+     *
+     * @since 0.22.7
+     */
+    public enum ResetPolicy {
+
+        /**
+         * Reset the stage after its delegate rule is satisfied.
+         */
+        ON_SATISFACTION,
+
+        /**
+         * Reset the stage when the observed trading-record position changes.
+         */
+        ON_POSITION_CHANGE,
+
+        /**
+         * Reset the stage when the optional explicit reset rule is satisfied.
+         */
+        ON_EXPLICIT_RESET_RULE
+    }
+
+    /**
+     * Immutable configuration for a single trigger/delegate stage.
+     *
+     * @param triggerRule                the rule that arms the stage
+     * @param delegateRule               the rule evaluated once the stage is armed
+     * @param activationWindowBars       the number of bars the stage may remain
+     *                                   armed, or {@link #UNBOUNDED_WINDOW}
+     * @param primeDelegateWhileInactive true to evaluate the delegate while the
+     *                                   stage is inactive so stateful delegates can
+     *                                   warm up
+     * @param resetPolicy                the stage reset policy
+     * @since 0.22.7
+     */
+    public record Stage(Rule triggerRule, Rule delegateRule, int activationWindowBars,
+            boolean primeDelegateWhileInactive, ResetPolicy resetPolicy) {
+
+        /**
+         * Creates an unbounded stage that resets after delegate satisfaction.
+         *
+         * @param triggerRule  the rule that arms the stage
+         * @param delegateRule the rule evaluated once the stage is armed
+         * @since 0.22.7
+         */
+        public Stage(Rule triggerRule, Rule delegateRule) {
+            this(triggerRule, delegateRule, UNBOUNDED_WINDOW);
+        }
+
+        /**
+         * Creates a stage that resets after delegate satisfaction.
+         *
+         * @param triggerRule          the rule that arms the stage
+         * @param delegateRule         the rule evaluated once the stage is armed
+         * @param activationWindowBars the number of bars the stage may remain armed, or
+         *                             {@link #UNBOUNDED_WINDOW}
+         * @since 0.22.7
+         */
+        public Stage(Rule triggerRule, Rule delegateRule, int activationWindowBars) {
+            this(triggerRule, delegateRule, activationWindowBars, false, ResetPolicy.ON_SATISFACTION);
+        }
+
+        /**
+         * Creates a stage with the supplied lifecycle configuration.
+         *
+         * @since 0.22.7
+         */
+        public Stage {
+            Objects.requireNonNull(triggerRule, "triggerRule");
+            Objects.requireNonNull(delegateRule, "delegateRule");
+            Objects.requireNonNull(resetPolicy, "resetPolicy");
+            if (activationWindowBars < 0) {
+                throw new IllegalArgumentException("activationWindowBars must be >= 0");
+            }
+        }
+    }
+
+    private final Rule alwaysActiveRule;
+    private final Rule explicitResetRule;
+    private final boolean resetAllStagesOnSatisfaction;
+    private final Rule[] triggerRules;
+    private final Rule[] delegateRules;
+    private final int[] activationWindowBars;
+    private final boolean[] primeDelegateWhileInactive;
+    private final ResetPolicy[] resetPolicies;
+    private final transient boolean hasPositionResetStages;
+    private final transient boolean hasExplicitResetStages;
+    private final transient StageState[] stageStates;
+
+    private transient PositionSnapshot lastPositionSnapshot;
+    private transient TradingRecord lastTradingRecord;
+    private transient int lastEvaluatedIndex = Integer.MIN_VALUE;
+    private transient boolean evaluationStarted;
+
+    /**
+     * Constructor.
+     *
+     * @param alwaysActiveRule the rule evaluated on every bar, or {@code null} to
+     *                         use a permanently false base rule
+     * @param stages           the triggered stages
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, Stage... stages) {
+        this(alwaysActiveRule, null, false, toStageArrays(stages));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param alwaysActiveRule  the rule evaluated on every bar, or {@code null} to
+     *                          use a permanently false base rule
+     * @param explicitResetRule the rule that resets
+     *                          {@link ResetPolicy#ON_EXPLICIT_RESET_RULE} stages
+     *                          when satisfied
+     * @param stages            the triggered stages
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, Rule explicitResetRule, Stage... stages) {
+        this(alwaysActiveRule, explicitResetRule, false, toStageArrays(stages));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param alwaysActiveRule             the rule evaluated on every bar, or
+     *                                     {@code null} to use a permanently false
+     *                                     base rule
+     * @param explicitResetRule            the rule that resets
+     *                                     {@link ResetPolicy#ON_EXPLICIT_RESET_RULE}
+     *                                     stages when satisfied
+     * @param resetAllStagesOnSatisfaction true to reset every active stage whenever
+     *                                     any delegate is satisfied
+     * @param stages                       the triggered stages
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, Rule explicitResetRule, boolean resetAllStagesOnSatisfaction,
+            Collection<Stage> stages) {
+        this(alwaysActiveRule, explicitResetRule, resetAllStagesOnSatisfaction, toStageArrays(stages));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param alwaysActiveRule             the rule evaluated on every bar, or
+     *                                     {@code null} to use a permanently false
+     *                                     base rule
+     * @param explicitResetRule            the rule that resets
+     *                                     {@link ResetPolicy#ON_EXPLICIT_RESET_RULE}
+     *                                     stages when satisfied
+     * @param resetAllStagesOnSatisfaction true to reset every active stage whenever
+     *                                     any delegate is satisfied
+     * @param stages                       the triggered stages
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, Rule explicitResetRule, boolean resetAllStagesOnSatisfaction,
+            Stage... stages) {
+        this(alwaysActiveRule, explicitResetRule, resetAllStagesOnSatisfaction, toStageArrays(stages));
+    }
+
+    /**
+     * Constructor used by rule serialization for triggered rules without an
+     * explicit reset rule.
+     *
+     * <p>
+     * All arrays are defensively copied and must have the same length.
+     * </p>
+     *
+     * @param alwaysActiveRule             the rule evaluated on every bar, or
+     *                                     {@code null} to use a permanently false
+     *                                     base rule
+     * @param resetAllStagesOnSatisfaction true to reset every active stage whenever
+     *                                     any delegate is satisfied
+     * @param triggerRules                 stage trigger rules
+     * @param delegateRules                stage delegate rules
+     * @param activationWindowBars         stage activation windows
+     * @param primeDelegateWhileInactive   stage delegate priming flags
+     * @param resetPolicies                stage reset policies
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, boolean resetAllStagesOnSatisfaction, Rule[] triggerRules,
+            Rule[] delegateRules, int[] activationWindowBars, boolean[] primeDelegateWhileInactive,
+            ResetPolicy[] resetPolicies) {
+        this(alwaysActiveRule, null, resetAllStagesOnSatisfaction, triggerRules, delegateRules, activationWindowBars,
+                primeDelegateWhileInactive, resetPolicies);
+    }
+
+    /**
+     * Constructor used by rule serialization and advanced callers that need compact
+     * array-based configuration.
+     *
+     * <p>
+     * All arrays are defensively copied and must have the same length.
+     * </p>
+     *
+     * @param alwaysActiveRule             the rule evaluated on every bar, or
+     *                                     {@code null} to use a permanently false
+     *                                     base rule
+     * @param explicitResetRule            the rule that resets
+     *                                     {@link ResetPolicy#ON_EXPLICIT_RESET_RULE}
+     *                                     stages when satisfied
+     * @param resetAllStagesOnSatisfaction true to reset every active stage whenever
+     *                                     any delegate is satisfied
+     * @param triggerRules                 stage trigger rules
+     * @param delegateRules                stage delegate rules
+     * @param activationWindowBars         stage activation windows
+     * @param primeDelegateWhileInactive   stage delegate priming flags
+     * @param resetPolicies                stage reset policies
+     * @since 0.22.7
+     */
+    public TriggeredRule(Rule alwaysActiveRule, Rule explicitResetRule, boolean resetAllStagesOnSatisfaction,
+            Rule[] triggerRules, Rule[] delegateRules, int[] activationWindowBars, boolean[] primeDelegateWhileInactive,
+            ResetPolicy[] resetPolicies) {
+        validateStageArrays(triggerRules, delegateRules, activationWindowBars, primeDelegateWhileInactive,
+                resetPolicies);
+        this.alwaysActiveRule = alwaysActiveRule != null ? alwaysActiveRule : BooleanRule.FALSE;
+        this.explicitResetRule = explicitResetRule;
+        this.resetAllStagesOnSatisfaction = resetAllStagesOnSatisfaction;
+        this.triggerRules = triggerRules.clone();
+        this.delegateRules = delegateRules.clone();
+        this.activationWindowBars = activationWindowBars.clone();
+        this.primeDelegateWhileInactive = primeDelegateWhileInactive.clone();
+        this.resetPolicies = resetPolicies.clone();
+        this.hasPositionResetStages = hasResetPolicy(this.resetPolicies, ResetPolicy.ON_POSITION_CHANGE);
+        this.hasExplicitResetStages = hasResetPolicy(this.resetPolicies, ResetPolicy.ON_EXPLICIT_RESET_RULE);
+        this.stageStates = createStageStates(this.triggerRules.length);
+    }
+
+    private TriggeredRule(Rule alwaysActiveRule, Rule explicitResetRule, boolean resetAllStagesOnSatisfaction,
+            StageArrays stages) {
+        this(alwaysActiveRule, explicitResetRule, resetAllStagesOnSatisfaction, stages.triggerRules(),
+                stages.delegateRules(), stages.activationWindowBars(), stages.primeDelegateWhileInactive(),
+                stages.resetPolicies());
+    }
+
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        resetStagesOnEvaluationRestart(index, tradingRecord);
+        resetStagesOnPositionChange(tradingRecord);
+        resetStagesOnExplicitSignal(index, tradingRecord);
+
+        boolean satisfied = alwaysActiveRule.isSatisfied(index, tradingRecord);
+        if (!satisfied) {
+            satisfied = evaluateStages(index, tradingRecord);
+        }
+
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+    }
+
+    private void resetStagesOnEvaluationRestart(int index, TradingRecord tradingRecord) {
+        if (evaluationStarted && (tradingRecord != lastTradingRecord || index < lastEvaluatedIndex)) {
+            resetAllStages();
+            lastPositionSnapshot = null;
+        }
+        evaluationStarted = true;
+        lastTradingRecord = tradingRecord;
+        lastEvaluatedIndex = index;
+    }
+
+    private boolean evaluateStages(int index, TradingRecord tradingRecord) {
+        boolean satisfied = false;
+        for (int stageIndex = 0; stageIndex < triggerRules.length; stageIndex++) {
+            StageState state = stageStates[stageIndex];
+
+            if (triggerRules[stageIndex].isSatisfied(index, tradingRecord)) {
+                state.activate(index);
+            }
+
+            if (!state.active) {
+                if (primeDelegateWhileInactive[stageIndex]) {
+                    delegateRules[stageIndex].isSatisfied(index, tradingRecord);
+                }
+                continue;
+            }
+
+            if (isExpired(stageIndex, state, index)) {
+                state.reset();
+                continue;
+            }
+
+            if (delegateRules[stageIndex].isSatisfied(index, tradingRecord)) {
+                satisfied = true;
+                if (!resetAllStagesOnSatisfaction && resetPolicies[stageIndex] == ResetPolicy.ON_SATISFACTION) {
+                    state.reset();
+                }
+            }
+        }
+
+        if (satisfied && resetAllStagesOnSatisfaction) {
+            resetAllStages();
+        }
+        return satisfied;
+    }
+
+    private void resetStagesOnPositionChange(TradingRecord tradingRecord) {
+        if (!hasPositionResetStages) {
+            return;
+        }
+        PositionSnapshot currentPositionSnapshot = PositionSnapshot.from(tradingRecord);
+        if (lastPositionSnapshot != null && !lastPositionSnapshot.equals(currentPositionSnapshot)) {
+            resetStagesWithPolicy(ResetPolicy.ON_POSITION_CHANGE);
+        }
+        lastPositionSnapshot = currentPositionSnapshot;
+    }
+
+    private void resetStagesOnExplicitSignal(int index, TradingRecord tradingRecord) {
+        if (explicitResetRule != null && hasExplicitResetStages
+                && explicitResetRule.isSatisfied(index, tradingRecord)) {
+            resetStagesWithPolicy(ResetPolicy.ON_EXPLICIT_RESET_RULE);
+        }
+    }
+
+    private void resetStagesWithPolicy(ResetPolicy resetPolicy) {
+        for (int stageIndex = 0; stageIndex < resetPolicies.length; stageIndex++) {
+            if (resetPolicies[stageIndex] == resetPolicy) {
+                stageStates[stageIndex].reset();
+            }
+        }
+    }
+
+    private void resetAllStages() {
+        for (StageState stageState : stageStates) {
+            stageState.reset();
+        }
+    }
+
+    private boolean isExpired(int stageIndex, StageState stageState, int index) {
+        return activationWindowBars[stageIndex] != UNBOUNDED_WINDOW
+                && index - stageState.activatedAtIndex > activationWindowBars[stageIndex];
+    }
+
+    private static StageArrays toStageArrays(Stage... stages) {
+        Objects.requireNonNull(stages, "stages");
+        return toStageArrays(Arrays.asList(stages));
+    }
+
+    private static StageArrays toStageArrays(Collection<Stage> stages) {
+        Objects.requireNonNull(stages, "stages");
+        Rule[] triggerRules = new Rule[stages.size()];
+        Rule[] delegateRules = new Rule[stages.size()];
+        int[] activationWindowBars = new int[stages.size()];
+        boolean[] primeDelegateWhileInactive = new boolean[stages.size()];
+        ResetPolicy[] resetPolicies = new ResetPolicy[stages.size()];
+
+        int index = 0;
+        for (Stage stage : stages) {
+            Stage checkedStage = Objects.requireNonNull(stage, "stage");
+            triggerRules[index] = checkedStage.triggerRule();
+            delegateRules[index] = checkedStage.delegateRule();
+            activationWindowBars[index] = checkedStage.activationWindowBars();
+            primeDelegateWhileInactive[index] = checkedStage.primeDelegateWhileInactive();
+            resetPolicies[index] = checkedStage.resetPolicy();
+            index++;
+        }
+        return new StageArrays(triggerRules, delegateRules, activationWindowBars, primeDelegateWhileInactive,
+                resetPolicies);
+    }
+
+    private static void validateStageArrays(Rule[] triggerRules, Rule[] delegateRules, int[] activationWindowBars,
+            boolean[] primeDelegateWhileInactive, ResetPolicy[] resetPolicies) {
+        Objects.requireNonNull(triggerRules, "triggerRules");
+        Objects.requireNonNull(delegateRules, "delegateRules");
+        Objects.requireNonNull(activationWindowBars, "activationWindowBars");
+        Objects.requireNonNull(primeDelegateWhileInactive, "primeDelegateWhileInactive");
+        Objects.requireNonNull(resetPolicies, "resetPolicies");
+        int stageCount = triggerRules.length;
+        if (delegateRules.length != stageCount || activationWindowBars.length != stageCount
+                || primeDelegateWhileInactive.length != stageCount || resetPolicies.length != stageCount) {
+            throw new IllegalArgumentException("stage arrays must have the same length");
+        }
+        for (int index = 0; index < stageCount; index++) {
+            Objects.requireNonNull(triggerRules[index], "triggerRules[" + index + "]");
+            Objects.requireNonNull(delegateRules[index], "delegateRules[" + index + "]");
+            Objects.requireNonNull(resetPolicies[index], "resetPolicies[" + index + "]");
+            if (activationWindowBars[index] < 0) {
+                throw new IllegalArgumentException("activationWindowBars[" + index + "] must be >= 0");
+            }
+        }
+    }
+
+    private static boolean hasResetPolicy(ResetPolicy[] resetPolicies, ResetPolicy resetPolicy) {
+        for (ResetPolicy candidate : resetPolicies) {
+            if (candidate == resetPolicy) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static StageState[] createStageStates(int stageCount) {
+        StageState[] states = new StageState[stageCount];
+        for (int index = 0; index < stageCount; index++) {
+            states[index] = new StageState();
+        }
+        return states;
+    }
+
+    private record StageArrays(Rule[] triggerRules, Rule[] delegateRules, int[] activationWindowBars,
+            boolean[] primeDelegateWhileInactive, ResetPolicy[] resetPolicies) {
+    }
+
+    private static final class StageState {
+        private boolean active;
+        private int activatedAtIndex = Integer.MIN_VALUE;
+
+        private void activate(int index) {
+            this.active = true;
+            this.activatedAtIndex = index;
+        }
+
+        private void reset() {
+            this.active = false;
+            this.activatedAtIndex = Integer.MIN_VALUE;
+        }
+    }
+
+    private record PositionSnapshot(boolean recordPresent, int positionCount, boolean positionNew,
+            boolean positionOpened, int currentEntryIndex, int lastTradeIndex, String lastTradeType) {
+
+        private static PositionSnapshot from(TradingRecord tradingRecord) {
+            if (tradingRecord == null) {
+                return new PositionSnapshot(false, 0, false, false, Integer.MIN_VALUE, Integer.MIN_VALUE, "");
+            }
+
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            Trade lastTrade = tradingRecord.getLastTrade();
+
+            int currentEntryIndex = Integer.MIN_VALUE;
+            boolean positionNew = false;
+            boolean positionOpened = false;
+            if (currentPosition != null) {
+                positionNew = currentPosition.isNew();
+                positionOpened = currentPosition.isOpened();
+                if (currentPosition.getEntry() != null) {
+                    currentEntryIndex = currentPosition.getEntry().getIndex();
+                }
+            }
+
+            int lastTradeIndex = lastTrade != null ? lastTrade.getIndex() : Integer.MIN_VALUE;
+            String lastTradeType = lastTrade != null && lastTrade.getType() != null ? lastTrade.getType().name() : "";
+
+            return new PositionSnapshot(true, tradingRecord.getPositionCount(), positionNew, positionOpened,
+                    currentEntryIndex, lastTradeIndex, lastTradeType);
+        }
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
@@ -34,6 +34,9 @@ import org.ta4j.core.TradingRecord;
  * <p>
  * This rule is stateful and not thread-safe. Use a fresh instance for each
  * independent strategy, backtest run, or evaluation thread.
+ * TradingRecord identity is tracked weakly, so if a caller drops its own strong
+ * reference and the record is garbage-collected between evaluations, stage state
+ * may be reset on the next call.
  * </p>
  *
  * @since 0.22.7

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
@@ -33,10 +33,10 @@ import org.ta4j.core.TradingRecord;
  *
  * <p>
  * This rule is stateful and not thread-safe. Use a fresh instance for each
- * independent strategy, backtest run, or evaluation thread.
- * TradingRecord identity is tracked weakly, so if a caller drops its own strong
- * reference and the record is garbage-collected between evaluations, stage state
- * may be reset on the next call.
+ * independent strategy, backtest run, or evaluation thread. TradingRecord
+ * identity is tracked weakly, so if a caller drops its own strong reference and
+ * the record is garbage-collected between evaluations, stage state may be reset
+ * on the next call.
  * </p>
  *
  * @since 0.22.7

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
@@ -3,6 +3,7 @@
  */
 package org.ta4j.core.rules;
 
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -24,10 +25,10 @@ import org.ta4j.core.TradingRecord;
  * </p>
  *
  * <p>
- * Triggered state is tied to one sequential rule evaluation pass. Reusing the
- * same rule with a different {@link TradingRecord}, or evaluating an earlier
- * bar index after a later one, resets all armed stages to avoid leaking staged
- * state across backtest runs.
+ * Triggered state is tied to one sequential rule evaluation pass. Any change of
+ * {@link TradingRecord} instance (including {@code null} ↔ non-{@code null}
+ * transitions), or evaluating an earlier bar index after a later one, resets
+ * all armed stages to avoid leaking staged state across backtest runs.
  * </p>
  *
  * <p>
@@ -138,7 +139,7 @@ public class TriggeredRule extends AbstractRule {
     private final transient StageState[] stageStates;
 
     private transient PositionSnapshot lastPositionSnapshot;
-    private transient TradingRecord lastTradingRecord;
+    private transient WeakReference<TradingRecord> lastTradingRecordRef;
     private transient int lastEvaluatedIndex = Integer.MIN_VALUE;
     private transient boolean evaluationStarted;
 
@@ -298,12 +299,13 @@ public class TriggeredRule extends AbstractRule {
     }
 
     private void resetStagesOnEvaluationRestart(int index, TradingRecord tradingRecord) {
+        TradingRecord lastTradingRecord = lastTradingRecordRef == null ? null : lastTradingRecordRef.get();
         if (evaluationStarted && (tradingRecord != lastTradingRecord || index < lastEvaluatedIndex)) {
             resetAllStages();
             lastPositionSnapshot = null;
         }
         evaluationStarted = true;
-        lastTradingRecord = tradingRecord;
+        lastTradingRecordRef = tradingRecord == null ? null : new WeakReference<>(tradingRecord);
         lastEvaluatedIndex = index;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/TriggeredRule.java
@@ -30,6 +30,11 @@ import org.ta4j.core.TradingRecord;
  * state across backtest runs.
  * </p>
  *
+ * <p>
+ * This rule is stateful and not thread-safe. Use a fresh instance for each
+ * independent strategy, backtest run, or evaluation thread.
+ * </p>
+ *
  * @since 0.22.7
  */
 public class TriggeredRule extends AbstractRule {
@@ -325,14 +330,14 @@ public class TriggeredRule extends AbstractRule {
 
             if (delegateRules[stageIndex].isSatisfied(index, tradingRecord)) {
                 satisfied = true;
-                if (!resetAllStagesOnSatisfaction && resetPolicies[stageIndex] == ResetPolicy.ON_SATISFACTION) {
+                if (resetAllStagesOnSatisfaction) {
+                    resetAllStages();
+                    break;
+                }
+                if (resetPolicies[stageIndex] == ResetPolicy.ON_SATISFACTION) {
                     state.reset();
                 }
             }
-        }
-
-        if (satisfied && resetAllStagesOnSatisfaction) {
-            resetAllStages();
         }
         return satisfied;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/WaitForRule.java
@@ -3,6 +3,8 @@
  */
 package org.ta4j.core.rules;
 
+import java.util.Objects;
+
 import org.ta4j.core.Bar;
 import org.ta4j.core.Trade;
 import org.ta4j.core.Trade.TradeType;
@@ -33,7 +35,10 @@ public class WaitForRule extends AbstractRule {
      * @param numberOfBars the number of bars to wait for
      */
     public WaitForRule(TradeType tradeType, int numberOfBars) {
-        this.tradeType = tradeType;
+        if (numberOfBars < 0) {
+            throw new IllegalArgumentException("numberOfBars must be >= 0");
+        }
+        this.tradeType = Objects.requireNonNull(tradeType, "tradeType");
         this.numberOfBars = numberOfBars;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
@@ -871,7 +871,10 @@ public final class RuleSerialization {
             // Handle arrays
             if (paramType.isArray()) {
                 Class<?> componentType = paramType.getComponentType();
-                if (Number.class.isAssignableFrom(componentType) || componentType.isPrimitive()) {
+                if (componentType.equals(boolean.class) || componentType.equals(Boolean.class)) {
+                    return context.resolveBooleanArray(paramName, paramType);
+                } else if (Number.class.isAssignableFrom(componentType)
+                        || (componentType.isPrimitive() && !componentType.equals(boolean.class))) {
                     return context.resolveNumberArray(paramName, paramType);
                 } else if (componentType.isEnum()) {
                     String enumTypeKey = "__enumType_" + paramName;
@@ -1037,6 +1040,20 @@ public final class RuleSerialization {
             for (int i = 0; i < list.size(); i++) {
                 Object element = list.get(i);
                 Object converted = convertNumber(element, componentType);
+                Array.set(array, i, converted);
+            }
+            return array;
+        }
+
+        private Object resolveBooleanArray(String name, Class<?> targetType) {
+            Object raw = descriptor.getParameters().get(name);
+            if (!(raw instanceof List<?> list)) {
+                throw new IllegalArgumentException("Missing boolean array parameter: " + name);
+            }
+            Class<?> componentType = targetType.getComponentType();
+            Object array = Array.newInstance(componentType, list.size());
+            for (int i = 0; i < list.size(); i++) {
+                Object converted = convertBoolean(list.get(i));
                 Array.set(array, i, converted);
             }
             return array;
@@ -1341,6 +1358,10 @@ public final class RuleSerialization {
                         return Optional.empty();
                     }
                     Class<?> componentType = type.getComponentType();
+                    if (componentType.equals(boolean.class) || componentType.equals(Boolean.class)) {
+                        arguments.add(Argument.boolArray(name, type, match.value));
+                        continue;
+                    }
                     if (componentType.isEnum()) {
                         arguments.add(Argument.enumArray(name, type, match.value));
                         continue;
@@ -1566,7 +1587,7 @@ public final class RuleSerialization {
 
     private enum ArgumentKind {
         SERIES, RULE, RULE_ARRAY, INDICATOR, NUM, NUMBER, INT, LONG, DOUBLE, BOOLEAN, STRING, ENUM, NUMBER_ARRAY,
-        INT_ARRAY, LONG_ARRAY, DOUBLE_ARRAY, ENUM_ARRAY, CHAIN_LINKS
+        INT_ARRAY, LONG_ARRAY, DOUBLE_ARRAY, BOOLEAN_ARRAY, ENUM_ARRAY, CHAIN_LINKS
     }
 
     private static final class Argument {
@@ -1619,6 +1640,10 @@ public final class RuleSerialization {
 
         private static Argument bool(String name, Class<?> targetType, Boolean value) {
             return new Argument(ArgumentKind.BOOLEAN, name, targetType, value, name);
+        }
+
+        private static Argument boolArray(String name, Class<?> targetType, Object value) {
+            return new Argument(ArgumentKind.BOOLEAN_ARRAY, name, targetType, value, name);
         }
 
         private static Argument number(String name, Class<?> targetType, Object value) {
@@ -1710,6 +1735,9 @@ public final class RuleSerialization {
             case BOOLEAN:
                 context.parameters.put(name, value);
                 break;
+            case BOOLEAN_ARRAY:
+                context.parameters.put(name, serializeBooleanArray(value));
+                break;
             case NUMBER:
             case INT:
             case LONG:
@@ -1753,6 +1781,15 @@ public final class RuleSerialization {
             for (int i = 0; i < length; i++) {
                 Object element = Array.get(array, i);
                 serialized.add(serializeNumber(element));
+            }
+            return serialized;
+        }
+
+        private static List<Object> serializeBooleanArray(Object array) {
+            int length = Array.getLength(array);
+            List<Object> serialized = new ArrayList<>(length);
+            for (int i = 0; i < length; i++) {
+                serialized.add(Array.get(array, i));
             }
             return serialized;
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
@@ -874,7 +874,7 @@ public final class RuleSerialization {
                 if (componentType.equals(boolean.class) || componentType.equals(Boolean.class)) {
                     return context.resolveBooleanArray(paramName, paramType);
                 } else if (Number.class.isAssignableFrom(componentType)
-                        || (componentType.isPrimitive() && !componentType.equals(boolean.class))) {
+                        || componentType.isPrimitive()) {
                     return context.resolveNumberArray(paramName, paramType);
                 } else if (componentType.isEnum()) {
                     String enumTypeKey = "__enumType_" + paramName;

--- a/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/serialization/RuleSerialization.java
@@ -873,8 +873,7 @@ public final class RuleSerialization {
                 Class<?> componentType = paramType.getComponentType();
                 if (componentType.equals(boolean.class) || componentType.equals(Boolean.class)) {
                     return context.resolveBooleanArray(paramName, paramType);
-                } else if (Number.class.isAssignableFrom(componentType)
-                        || componentType.isPrimitive()) {
+                } else if (Number.class.isAssignableFrom(componentType) || componentType.isPrimitive()) {
                     return context.resolveNumberArray(paramName, paramType);
                 } else if (componentType.isEnum()) {
                     String enumTypeKey = "__enumType_" + paramName;

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/OpenedPositionMinimumBarCountRuleTest.java
@@ -78,6 +78,14 @@ public class OpenedPositionMinimumBarCountRuleTest {
     }
 
     @Test
+    public void testAtLeastBarCountRuleForNullTradingRecordShouldAlwaysReturnsFalse() {
+        final var rule = new OpenedPositionMinimumBarCountRule(1);
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, null));
+    }
+
+    @Test
     public void serializeAndDeserialize() {
         final var series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
                 .withData(1, 2, 3)

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -77,6 +78,20 @@ public class StopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
     }
 
     @Test
+    public void touchBoundaryTriggersForBuyAndSell() {
+        ClosePriceIndicator boundaryPrices = StopRuleTestSupport.closePrice(numFactory, 100, 105, 95);
+        StopGainRule rule = new StopGainRule(boundaryPrices, numOf(5));
+        BaseTradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        BaseTradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+
+        buyRecord.enter(0, numOf(100), numOf(1));
+        sellRecord.enter(0, numOf(100), numOf(1));
+
+        assertTrue(rule.isSatisfied(1, buyRecord));
+        assertTrue(rule.isSatisfied(2, sellRecord));
+    }
+
+    @Test
     public void isSatisfiedWorksForSell() {
         final TradingRecord tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
         final Num tradedAmount = numOf(1);
@@ -126,5 +141,12 @@ public class StopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         var rule = new StopGainRule(closePrice, numOf(15));
         RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(closePrice.getBarSeries(), rule);
         RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(closePrice.getBarSeries(), rule);
+    }
+
+    @Test
+    public void constructorValidation() {
+        assertThrows(NullPointerException.class, () -> new StopGainRule(null, numOf(5)));
+        assertThrows(NullPointerException.class, () -> new StopGainRule(closePrice, (Number) null));
+        assertThrows(IllegalArgumentException.class, () -> new StopGainRule(closePrice, numFactory.minusOne()));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopGainRuleTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -18,6 +19,7 @@ import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
 
@@ -49,6 +51,23 @@ public class StopGainRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertNumEquals(105, StopGainRule.trailingStopGainPrice(entryPrice, gainPercent, false));
         assertNumEquals(95, StopGainRule.trailingStopGainPriceFromDistance(entryPrice, numFactory.numOf(5), true));
         assertNumEquals(105, StopGainRule.trailingStopGainPriceFromDistance(entryPrice, numFactory.numOf(5), false));
+    }
+
+    @Test
+    public void stopGainPriceValidationDescribesNaNInputs() {
+        IllegalArgumentException gainException = assertThrows(IllegalArgumentException.class,
+                () -> StopGainRule.stopGainPrice(NaN.NaN, numFactory.one(), true));
+        IllegalArgumentException distanceException = assertThrows(IllegalArgumentException.class,
+                () -> StopGainRule.stopGainPriceFromDistance(NaN.NaN, numFactory.one(), true));
+        IllegalArgumentException trailingException = assertThrows(IllegalArgumentException.class,
+                () -> StopGainRule.trailingStopGainPrice(NaN.NaN, numFactory.one(), true));
+        IllegalArgumentException trailingDistanceException = assertThrows(IllegalArgumentException.class,
+                () -> StopGainRule.trailingStopGainPriceFromDistance(NaN.NaN, numFactory.one(), true));
+
+        assertEquals("entryPrice must not be null or NaN", gainException.getMessage());
+        assertEquals("entryPrice must not be null or NaN", distanceException.getMessage());
+        assertEquals("favorablePrice must not be null or NaN", trailingException.getMessage());
+        assertEquals("favorablePrice must not be null or NaN", trailingDistanceException.getMessage());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -72,6 +73,20 @@ public class StopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
     }
 
     @Test
+    public void touchBoundaryTriggersForBuyAndSell() {
+        ClosePriceIndicator boundaryPrices = StopRuleTestSupport.closePrice(numFactory, 100, 95, 105);
+        StopLossRule rule = new StopLossRule(boundaryPrices, numOf(5));
+        BaseTradingRecord buyRecord = new BaseTradingRecord(Trade.TradeType.BUY);
+        BaseTradingRecord sellRecord = new BaseTradingRecord(Trade.TradeType.SELL);
+
+        buyRecord.enter(0, numOf(100), numOf(1));
+        sellRecord.enter(0, numOf(100), numOf(1));
+
+        assertTrue(rule.isSatisfied(1, buyRecord));
+        assertTrue(rule.isSatisfied(2, sellRecord));
+    }
+
+    @Test
     public void isSatisfiedWorksForSell() {
         final var tradingRecord = new BaseTradingRecord(Trade.TradeType.SELL);
         final Num tradedAmount = numOf(1);
@@ -121,5 +136,12 @@ public class StopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         var rule = new StopLossRule(closePrice, numOf(8));
         RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(closePrice.getBarSeries(), rule);
         RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(closePrice.getBarSeries(), rule);
+    }
+
+    @Test
+    public void constructorValidation() {
+        assertThrows(NullPointerException.class, () -> new StopLossRule(null, numOf(5)));
+        assertThrows(NullPointerException.class, () -> new StopLossRule(closePrice, (Number) null));
+        assertThrows(IllegalArgumentException.class, () -> new StopLossRule(closePrice, numFactory.minusOne()));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopLossRuleTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -17,6 +18,7 @@ import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.indicators.helpers.HighPriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
 
@@ -44,6 +46,17 @@ public class StopLossRuleTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertNumEquals(105, StopLossRule.stopLossPrice(entryPrice, lossPercent, false));
         assertNumEquals(95, StopLossRule.stopLossPriceFromDistance(entryPrice, numFactory.numOf(5), true));
         assertNumEquals(105, StopLossRule.stopLossPriceFromDistance(entryPrice, numFactory.numOf(5), false));
+    }
+
+    @Test
+    public void stopLossPriceValidationDescribesNaNInputs() {
+        IllegalArgumentException percentageException = assertThrows(IllegalArgumentException.class,
+                () -> StopLossRule.stopLossPrice(NaN.NaN, numFactory.one(), true));
+        IllegalArgumentException distanceException = assertThrows(IllegalArgumentException.class,
+                () -> StopLossRule.stopLossPriceFromDistance(NaN.NaN, numFactory.one(), true));
+
+        assertEquals("entryPrice must not be null or NaN", percentageException.getMessage());
+        assertEquals("entryPrice must not be null or NaN", distanceException.getMessage());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/StopRuleTestSupport.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/StopRuleTestSupport.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
 import org.ta4j.core.num.NumFactory;
 
 final class StopRuleTestSupport {
@@ -22,5 +23,24 @@ final class StopRuleTestSupport {
 
     static ClosePriceIndicator closePrice(NumFactory numFactory, Number... closes) {
         return new ClosePriceIndicator(series(numFactory, closes));
+    }
+
+    static ClosePriceIndicator strictClosePrice(BarSeries series) {
+        return new StrictClosePriceIndicator(series);
+    }
+
+    private static final class StrictClosePriceIndicator extends ClosePriceIndicator {
+
+        private StrictClosePriceIndicator(BarSeries series) {
+            super(series);
+        }
+
+        @Override
+        public Num getValue(int index) {
+            if (index < getBarSeries().getBeginIndex()) {
+                throw new IndexOutOfBoundsException("index before retained begin");
+            }
+            return super.getValue(index);
+        }
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopGainRuleTest.java
@@ -56,6 +56,32 @@ public class TrailingStopGainRuleTest extends AbstractIndicatorTest<Object, Obje
     }
 
     @Test
+    public void isSatisfiedForBuyForBarCount() {
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 110, 120, 130, 120, 117, 117);
+
+        TrailingStopGainRule rule = new TrailingStopGainRule(closePrice, numOf(10), 3);
+        tradingRecord.enter(2, numOf(114), numOf(1));
+
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+        assertFalse(rule.isSatisfied(3, tradingRecord));
+        assertFalse(rule.isSatisfied(4, tradingRecord));
+        assertTrue(rule.isSatisfied(5, tradingRecord));
+        assertFalse(rule.isSatisfied(6, tradingRecord));
+    }
+
+    @Test
+    public void isNotSatisfiedBeforeEntryIndex() {
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 110, 120);
+        TrailingStopGainRule rule = new TrailingStopGainRule(closePrice, numOf(10));
+
+        tradingRecord.enter(2, numOf(120), numOf(1));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+    }
+
+    @Test
     public void isSatisfiedForSell() {
         BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.SELL);
         ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 90, 80, 70, 77.00, 120,

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopGainRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopGainRuleTest.java
@@ -9,9 +9,12 @@ import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.NumFactory;
 
 public class TrailingStopGainRuleTest extends AbstractIndicatorTest<Object, Object> {
@@ -82,6 +85,22 @@ public class TrailingStopGainRuleTest extends AbstractIndicatorTest<Object, Obje
     }
 
     @Test
+    public void clampsTrailingWindowToRetainedBarsForBuy() {
+        MockBarSeriesBuilder builder = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 110, 120, 130, 117, 116);
+        builder.withMaxBarCount(3);
+        BarSeries series = builder.build();
+        ClosePriceIndicator closePrice = StopRuleTestSupport.strictClosePrice(series);
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        TrailingStopGainRule rule = new TrailingStopGainRule(closePrice, numOf(10));
+
+        tradingRecord.enter(0, numOf(100), numOf(1));
+
+        assertTrue(rule.isSatisfied(5, tradingRecord));
+        assertTrue(rule.stopPrice(series, tradingRecord.getCurrentPosition()).isEqual(numOf(117)));
+    }
+
+    @Test
     public void isSatisfiedForSell() {
         BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.SELL);
         ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 90, 80, 70, 77.00, 120,
@@ -127,8 +146,9 @@ public class TrailingStopGainRuleTest extends AbstractIndicatorTest<Object, Obje
     @Test
     public void constructorValidation() {
         ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 101);
-        assertThrows(IllegalArgumentException.class, () -> new TrailingStopGainRule(null, numFactory.numOf(10), 2));
-        assertThrows(IllegalArgumentException.class, () -> new TrailingStopGainRule(closePrice, numFactory.zero(), 2));
+        assertThrows(NullPointerException.class, () -> new TrailingStopGainRule(null, numFactory.numOf(10), 2));
+        new TrailingStopGainRule(closePrice, numFactory.zero(), 2);
+        assertThrows(IllegalArgumentException.class, () -> new TrailingStopGainRule(closePrice, NaN.NaN, 2));
         assertThrows(IllegalArgumentException.class,
                 () -> new TrailingStopGainRule(closePrice, numFactory.minusOne(), 2));
         assertThrows(IllegalArgumentException.class,

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -26,6 +26,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -99,6 +100,17 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
     }
 
     @Test
+    public void isNotSatisfiedBeforeEntryIndex() {
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 110, 120);
+        TrailingStopLossRule rule = new TrailingStopLossRule(closePrice, numOf(10));
+
+        tradingRecord.enter(2, numOf(120), numOf(1));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+    }
+
+    @Test
     public void isSatisfiedForSell() {
         BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.SELL);
         ClosePriceIndicator closePrice = new ClosePriceIndicator(new MockBarSeriesBuilder().withNumFactory(numFactory)
@@ -162,5 +174,16 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
         TrailingStopLossRule rule = new TrailingStopLossRule(closePrice, numOf(7), 2);
         RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(closePrice.getBarSeries(), rule);
         RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(closePrice.getBarSeries(), rule);
+    }
+
+    @Test
+    public void constructorValidation() {
+        ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 101);
+        assertThrows(IllegalArgumentException.class, () -> new TrailingStopLossRule(null, numFactory.numOf(10), 2));
+        assertThrows(IllegalArgumentException.class, () -> new TrailingStopLossRule(closePrice, numFactory.zero(), 2));
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrailingStopLossRule(closePrice, numFactory.minusOne(), 2));
+        assertThrows(IllegalArgumentException.class,
+                () -> new TrailingStopLossRule(closePrice, numFactory.numOf(10), 0));
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TrailingStopLossRuleTest.java
@@ -31,10 +31,12 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Trade.TradeType;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NaN;
 import org.ta4j.core.num.NumFactory;
 
 public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Object> {
@@ -111,6 +113,22 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
     }
 
     @Test
+    public void clampsTrailingWindowToRetainedBarsForBuy() {
+        MockBarSeriesBuilder builder = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 110, 120, 130, 117, 116);
+        builder.withMaxBarCount(3);
+        BarSeries series = builder.build();
+        ClosePriceIndicator closePrice = StopRuleTestSupport.strictClosePrice(series);
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        TrailingStopLossRule rule = new TrailingStopLossRule(closePrice, numOf(10));
+
+        tradingRecord.enter(0, numOf(100), numOf(1));
+
+        assertTrue(rule.isSatisfied(5, tradingRecord));
+        assertTrue(rule.stopPrice(series, tradingRecord.getCurrentPosition()).isEqual(numOf(117)));
+    }
+
+    @Test
     public void isSatisfiedForSell() {
         BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.SELL);
         ClosePriceIndicator closePrice = new ClosePriceIndicator(new MockBarSeriesBuilder().withNumFactory(numFactory)
@@ -179,8 +197,9 @@ public class TrailingStopLossRuleTest extends AbstractIndicatorTest<Object, Obje
     @Test
     public void constructorValidation() {
         ClosePriceIndicator closePrice = StopRuleTestSupport.closePrice(numFactory, 100, 101);
-        assertThrows(IllegalArgumentException.class, () -> new TrailingStopLossRule(null, numFactory.numOf(10), 2));
-        assertThrows(IllegalArgumentException.class, () -> new TrailingStopLossRule(closePrice, numFactory.zero(), 2));
+        assertThrows(NullPointerException.class, () -> new TrailingStopLossRule(null, numFactory.numOf(10), 2));
+        new TrailingStopLossRule(closePrice, numFactory.zero(), 2);
+        assertThrows(IllegalArgumentException.class, () -> new TrailingStopLossRule(closePrice, NaN.NaN, 2));
         assertThrows(IllegalArgumentException.class,
                 () -> new TrailingStopLossRule(closePrice, numFactory.minusOne(), 2));
         assertThrows(IllegalArgumentException.class,

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TriggeredRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TriggeredRuleTest.java
@@ -1,0 +1,301 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.rules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.IntPredicate;
+
+import org.junit.Test;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Rule;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.rules.TriggeredRule.ResetPolicy;
+import org.ta4j.core.rules.TriggeredRule.Stage;
+import org.ta4j.core.serialization.ComponentDescriptor;
+import org.ta4j.core.serialization.ComponentSerialization;
+import org.ta4j.core.serialization.RuleSerialization;
+
+public class TriggeredRuleTest {
+
+    @Test
+    public void alwaysActiveRuleIsEvaluatedOnEveryBar() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.TRUE);
+
+        assertTrue(rule.isSatisfied(0, null));
+        assertTrue(rule.isSatisfied(10, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void stageArmsAndDelegatesWithinActivationWindow() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE,
+                new Stage(new IndexRule(2), new IndexRule(4), 2, false, ResetPolicy.ON_SATISFACTION));
+
+        assertFalse(rule.isSatisfied(1, null));
+        assertFalse(rule.isSatisfied(2, null));
+        assertFalse(rule.isSatisfied(3, null));
+        assertTrue(rule.isSatisfied(4, null));
+        assertFalse(rule.isSatisfied(4, null));
+    }
+
+    @Test
+    public void zeroActivationWindowAllowsOnlySameBarDelegate() {
+        TriggeredRule sameBar = new TriggeredRule(BooleanRule.FALSE,
+                new Stage(new IndexRule(2), new IndexRule(2), 0, false, ResetPolicy.ON_SATISFACTION));
+        TriggeredRule nextBar = new TriggeredRule(BooleanRule.FALSE,
+                new Stage(new IndexRule(2), new IndexRule(3), 0, false, ResetPolicy.ON_SATISFACTION));
+
+        assertTrue(sameBar.isSatisfied(2, null));
+        assertFalse(nextBar.isSatisfied(2, null));
+        assertFalse(nextBar.isSatisfied(3, null));
+    }
+
+    @Test
+    public void unboundedActivationWindowStaysArmedUntilDelegateSatisfies() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(1), new IndexRule(100),
+                TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_SATISFACTION));
+
+        assertFalse(rule.isSatisfied(1, null));
+        assertFalse(rule.isSatisfied(50, null));
+        assertTrue(rule.isSatisfied(100, null));
+    }
+
+    @Test
+    public void canPrimeStatefulDelegateWhileInactive() {
+        CountingRule delegate = new CountingRule(index -> index >= 3);
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(3), delegate,
+                TriggeredRule.UNBOUNDED_WINDOW, true, ResetPolicy.ON_SATISFACTION));
+
+        assertFalse(rule.isSatisfied(0, null));
+        assertFalse(rule.isSatisfied(1, null));
+        assertFalse(rule.isSatisfied(2, null));
+        assertEquals(3, delegate.evaluations);
+        assertTrue(rule.isSatisfied(3, null));
+        assertEquals(4, delegate.evaluations);
+    }
+
+    @Test
+    public void explicitResetRuleClearsMatchingStagesBeforeDelegatesRun() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new IndexRule(2), new Stage(new IndexRule(1),
+                new IndexRule(2), TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_EXPLICIT_RESET_RULE));
+
+        assertFalse(rule.isSatisfied(1, null));
+        assertFalse(rule.isSatisfied(2, null));
+    }
+
+    @Test
+    public void positionChangeResetClearsMatchingStages() {
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(0), new IndexRule(2),
+                TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_POSITION_CHANGE));
+
+        assertFalse(rule.isSatisfied(0, tradingRecord));
+        tradingRecord.enter(1);
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+    }
+
+    @Test
+    public void resetAllStagesOnSatisfactionClearsEveryArmedStage() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, null, true,
+                new Stage(new IndexRule(1), new IndexRule(2), TriggeredRule.UNBOUNDED_WINDOW, false,
+                        ResetPolicy.ON_POSITION_CHANGE),
+                new Stage(new IndexRule(1), new IndexRule(3), TriggeredRule.UNBOUNDED_WINDOW, false,
+                        ResetPolicy.ON_POSITION_CHANGE));
+
+        assertFalse(rule.isSatisfied(1, null));
+        assertTrue(rule.isSatisfied(2, null));
+        assertFalse(rule.isSatisfied(3, null));
+    }
+
+    @Test
+    public void evaluationRestartAtEarlierIndexClearsArmedStages() {
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(1), new IndexRule(2),
+                TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_EXPLICIT_RESET_RULE));
+
+        assertFalse(rule.isSatisfied(1, tradingRecord));
+        assertFalse(rule.isSatisfied(0, tradingRecord));
+        assertFalse(rule.isSatisfied(2, tradingRecord));
+    }
+
+    @Test
+    public void changedTradingRecordClearsArmedStages() {
+        TradingRecord firstRecord = new BaseTradingRecord();
+        TradingRecord secondRecord = new BaseTradingRecord();
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(1), new IndexRule(2),
+                TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_EXPLICIT_RESET_RULE));
+
+        assertFalse(rule.isSatisfied(1, firstRecord));
+        assertFalse(rule.isSatisfied(2, secondRecord));
+    }
+
+    @Test
+    public void omniStyleExitTriggersInvalidationOnStopLossTouch() {
+        BarSeries series = new MockBarSeriesBuilder().withData(100, 96, 90).build();
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        TriggeredRule exitRule = new TriggeredRule(new StopLossRule(closePrice, 10));
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+        Num amount = series.numFactory().one();
+
+        tradingRecord.enter(0, series.numFactory().hundred(), amount);
+
+        assertFalse(exitRule.isSatisfied(1, tradingRecord));
+        assertTrue(exitRule.isSatisfied(2, tradingRecord));
+    }
+
+    @Test
+    public void omniStyleExitTriggersTimeoutWhenTargetAndInvalidationDoNotFire() {
+        BarSeries series = new MockBarSeriesBuilder().withData(100, 101, 102, 103, 104, 105).build();
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        Rule invalidationOrTimeout = new StopLossRule(closePrice, 10).or(new OpenedPositionMinimumBarCountRule(5));
+        TriggeredRule exitRule = new TriggeredRule(invalidationOrTimeout,
+                new Stage(new StopGainRule(closePrice, 10),
+                        new TrailingStopLossRule(closePrice, series.numFactory().numOf(5)),
+                        TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_POSITION_CHANGE));
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+
+        tradingRecord.enter(0, series.numFactory().hundred(), series.numFactory().one());
+
+        assertFalse(exitRule.isSatisfied(4, tradingRecord));
+        assertTrue(exitRule.isSatisfied(5, tradingRecord));
+    }
+
+    @Test
+    public void omniStyleTargetCanArmTrailingExitInsteadOfExitingImmediately() {
+        BarSeries series = new MockBarSeriesBuilder().withData(100, 105, 110, 112, 100).build();
+        ClosePriceIndicator closePrice = new ClosePriceIndicator(series);
+        Rule invalidationOrTimeout = new StopLossRule(closePrice, 20).or(new OpenedPositionMinimumBarCountRule(10));
+        TriggeredRule exitRule = new TriggeredRule(invalidationOrTimeout,
+                new Stage(new StopGainRule(closePrice, 10),
+                        new TrailingStopLossRule(closePrice, series.numFactory().numOf(5)),
+                        TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_POSITION_CHANGE));
+        BaseTradingRecord tradingRecord = new BaseTradingRecord(TradeType.BUY);
+
+        tradingRecord.enter(0, series.numFactory().hundred(), series.numFactory().one());
+
+        assertFalse(exitRule.isSatisfied(1, tradingRecord));
+        assertFalse(exitRule.isSatisfied(2, tradingRecord));
+        assertFalse(exitRule.isSatisfied(3, tradingRecord));
+        assertTrue(exitRule.isSatisfied(4, tradingRecord));
+    }
+
+    @Test
+    public void constructorValidationRejectsInvalidStages() {
+        Rule trigger = new IndexRule(1);
+        Rule delegate = new IndexRule(2);
+
+        assertThrows(NullPointerException.class,
+                () -> new Stage(null, delegate, 1, false, ResetPolicy.ON_SATISFACTION));
+        assertThrows(NullPointerException.class, () -> new Stage(trigger, null, 1, false, ResetPolicy.ON_SATISFACTION));
+        assertThrows(NullPointerException.class, () -> new Stage(trigger, delegate, 1, false, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new Stage(trigger, delegate, -1, false, ResetPolicy.ON_SATISFACTION));
+        new Stage(trigger, delegate);
+        new Stage(trigger, delegate, 1);
+        assertThrows(NullPointerException.class, () -> new TriggeredRule(BooleanRule.FALSE, (Stage[]) null));
+        assertThrows(NullPointerException.class, () -> new TriggeredRule(BooleanRule.FALSE, new Stage[] { null }));
+    }
+
+    @Test
+    public void arrayConstructorDefensivelyValidatesConfiguration() {
+        Rule[] triggers = { new BooleanRule(true) };
+        Rule[] delegates = { new BooleanRule(false) };
+        int[] windows = { TriggeredRule.UNBOUNDED_WINDOW };
+        boolean[] priming = { true };
+        ResetPolicy[] policies = { ResetPolicy.ON_SATISFACTION };
+
+        new TriggeredRule(BooleanRule.FALSE, true, triggers, delegates, windows, priming, policies);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new TriggeredRule(BooleanRule.FALSE, true, triggers, new Rule[0], windows, priming, policies));
+        assertThrows(IllegalArgumentException.class, () -> new TriggeredRule(BooleanRule.FALSE, true, triggers,
+                delegates, new int[] { -1 }, priming, policies));
+        assertThrows(NullPointerException.class, () -> new TriggeredRule(BooleanRule.FALSE, true, new Rule[] { null },
+                delegates, windows, priming, policies));
+    }
+
+    @Test
+    public void serializeAndDeserializeWithoutExplicitResetRule() {
+        TriggeredRule rule = new TriggeredRule(new BooleanRule(false), true, new Rule[] { new BooleanRule(true) },
+                new Rule[] { new BooleanRule(false) }, new int[] { TriggeredRule.UNBOUNDED_WINDOW },
+                new boolean[] { true }, new ResetPolicy[] { ResetPolicy.ON_SATISFACTION });
+
+        BarSeries series = new MockBarSeriesBuilder().withData(1, 2, 3).build();
+        RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, rule);
+        RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, rule);
+    }
+
+    @Test
+    public void serializeAndDeserializeWithExplicitResetRule() {
+        TriggeredRule rule = new TriggeredRule(new BooleanRule(false), new BooleanRule(true), false,
+                new Rule[] { new BooleanRule(true) }, new Rule[] { new BooleanRule(false) },
+                new int[] { TriggeredRule.UNBOUNDED_WINDOW }, new boolean[] { false },
+                new ResetPolicy[] { ResetPolicy.ON_EXPLICIT_RESET_RULE });
+
+        BarSeries series = new MockBarSeriesBuilder().withData(1, 2, 3).build();
+        RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, rule);
+        RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, rule);
+    }
+
+    @Test
+    public void serializationExcludesRuntimeStageStateAfterEvaluation() {
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(1), new IndexRule(3),
+                TriggeredRule.UNBOUNDED_WINDOW, false, ResetPolicy.ON_POSITION_CHANGE));
+
+        assertFalse(rule.isSatisfied(1, new BaseTradingRecord()));
+
+        ComponentDescriptor descriptor = RuleSerialization.describe(rule);
+        String json = ComponentSerialization.toJson(descriptor);
+
+        assertFalse(json.contains("stageStates"));
+        assertFalse(json.contains("lastPositionSnapshot"));
+        assertFalse(json.contains("lastTradingRecord"));
+        assertFalse(json.contains("lastEvaluatedIndex"));
+        assertFalse(json.contains("evaluationStarted"));
+        assertFalse(json.contains("hasPositionResetStages"));
+        assertFalse(json.contains("hasExplicitResetStages"));
+    }
+
+    private static final class IndexRule extends AbstractRule {
+
+        private final int satisfiedIndex;
+
+        private IndexRule(int satisfiedIndex) {
+            this.satisfiedIndex = satisfiedIndex;
+        }
+
+        @Override
+        public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+            boolean satisfied = index == satisfiedIndex;
+            traceIsSatisfied(index, satisfied);
+            return satisfied;
+        }
+    }
+
+    private static final class CountingRule extends AbstractRule {
+
+        private final IntPredicate satisfiedIndex;
+        private int evaluations;
+
+        private CountingRule(IntPredicate satisfiedIndex) {
+            this.satisfiedIndex = satisfiedIndex;
+        }
+
+        @Override
+        public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+            evaluations++;
+            boolean satisfied = satisfiedIndex.test(index);
+            traceIsSatisfied(index, satisfied);
+            return satisfied;
+        }
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/TriggeredRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/TriggeredRuleTest.java
@@ -117,6 +117,23 @@ public class TriggeredRuleTest {
     }
 
     @Test
+    public void resetAllStagesOnSatisfactionShortCircuitsLaterStages() {
+        CountingRule firstDelegate = new CountingRule(index -> true);
+        CountingRule secondTrigger = new CountingRule(index -> true);
+        CountingRule secondDelegate = new CountingRule(index -> true);
+        TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, null, true,
+                new Stage(new IndexRule(1), firstDelegate, TriggeredRule.UNBOUNDED_WINDOW, false,
+                        ResetPolicy.ON_POSITION_CHANGE),
+                new Stage(secondTrigger, secondDelegate, TriggeredRule.UNBOUNDED_WINDOW, false,
+                        ResetPolicy.ON_POSITION_CHANGE));
+
+        assertTrue(rule.isSatisfied(1, null));
+        assertEquals(1, firstDelegate.evaluations);
+        assertEquals(0, secondTrigger.evaluations);
+        assertEquals(0, secondDelegate.evaluations);
+    }
+
+    @Test
     public void evaluationRestartAtEarlierIndexClearsArmedStages() {
         TradingRecord tradingRecord = new BaseTradingRecord();
         TriggeredRule rule = new TriggeredRule(BooleanRule.FALSE, new Stage(new IndexRule(1), new IndexRule(2),

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/WaitForRuleTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.rules;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -86,5 +87,11 @@ public class WaitForRuleTest {
         rule = new WaitForRule(Trade.TradeType.BUY, 2);
         RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, rule);
         RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, rule);
+    }
+
+    @Test
+    public void constructorValidation() {
+        assertThrows(NullPointerException.class, () -> new WaitForRule(null, 1));
+        assertThrows(IllegalArgumentException.class, () -> new WaitForRule(Trade.TradeType.BUY, -1));
     }
 }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Add `TriggeredRule` for staged rule composition where an always-active invalidation/timeout rule can coexist with trigger/delegate stages such as target-armed trailing exits. Existing boolean composites (`and`/`or`/`xor`/chain/vote) do not model armed lifecycle, activation windows, delegate priming, or reset policies, so this is the reusable rule primitive for that behavior.
- Harden stop-loss, stop-gain, trailing stop, open-position timeout, and wait-for rules with explicit validation, null/NaN guards, touch-or-beyond boundary coverage, and lower-allocation trailing stop evaluation.
- Extend rule serialization for boolean-array constructor parameters and document staged exit composition, reset choices, and touch-vs-cross rule selection in the README and changelog.

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `TriggeredRule` for composing multi-stage exit logic with configurable activation windows and reset policies.

* **Bug Fixes**
  * Enhanced null-safety and validation across stop-loss, stop-gain, and trailing stop rules.
  * Improved robustness of minimum bar count and wait-for rules.

* **Documentation**
  * Added staged exit rules guide with Java examples demonstrating composed exit strategies.

* **Tests**
  * Comprehensive test coverage for new and updated rule behaviors, including constructor validation and boundary conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ta4j/ta4j/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->