### PR TITLE
Refit NetMomentum as a rebound battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Breaking
 - Updated project Java JDK from 21 to 25
+- **NetMomentum now models oscillator battery exhaustion**: `NetMomentumIndicator` inverts RSI-style
+  distance from the neutral pivot so below-pivot pressure charges rebound energy and above-pivot
+  pressure depletes it. Distance is now convex-weighted, so extreme oscillator readings count more
+  than repeated mild deviations.
 
 ### Added
 - **Rolling advanced correlation indicators**: Added Spearman rank correlation, Kendall tau-b, lag-aware cross-correlation, distance correlation, mutual information, and regime-segmented correlation indicators under `org.ta4j.core.indicators.statistics`, with NaN handling for undefined windows and documentation for choosing the right metric.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AGENTS.md
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AGENTS.md
@@ -42,7 +42,11 @@ Applies to this package unless a deeper `AGENTS.md` overrides it.
 
 ## NetMomentumIndicator specifics
 
-- Preserve decay semantics: `decay = 1` keeps legacy running-total behavior; values below `1` apply exponential fade.
+- Preserve battery semantics: below-pivot oscillator pressure contributes positive rebound energy,
+  above-pivot pressure contributes negative depletion, and distance from the pivot is convex-weighted.
+- Preserve decay semantics: `decay = 1` keeps the undecayed windowed battery sum; values below `1`
+  apply exponential fade.
 - Keep the recursive weighted-sum formulation intact (do not reintroduce `RunningTotalIndicator`).
-- For deterministic expectations, use the steady-state reference formula `delta * (1 - decay^window) / (1 - decay)`.
+- For deterministic expectations, use the steady-state reference formula
+  `contribution * (1 - decay^window) / (1 - decay)`.
 - Prefer `NetMomentumIndicator.forRsi(...)` and `NetMomentumIndicator.forRsiWithDecay(...)` in tests/examples to avoid constructor ambiguity.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
@@ -16,34 +16,42 @@ import static org.ta4j.core.num.NaN.NaN;
  * Net Momentum Indicator.
  *
  * <p>
- * This indicator measures the cumulative deviation of an oscillating indicator
- * from its neutral pivot point over a specified timeframe. It helps identify:
+ * This indicator models oscillator extremes as a finite psychological battery
+ * over a specified timeframe. For RSI-style inputs, readings below the neutral
+ * pivot charge positive rebound energy, while readings above the pivot deplete
+ * it. It helps identify:
  * <ul>
- * <li>Persistent momentum bias (bullish/bearish energy)</li>
- * <li>Potential mean reversion opportunities at extremes</li>
- * <li>Divergences between price action and momentum</li>
+ * <li>Potential troughs when rebound battery crosses back above zero after
+ * downside pressure</li>
+ * <li>Potential tops when rebound energy is worked off and crosses below
+ * zero</li>
+ * <li>Divergences between price action and remaining oscillator fuel</li>
  * </ul>
  *
  * <p>
  * The calculation process:
  * <ol>
  * <li>Applies Kalman filter smoothing to the input oscillator</li>
- * <li>Calculates deviation from the neutral pivot value</li>
- * <li>Maintains a running total over the specified timeframe</li>
+ * <li>Calculates inverted distance from the neutral pivot value</li>
+ * <li>Adds a pivot-normalized squared distance term so extremes count more than
+ * repeated mild deviations</li>
+ * <li>Maintains a running battery balance over the specified timeframe</li>
  * <li>Optionally applies exponential decay so that momentum can reset through
  * time/sideways action</li>
  * </ol>
  *
  * <p>
  * Why use this over the raw oscillator? The raw oscillator shows the
- * instantaneous state, while the Net Momentum integrates both the magnitude and
- * the duration spent above/below the neutral pivot (e.g., RSI 50). This
- * distinguishes persistent pressure from fleeting spikes and provides a more
- * stable signal for regime detection.
+ * instantaneous state, while the Net Momentum integrates both the non-linear
+ * magnitude and the duration spent away from the neutral pivot (e.g., RSI 50).
+ * This distinguishes a real store of regime fuel from fleeting pivot noise and
+ * provides a more stable signal for swing-scale regime exhaustion.
  * <ul>
  * <li>Two periods can end with the same oscillator value, but the one that
- * accumulated more time and distance above the pivot will have higher net
- * momentum.</li>
+ * accumulated more time and distance below the pivot will have higher rebound
+ * battery.</li>
+ * <li>A larger extreme contributes more than multiple mild deviations; for
+ * example, an RSI move to 90 has more impact than two readings at 70.</li>
  * <li>Kalman smoothing reduces whipsaw before accumulation, improving the
  * usefulness of the running total for decision-making.</li>
  * </ul>
@@ -51,16 +59,13 @@ import static org.ta4j.core.num.NaN.NaN;
  * <p>
  * Practical scenarios where Net Momentum adds insight beyond the oscillator:
  * <ul>
- * <li><b>Regime filter</b>: Sustained positive readings indicate a bullish
- * environment; sustained negative readings a bearish one. The zero line can act
- * as a trend filter for enabling/disabling strategies.</li>
- * <li><b>Breakout readiness</b>: A steady rise from negative to positive while
- * price is still range-bound can foreshadow directional breaks.</li>
- * <li><b>Continuation vs. exhaustion</b>: New price highs with
- * flattening/falling net momentum warn of waning fuel; rising net momentum
- * confirms trend continuation.</li>
- * <li><b>Mean reversion extremes</b>: Unusually high/low cumulative values
- * versus a rolling history highlight stretched conditions that often
+ * <li><b>Rebound readiness</b>: A steady rise through zero after downside RSI
+ * pressure often marks a local trough or the early transition away from
+ * one.</li>
+ * <li><b>Exhaustion timing</b>: A fall through zero after upside RSI pressure
+ * often marks a local top or the late transition into one.</li>
+ * <li><b>Mean reversion extremes</b>: Unusually high/low cumulative battery
+ * values versus a rolling history highlight stretched conditions that often
  * mean-revert.</li>
  * <li><b>Noise reduction in ranges</b>: Oscillators often whipsaw around the
  * pivot in ranges; net momentum tends to hover near zero, reducing false
@@ -76,13 +81,12 @@ import static org.ta4j.core.num.NaN.NaN;
  * <p>
  * RSI-specific intuition (pivot at 50):
  * <ul>
- * <li>Brief RSI readings just above 50 produce small net momentum; RSI between
- * 55–70 for many bars produces large positive net momentum (persistent buying
- * pressure).</li>
- * <li>Two series can end at RSI = 60; the one that spent more time and distance
- * above 50 will show higher net momentum.</li>
- * <li>Zero-line crosses and slope changes in net momentum can be used as robust
- * filters or timing aids compared to single RSI threshold checks.</li>
+ * <li>Brief RSI readings just below 50 produce small positive charge; RSI
+ * between 0 and 30 for many bars produces large positive rebound battery.</li>
+ * <li>Readings above 50 subtract from that battery; a cross below zero suggests
+ * the prior rebound fuel has been worked off.</li>
+ * <li>Zero-line crosses and slope changes can be used as swing-turn timing aids
+ * compared to single RSI threshold checks.</li>
  * </ul>
  *
  * <p>
@@ -116,6 +120,7 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
     private final int timeFrame;
     private final Num decayFactor;
     private final Num decayFactorAtWindowLimit;
+    private final Num convexityScale;
     private final Num zero;
     private final int unstableBars;
 
@@ -183,6 +188,7 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
         NumFactory numFactory = oscillatingIndicator.getBarSeries().numFactory();
         this.decayFactor = numFactory.numOf(decayFactor);
         this.decayFactorAtWindowLimit = this.decayFactor.pow(timeFrame);
+        this.convexityScale = numFactory.numOf(Math.max(Math.abs(rawPivot), 1.0d));
         this.zero = numFactory.zero();
         int smoothingUnstable = Math.max(oscillatingIndicator.getCountOfUnstableBars(),
                 smoothedIndicator.getCountOfUnstableBars());
@@ -230,7 +236,7 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
             return NaN;
         }
 
-        Num delta = deltaFromNeutralIndicator.getValue(index);
+        Num delta = contribution(index);
         if (Num.isNaNOrNull(delta)) {
             return NaN;
         }
@@ -247,8 +253,7 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
 
         if (index >= timeFrame) {
             int expiredIndex = index - timeFrame;
-            Num expiredContribution = expiredIndex < getCountOfUnstableBars() ? zero
-                    : deltaFromNeutralIndicator.getValue(expiredIndex);
+            Num expiredContribution = expiredIndex < getCountOfUnstableBars() ? zero : contribution(expiredIndex);
             if (Num.isNaNOrNull(expiredContribution)) {
                 expiredContribution = zero;
             }
@@ -257,6 +262,17 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         return decayedWithCurrent;
+    }
+
+    private Num contribution(int index) {
+        Num rawDistance = deltaFromNeutralIndicator.getValue(index);
+        if (Num.isNaNOrNull(rawDistance)) {
+            return NaN;
+        }
+
+        Num distance = rawDistance.abs();
+        Num convexDistance = distance.plus(distance.pow(2).dividedBy(convexityScale));
+        return rawDistance.isNegative() ? convexDistance : convexDistance.negate();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
@@ -104,6 +104,9 @@ import static org.ta4j.core.num.NaN.NaN;
  * NetMomentumIndicator netMomentum = NetMomentumIndicator.forRsiWithDecay(rsi, 20, 0.85);
  * }</pre>
  *
+ * <p>
+ * Battery-model adaptation by TheCookieLab.
+ *
  * @see RSIIndicator
  * @see KalmanFilterIndicator
  *
@@ -166,11 +169,6 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
         Objects.requireNonNull(neutralPivotValue, "Neutral pivot value must not be null");
         Objects.requireNonNull(decayFactor, "Decay factor must not be null");
 
-        double rawPivot = neutralPivotValue.doubleValue();
-        if (Double.isNaN(rawPivot) || Double.isInfinite(rawPivot)) {
-            throw new IllegalArgumentException("Neutral pivot value must be finite (not NaN or infinite)");
-        }
-
         if (timeFrame <= 0) {
             throw new IllegalArgumentException("Time frame must be greater than 0");
         }
@@ -186,9 +184,13 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
         }
 
         NumFactory numFactory = oscillatingIndicator.getBarSeries().numFactory();
+        Num neutralPivot = numFactory.numOf(neutralPivotValue);
+        if (Num.isNaNOrNull(neutralPivot) || neutralPivot.decimalValue() == null) {
+            throw new IllegalArgumentException("Neutral pivot value must be finite (not NaN or infinite)");
+        }
         this.decayFactor = numFactory.numOf(decayFactor);
         this.decayFactorAtWindowLimit = this.decayFactor.pow(timeFrame);
-        this.convexityScale = numFactory.numOf(Math.max(Math.abs(rawPivot), 1.0d));
+        this.convexityScale = neutralPivot.abs().max(numFactory.one());
         this.zero = numFactory.zero();
         int smoothingUnstable = Math.max(oscillatingIndicator.getCountOfUnstableBars(),
                 smoothedIndicator.getCountOfUnstableBars());

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/NetMomentumIndicator.java
@@ -185,7 +185,8 @@ public class NetMomentumIndicator extends RecursiveCachedIndicator<Num> {
 
         NumFactory numFactory = oscillatingIndicator.getBarSeries().numFactory();
         Num neutralPivot = numFactory.numOf(neutralPivotValue);
-        if (Num.isNaNOrNull(neutralPivot) || neutralPivot.decimalValue() == null) {
+        double rawPivot = neutralPivot.doubleValue();
+        if (Num.isNaNOrNull(neutralPivot) || Double.isInfinite(rawPivot)) {
             throw new IllegalArgumentException("Neutral pivot value must be finite (not NaN or infinite)");
         }
         this.decayFactor = numFactory.numOf(decayFactor);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/NetMomentumIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/NetMomentumIndicatorTest.java
@@ -157,7 +157,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     }
 
     @Test
-    public void testTrendDetection() {
+    public void testBullishPressureDepletesBattery() {
         // Create a trending indicator (consistently above neutral)
         CachedIndicator<Num> trendingUp = new CachedIndicator<>(closePrice) {
             @Override
@@ -173,9 +173,20 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
 
         NetMomentumIndicator subject = new NetMomentumIndicator(trendingUp, 5, 50);
 
-        // After several bars, balance should be positive
+        // After several bars, above-pivot pressure should deplete rebound battery.
         Num balance = subject.getValue(10);
-        assertTrue(balance.isPositive());
+        assertTrue(balance.isNegative());
+    }
+
+    @Test
+    public void testExtremeDistanceOutweighsRepeatedMildDistance() {
+        CachedIndicator<Num> mildBullish = constantOscillator(70);
+        CachedIndicator<Num> extremeBullish = constantOscillator(90);
+
+        NetMomentumIndicator mild = new NetMomentumIndicator(mildBullish, 1, 50);
+        NetMomentumIndicator extreme = new NetMomentumIndicator(extremeBullish, 1, 50);
+
+        assertTrue(extreme.getValue(5).abs().isGreaterThan(mild.getValue(5).abs().multipliedBy(numOf(2))));
     }
 
     @Test
@@ -268,14 +279,15 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
             }
 
             if (expected == null) {
-                expected = deltaIndicator.getValue(i);
+                expected = contribution(deltaIndicator.getValue(i), 50);
                 continue;
             }
 
-            expected = expected.multipliedBy(decay).plus(deltaIndicator.getValue(i));
+            expected = expected.multipliedBy(decay).plus(contribution(deltaIndicator.getValue(i), 50));
             if (i >= timeFrame) {
                 int expiredIndex = i - timeFrame;
-                Num expired = expiredIndex < unstableBars ? numOf(0) : deltaIndicator.getValue(expiredIndex);
+                Num expired = expiredIndex < unstableBars ? numOf(0)
+                        : contribution(deltaIndicator.getValue(expiredIndex), 50);
                 expected = expected.minus(expired.multipliedBy(decayAtWindow));
             }
         }
@@ -284,7 +296,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     }
 
     @Test
-    public void testDecayFactorZeroBehavesLikeInstantaneousDelta() {
+    public void testDecayFactorZeroBehavesLikeInstantaneousContribution() {
         CachedIndicator<Num> varying = new CachedIndicator<>(closePrice) {
             @Override
             public int getCountOfUnstableBars() {
@@ -307,7 +319,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
         }
 
         for (int i = unstableBars; i < series.getBarCount(); i++) {
-            Num expected = deltaIndicator.getValue(i);
+            Num expected = contribution(deltaIndicator.getValue(i), 50);
             assertTrue("Mismatch at index " + i, instant.getValue(i).isEqual(expected));
         }
     }
@@ -384,7 +396,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     }
 
     @Test
-    public void testDecayOneLegacyParityDeterministic() {
+    public void testDecayOneMatchesWindowedBatterySum() {
         double constantOsc = 60.0;
         double pivot = 50.0;
         int timeFrame = 5;
@@ -410,11 +422,10 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
             int start = Math.max(0, i - timeFrame + 1);
             for (int j = start; j <= i; j++) {
                 if (j >= unstableBars) {
-                    expected = expected.plus(deltaIndicator.getValue(j));
+                    expected = expected.plus(contribution(deltaIndicator.getValue(j), pivot));
                 }
             }
-            assertTrue("Decay=1 must match legacy cumulative sum at index " + i,
-                    decayOne.getValue(i).isEqual(expected));
+            assertTrue("Decay=1 must match windowed battery sum at index " + i, decayOne.getValue(i).isEqual(expected));
         }
     }
 
@@ -438,7 +449,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
 
         KalmanFilterIndicator smoothed = new KalmanFilterIndicator(constantAbove);
         BinaryOperationIndicator deltaIndicator = BinaryOperationIndicator.difference(smoothed, pivot);
-        Num delta = deltaIndicator.getValue(series.getBarCount() - 1);
+        Num delta = contribution(deltaIndicator.getValue(series.getBarCount() - 1), pivot);
 
         Num decayNum = numOf(decay);
         Num decayAtWindow = decayNum.pow(timeFrame);
@@ -490,7 +501,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
     }
 
     @Test
-    public void testTimeframeOneSignMatchesOscillatorMinusPivot() {
+    public void testTimeframeOneSignMatchesBatteryOrientation() {
         // Oscillator always above pivot
         CachedIndicator<Num> constantAbove = new CachedIndicator<>(closePrice) {
             @Override
@@ -520,10 +531,10 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
         NetMomentumIndicator above = new NetMomentumIndicator(constantAbove, 1, 50);
         NetMomentumIndicator below = new NetMomentumIndicator(constantBelow, 1, 50);
 
-        assertTrue(above.getValue(0).isPositive());
-        assertTrue(below.getValue(0).isNegative());
-        assertTrue(above.getValue(10).isPositive());
-        assertTrue(below.getValue(10).isNegative());
+        assertTrue(above.getValue(0).isNegative());
+        assertTrue(below.getValue(0).isPositive());
+        assertTrue(above.getValue(10).isNegative());
+        assertTrue(below.getValue(10).isPositive());
     }
 
     @Test
@@ -592,7 +603,7 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
                 continue;
             }
             int window = Math.min(i - unstableBars + 1, timeFrame);
-            Num expected = numOf(window * (51.25 - pivot));
+            Num expected = contribution(numOf(51.25 - pivot), pivot).multipliedBy(numOf(window));
             assertTrue("Unexpected value at index " + i, actual.isEqual(expected));
         }
     }
@@ -689,5 +700,26 @@ public class NetMomentumIndicatorTest extends AbstractIndicatorTest<Indicator<Nu
                 return numOf(50 + 15 * Math.sin(index * 0.35));
             }
         };
+    }
+
+    private CachedIndicator<Num> constantOscillator(double value) {
+        return new CachedIndicator<>(closePrice) {
+            @Override
+            public int getCountOfUnstableBars() {
+                return 0;
+            }
+
+            @Override
+            protected Num calculate(int index) {
+                return numOf(value);
+            }
+        };
+    }
+
+    private Num contribution(Num rawDistance, double pivot) {
+        Num convexityScale = numOf(Math.max(Math.abs(pivot), 1.0d));
+        Num distance = rawDistance.abs();
+        Num convexDistance = distance.plus(distance.pow(2).dividedBy(convexityScale));
+        return rawDistance.isNegative() ? convexDistance : convexDistance.negate();
     }
 }

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
@@ -312,7 +312,7 @@ import java.util.function.Consumer;
  */
 public class BacktestPerformanceTuningHarness {
 
-    // PERFORMANCE NOTE: The current ranges generate ~10,000+ strategies.
+    // PERFORMANCE NOTE: The current ranges generate ~10,500+ strategies.
     // BacktestExecutor automatically uses batch processing for large strategy
     // counts (>1000)
     // to prevent memory exhaustion. If execution is still too slow, consider:
@@ -998,7 +998,7 @@ public class BacktestPerformanceTuningHarness {
             effectiveTarget = requestedStrategyCount;
         }
 
-        List<Strategy> strategies = new ArrayList<>(requestedStrategyCount > 0 ? requestedStrategyCount : 10_416);
+        List<Strategy> strategies = new ArrayList<>(requestedStrategyCount > 0 ? requestedStrategyCount : 10_584);
         ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(series);
         Map<Integer, RSIIndicator> rsiIndicators = new LinkedHashMap<>();
         Map<String, NetMomentumIndicator> netMomentumIndicators = new LinkedHashMap<>();
@@ -1013,7 +1013,7 @@ public class BacktestPerformanceTuningHarness {
                 for (int timeFrame = MOMENTUM_TIMEFRAME_MIN; timeFrame <= MOMENTUM_TIMEFRAME_MAX; timeFrame += MOMENTUM_TIMEFRAME_INCREMENT) {
                     for (int reboundEntryThreshold = REBOUND_ENTRY_THRESHOLD_MIN; reboundEntryThreshold <= REBOUND_ENTRY_THRESHOLD_MAX; reboundEntryThreshold += REBOUND_ENTRY_THRESHOLD_INCREMENT) {
                         for (int exhaustionExitThreshold = EXHAUSTION_EXIT_THRESHOLD_MIN; exhaustionExitThreshold <= EXHAUSTION_EXIT_THRESHOLD_MAX; exhaustionExitThreshold += EXHAUSTION_EXIT_THRESHOLD_INCREMENT) {
-                            if (exhaustionExitThreshold >= reboundEntryThreshold) {
+                            if (exhaustionExitThreshold > reboundEntryThreshold) {
                                 continue;
                             }
                             for (double decayFactor = DECAY_FACTOR_MIN; decayFactor <= DECAY_FACTOR_MAX; decayFactor += DECAY_FACTOR_INCREMENT) {

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
@@ -227,8 +227,8 @@ import java.util.function.Consumer;
  * <ul>
  * <li>RSI bar count: 7 to 49 (increment: 7)</li>
  * <li>Momentum timeframe: 100 to 400 (increment: 100)</li>
- * <li>Oversold threshold: -2000 to 0 (increment: 250)</li>
- * <li>Overbought threshold: 0 to 1500 (increment: 250)</li>
+ * <li>Rebound entry threshold: 0 to 1500 (increment: 250)</li>
+ * <li>Exhaustion exit threshold: -2000 to 0 (increment: 250)</li>
  * <li>Decay factor: 0.9 to 1.0 (increment: 0.02)</li>
  * </ul>
  * This generates approximately 10,416 unique strategy combinations. When fewer
@@ -328,13 +328,13 @@ public class BacktestPerformanceTuningHarness {
     private static final int MOMENTUM_TIMEFRAME_MIN = 100;
     private static final int MOMENTUM_TIMEFRAME_MAX = 400;
 
-    private static final int OVERBOUGHT_THRESHOLD_INCREMENT = 250;
-    private static final int OVERBOUGHT_THRESHOLD_MIN = 0;
-    private static final int OVERBOUGHT_THRESHOLD_MAX = 1500;
+    private static final int REBOUND_ENTRY_THRESHOLD_INCREMENT = 250;
+    private static final int REBOUND_ENTRY_THRESHOLD_MIN = 0;
+    private static final int REBOUND_ENTRY_THRESHOLD_MAX = 1500;
 
-    private static final int OVERSOLD_THRESHOLD_INCREMENT = 250;
-    private static final int OVERSOLD_THRESHOLD_MIN = -2000;
-    private static final int OVERSOLD_THRESHOLD_MAX = 0;
+    private static final int EXHAUSTION_EXIT_THRESHOLD_INCREMENT = 250;
+    private static final int EXHAUSTION_EXIT_THRESHOLD_MIN = -2000;
+    private static final int EXHAUSTION_EXIT_THRESHOLD_MAX = 0;
 
     private static final double DECAY_FACTOR_INCREMENT = 0.02;
     private static final double DECAY_FACTOR_MIN = 0.9;
@@ -955,8 +955,8 @@ public class BacktestPerformanceTuningHarness {
      * <ul>
      * <li>RSI bar count: 7 to 49 (increment: 7)</li>
      * <li>Momentum timeframe: 100 to 400 (increment: 100)</li>
-     * <li>Oversold threshold: -2000 to 0 (increment: 250)</li>
-     * <li>Overbought threshold: 0 to 1500 (increment: 250)</li>
+     * <li>Rebound entry threshold: 0 to 1500 (increment: 250)</li>
+     * <li>Exhaustion exit threshold: -2000 to 0 (increment: 250)</li>
      * <li>Decay factor: 0.9 to 1.0 (increment: 0.02)</li>
      * </ul>
      * <p>
@@ -967,9 +967,9 @@ public class BacktestPerformanceTuningHarness {
      * Strategies use:
      * <ul>
      * <li>Entry rule: CrossedUpIndicatorRule when NetMomentumIndicator crosses
-     * above oversold threshold</li>
+     * above the rebound entry threshold</li>
      * <li>Exit rule: CrossedDownIndicatorRule when NetMomentumIndicator crosses
-     * below overbought threshold</li>
+     * below the exhaustion exit threshold</li>
      * </ul>
      * <p>
      * Strategies that share the same RSI, Net Momentum timeframe, and decay factor
@@ -1011,9 +1011,9 @@ public class BacktestPerformanceTuningHarness {
 
             for (int rsiBarCount = RSI_BARCOUNT_MIN; rsiBarCount <= RSI_BARCOUNT_MAX; rsiBarCount += RSI_BARCOUNT_INCREMENT) {
                 for (int timeFrame = MOMENTUM_TIMEFRAME_MIN; timeFrame <= MOMENTUM_TIMEFRAME_MAX; timeFrame += MOMENTUM_TIMEFRAME_INCREMENT) {
-                    for (int oversoldThreshold = OVERSOLD_THRESHOLD_MIN; oversoldThreshold <= OVERSOLD_THRESHOLD_MAX; oversoldThreshold += OVERSOLD_THRESHOLD_INCREMENT) {
-                        for (int overboughtThreshold = OVERBOUGHT_THRESHOLD_MIN; overboughtThreshold <= OVERBOUGHT_THRESHOLD_MAX; overboughtThreshold += OVERBOUGHT_THRESHOLD_INCREMENT) {
-                            if (oversoldThreshold >= overboughtThreshold) {
+                    for (int reboundEntryThreshold = REBOUND_ENTRY_THRESHOLD_MIN; reboundEntryThreshold <= REBOUND_ENTRY_THRESHOLD_MAX; reboundEntryThreshold += REBOUND_ENTRY_THRESHOLD_INCREMENT) {
+                        for (int exhaustionExitThreshold = EXHAUSTION_EXIT_THRESHOLD_MIN; exhaustionExitThreshold <= EXHAUSTION_EXIT_THRESHOLD_MAX; exhaustionExitThreshold += EXHAUSTION_EXIT_THRESHOLD_INCREMENT) {
+                            if (exhaustionExitThreshold >= reboundEntryThreshold) {
                                 continue;
                             }
                             for (double decayFactor = DECAY_FACTOR_MIN; decayFactor <= DECAY_FACTOR_MAX; decayFactor += DECAY_FACTOR_INCREMENT) {
@@ -1032,7 +1032,7 @@ public class BacktestPerformanceTuningHarness {
                                                                                     key)),
                                                                     currentTimeFrame, currentDecayFactor));
                                     Strategy strategy = createStrategy(netMomentumIndicator, currentRsiBarCount,
-                                            currentTimeFrame, oversoldThreshold, overboughtThreshold,
+                                            currentTimeFrame, reboundEntryThreshold, exhaustionExitThreshold,
                                             currentDecayFactor, repetition);
                                     strategies.add(strategy);
                                     created++;
@@ -1041,10 +1041,10 @@ public class BacktestPerformanceTuningHarness {
                                         return strategies;
                                     }
                                 } catch (Exception e) {
-                                    LOG.debug(
-                                            "Skipping invalid strategy combination: rsiBarCount={}, timeFrame={}, oversoldThreshold={}, overboughtThreshold={}, decayFactor={}: {}",
-                                            rsiBarCount, timeFrame, oversoldThreshold, overboughtThreshold, decayFactor,
-                                            e.getMessage());
+                                    LOG.debug("Skipping invalid strategy combination: rsiBarCount={}, timeFrame={}, "
+                                            + "reboundEntryThreshold={}, exhaustionExitThreshold={}, decayFactor={}: {}",
+                                            rsiBarCount, timeFrame, reboundEntryThreshold, exhaustionExitThreshold,
+                                            decayFactor, e.getMessage());
                                 }
                             }
                         }
@@ -1077,45 +1077,46 @@ public class BacktestPerformanceTuningHarness {
      * <li>RSI indicator with the specified bar count</li>
      * <li>NetMomentumIndicator wrapping the RSI with the specified timeframe and
      * decay factor</li>
-     * <li>Entry rule: Buy when NetMomentumIndicator crosses above the oversold
+     * <li>Entry rule: Buy when NetMomentumIndicator crosses above the rebound entry
      * threshold</li>
-     * <li>Exit rule: Sell when NetMomentumIndicator crosses below the overbought
-     * threshold</li>
+     * <li>Exit rule: Sell when NetMomentumIndicator crosses below the exhaustion
+     * exit threshold</li>
      * </ul>
      * <p>
      * The repetition parameter is used to create multiple strategies with the same
      * parameters when more strategies are requested than the grid can provide. It's
      * included in the strategy name for identification.
      *
-     * @param series              The bar series to use for indicator calculations
-     * @param rsiBarCount         The number of bars to use for RSI calculation
-     *                            (must be positive)
-     * @param timeFrame           The timeframe for NetMomentumIndicator (must be
-     *                            positive)
-     * @param oversoldThreshold   The oversold threshold for entry signals
-     * @param overboughtThreshold The overbought threshold for exit signals
-     * @param decayFactor         The decay factor for NetMomentumIndicator
-     *                            (typically 0.9 to 1.0)
-     * @param repetition          The repetition number (0 for first occurrence,
-     *                            incremented for repeats)
+     * @param series                  The bar series to use for indicator
+     *                                calculations
+     * @param rsiBarCount             The number of bars to use for RSI calculation
+     *                                (must be positive)
+     * @param timeFrame               The timeframe for NetMomentumIndicator (must
+     *                                be positive)
+     * @param reboundEntryThreshold   The rebound threshold for entry signals
+     * @param exhaustionExitThreshold The exhaustion threshold for exit signals
+     * @param decayFactor             The decay factor for NetMomentumIndicator
+     *                                (typically 0.9 to 1.0)
+     * @param repetition              The repetition number (0 for first occurrence,
+     *                                incremented for repeats)
      * @return A new strategy with the specified parameters
      * @throws NullPointerException     If series is null
      * @throws IllegalArgumentException If rsiBarCount or timeFrame is not positive
      */
-    static Strategy createStrategy(BarSeries series, int rsiBarCount, int timeFrame, int oversoldThreshold,
-            int overboughtThreshold, double decayFactor, int repetition) {
+    static Strategy createStrategy(BarSeries series, int rsiBarCount, int timeFrame, int reboundEntryThreshold,
+            int exhaustionExitThreshold, double decayFactor, int repetition) {
         Objects.requireNonNull(series, "series cannot be null");
 
         ClosePriceIndicator closePriceIndicator = new ClosePriceIndicator(series);
         RSIIndicator rsiIndicator = new RSIIndicator(closePriceIndicator, rsiBarCount);
         NetMomentumIndicator netMomentumIndicator = NetMomentumIndicator.forRsiWithDecay(rsiIndicator, timeFrame,
                 decayFactor);
-        return createStrategy(netMomentumIndicator, rsiBarCount, timeFrame, oversoldThreshold, overboughtThreshold,
-                decayFactor, repetition);
+        return createStrategy(netMomentumIndicator, rsiBarCount, timeFrame, reboundEntryThreshold,
+                exhaustionExitThreshold, decayFactor, repetition);
     }
 
     private static Strategy createStrategy(NetMomentumIndicator netMomentumIndicator, int rsiBarCount, int timeFrame,
-            int oversoldThreshold, int overboughtThreshold, double decayFactor, int repetition) {
+            int reboundEntryThreshold, int exhaustionExitThreshold, double decayFactor, int repetition) {
         Objects.requireNonNull(netMomentumIndicator, "netMomentumIndicator cannot be null");
 
         if (rsiBarCount <= 0) {
@@ -1125,14 +1126,14 @@ public class BacktestPerformanceTuningHarness {
             throw new IllegalArgumentException("timeFrame should be positive");
         }
 
-        Rule entryRule = new CrossedUpIndicatorRule(netMomentumIndicator, oversoldThreshold);
-        Rule exitRule = new CrossedDownIndicatorRule(netMomentumIndicator, overboughtThreshold);
+        Rule entryRule = new CrossedUpIndicatorRule(netMomentumIndicator, reboundEntryThreshold);
+        Rule exitRule = new CrossedDownIndicatorRule(netMomentumIndicator, exhaustionExitThreshold);
 
         String suffix = repetition > 0 ? " (rep=" + repetition + ")" : "";
         String strategyName = "Entry Crossed Up: {rsiBarCount=" + rsiBarCount + ", timeFrame=" + timeFrame
-                + ", oversoldThreshold=" + oversoldThreshold + "}, Exit Crossed Down: {rsiBarCount=" + rsiBarCount
-                + ", timeFrame=" + timeFrame + ", overboughtThreshold=" + overboughtThreshold + ", decayFactor="
-                + decayFactor + "}" + suffix;
+                + ", reboundEntryThreshold=" + reboundEntryThreshold + "}, Exit Crossed Down: {rsiBarCount="
+                + rsiBarCount + ", timeFrame=" + timeFrame + ", exhaustionExitThreshold=" + exhaustionExitThreshold
+                + ", decayFactor=" + decayFactor + "}" + suffix;
 
         return new BaseStrategy(strategyName, entryRule, exitRule);
     }

--- a/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/backtesting/BacktestPerformanceTuningHarness.java
@@ -1013,9 +1013,6 @@ public class BacktestPerformanceTuningHarness {
                 for (int timeFrame = MOMENTUM_TIMEFRAME_MIN; timeFrame <= MOMENTUM_TIMEFRAME_MAX; timeFrame += MOMENTUM_TIMEFRAME_INCREMENT) {
                     for (int reboundEntryThreshold = REBOUND_ENTRY_THRESHOLD_MIN; reboundEntryThreshold <= REBOUND_ENTRY_THRESHOLD_MAX; reboundEntryThreshold += REBOUND_ENTRY_THRESHOLD_INCREMENT) {
                         for (int exhaustionExitThreshold = EXHAUSTION_EXIT_THRESHOLD_MIN; exhaustionExitThreshold <= EXHAUSTION_EXIT_THRESHOLD_MAX; exhaustionExitThreshold += EXHAUSTION_EXIT_THRESHOLD_INCREMENT) {
-                            if (exhaustionExitThreshold > reboundEntryThreshold) {
-                                continue;
-                            }
                             for (double decayFactor = DECAY_FACTOR_MIN; decayFactor <= DECAY_FACTOR_MAX; decayFactor += DECAY_FACTOR_INCREMENT) {
                                 try {
                                     int currentRsiBarCount = rsiBarCount;

--- a/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/strategies/NetMomentumStrategy.java
@@ -27,9 +27,9 @@ public class NetMomentumStrategy {
 
     private static final Logger LOG = LogManager.getLogger(NetMomentumStrategy.class);
 
-    private static final int DEFAULT_OVERBOUGHT_THRESHOLD = 900;
+    private static final int DEFAULT_EXHAUSTION_EXIT_THRESHOLD = 0;
     private static final int DEFAULT_MOMENTUM_TIMEFRAME = 200;
-    private static final int DEFAULT_OVERSOLD_THRESHOLD = -200;
+    private static final int DEFAULT_REBOUND_ENTRY_THRESHOLD = 0;
     private static final int DEFAULT_RSI_BARCOUNT = 14;
     private static final double DEFAULT_DECAY_FACTOR = 1;
 
@@ -92,8 +92,8 @@ public class NetMomentumStrategy {
     }
 
     private static Strategy createStrategy(NetMomentumIndicator rsiM) {
-        Rule entryRule = new CrossedUpIndicatorRule(rsiM, DEFAULT_OVERSOLD_THRESHOLD);
-        Rule exitRule = new CrossedDownIndicatorRule(rsiM, DEFAULT_OVERBOUGHT_THRESHOLD);
+        Rule entryRule = new CrossedUpIndicatorRule(rsiM, DEFAULT_REBOUND_ENTRY_THRESHOLD);
+        Rule exitRule = new CrossedDownIndicatorRule(rsiM, DEFAULT_EXHAUSTION_EXIT_THRESHOLD);
 
         return new BaseStrategy(NetMomentumStrategy.class.getSimpleName(), entryRule, exitRule);
     }


### PR DESCRIPTION
Fixes: N/A.

Changes proposed in this pull request:
- Reframes `NetMomentumIndicator` as a finite rebound/exhaustion battery: sub-neutral RSI charges rebound energy, supra-neutral RSI depletes it, and zero crosses mark local regime turns.
- Adds soft-convex RSI distance weighting so extreme RSI values contribute non-linearly without the timing collapse seen in a pure quadratic model.

- [X] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 
