### PR TITLE
Add active return criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   than repeated mild deviations.
 
 ### Added
+- **Active return criteria for benchmark comparisons**: Added `ActiveReturnCriterion` and `ActiveReturnVersusEnterAndHoldCriterion` so return-like criteria can report benchmark-relative active return in decimal, percentage, multiplicative, or log form without changing the established normalized `VersusEnterAndHoldCriterion` behavior.
 - **Composable regime and edge primitives**: Added `StretchZScoreIndicator`, `CompressionIndicator`, `TrendScoreIndicator`, `TrendConclusionIndicator`, `EntryEdgeIndicator`, `EdgeDecaySlopeIndicator`, `LossTriggeredCooldownRule`, and `EdgeHealthyRule` so strategies can model stretch, compression, trend state, realized entry edge, edge decay, and post-loss cooldowns with reusable ta4j-native building blocks (`CF-86`).
 - **Rolling advanced correlation indicators**: Added Spearman rank correlation, Kendall tau-b, lag-aware cross-correlation, distance correlation, mutual information, and regime-segmented correlation indicators under `org.ta4j.core.indicators.statistics`, with NaN handling for undefined windows and documentation for choosing the right metric.
 - **Staged rule composition for thesis-based exits**: Added `TriggeredRule` so strategies can keep invalidation and timeout rules active while trigger/delegate stages arm follow-on exits such as trailing stops. Stages support finite or unbounded activation windows, delegate priming, explicit reset rules, and position-change resets for reusable target, timeout, and risk-management workflows.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnCriterion.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Active return between two return criteria.
+ *
+ * <p>
+ * Active return is the arithmetic difference between a primary return and a
+ * benchmark return:
+ *
+ * <pre>
+ * activeReturn = primaryReturn - benchmarkReturn
+ * </pre>
+ *
+ * <p>
+ * Both wrapped criteria must be {@link ReturnCriterion return criteria} and
+ * must expose a {@link ReturnRepresentation}. Their calculated values are
+ * normalized to 0-based rates of return before subtraction, then the active
+ * return is formatted with the configured output representation. A value of
+ * {@code 0.0} in {@link ReturnRepresentation#DECIMAL} or {@code 0.0} in
+ * {@link ReturnRepresentation#PERCENTAGE} means the primary criterion matched
+ * the benchmark criterion. A positive value means outperformance, and a
+ * negative value means underperformance.
+ *
+ * <p>
+ * This criterion measures percentage-point active return. It does not divide by
+ * the benchmark return magnitude. Use {@link VersusEnterAndHoldCriterion} for
+ * the existing normalized enter-and-hold comparison.
+ *
+ * @see ActiveReturnVersusEnterAndHoldCriterion
+ * @see ReturnCriterion
+ * @see ReturnRepresentation
+ * @since 0.22.7
+ */
+public class ActiveReturnCriterion extends AbstractAnalysisCriterion {
+
+    private final AnalysisCriterion primaryCriterion;
+    private final AnalysisCriterion benchmarkCriterion;
+    private final ReturnRepresentation primaryReturnRepresentation;
+    private final ReturnRepresentation benchmarkReturnRepresentation;
+    private final ReturnRepresentation returnRepresentation;
+
+    /**
+     * Constructor with {@link ReturnRepresentation#DECIMAL} output.
+     *
+     * @param primaryCriterion   the return criterion to compare
+     * @param benchmarkCriterion the return benchmark criterion
+     * @throws IllegalArgumentException if either criterion does not expose a
+     *                                  {@link ReturnRepresentation}, or if either
+     *                                  criterion is not a return criterion or is
+     *                                  itself a relative-return criterion
+     * @throws NullPointerException     if either criterion is {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnCriterion(AnalysisCriterion primaryCriterion, AnalysisCriterion benchmarkCriterion) {
+        this(primaryCriterion, benchmarkCriterion, ReturnRepresentation.DECIMAL);
+    }
+
+    /**
+     * Constructor with explicit output representation.
+     *
+     * @param primaryCriterion     the return criterion to compare
+     * @param benchmarkCriterion   the return benchmark criterion
+     * @param returnRepresentation the representation to use for the active-return
+     *                             output
+     * @throws IllegalArgumentException if either criterion does not expose a
+     *                                  {@link ReturnRepresentation}, or if either
+     *                                  criterion is not a return criterion or is
+     *                                  itself a relative-return criterion
+     * @throws NullPointerException     if any argument is {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnCriterion(AnalysisCriterion primaryCriterion, AnalysisCriterion benchmarkCriterion,
+            ReturnRepresentation returnRepresentation) {
+        this.primaryCriterion = Objects.requireNonNull(primaryCriterion, "primaryCriterion");
+        this.benchmarkCriterion = Objects.requireNonNull(benchmarkCriterion, "benchmarkCriterion");
+        this.primaryReturnRepresentation = validateReturnCriterion("primaryCriterion", this.primaryCriterion);
+        this.benchmarkReturnRepresentation = validateReturnCriterion("benchmarkCriterion", this.benchmarkCriterion);
+        this.returnRepresentation = Objects.requireNonNull(returnRepresentation, "returnRepresentation");
+    }
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        Num primaryValue = primaryCriterion.calculate(series, position);
+        Num benchmarkValue = benchmarkCriterion.calculate(series, position);
+        return calculateActiveReturn(primaryValue, benchmarkValue);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        Num primaryValue = primaryCriterion.calculate(series, tradingRecord);
+        Num benchmarkValue = benchmarkCriterion.calculate(series, tradingRecord);
+        return calculateActiveReturn(primaryValue, benchmarkValue);
+    }
+
+    @Override
+    public Optional<ReturnRepresentation> getReturnRepresentation() {
+        return Optional.of(returnRepresentation);
+    }
+
+    /** The higher the active return, the better. */
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    private Num calculateActiveReturn(Num primaryValue, Num benchmarkValue) {
+        Num primaryRate = primaryReturnRepresentation.toRateOfReturn(primaryValue);
+        Num benchmarkRate = benchmarkReturnRepresentation.toRateOfReturn(benchmarkValue);
+        Num activeReturn = primaryRate.minus(benchmarkRate);
+        return returnRepresentation.toRepresentationFromRateOfReturn(activeReturn);
+    }
+
+    private static ReturnRepresentation validateReturnCriterion(String role, AnalysisCriterion criterion) {
+        rejectRelativeReturnCriterion(role, criterion);
+        if (!isReturnCriterion(criterion)) {
+            throw new IllegalArgumentException(role + " must be a ReturnCriterion.");
+        }
+        Optional<ReturnRepresentation> representation = getReturnRepresentation(criterion);
+        if (representation.isEmpty()) {
+            throw new IllegalArgumentException(role + " must expose a ReturnRepresentation.");
+        }
+        return representation.get();
+    }
+
+    private static boolean isReturnCriterion(AnalysisCriterion criterion) {
+        if (criterion instanceof ReturnCriterion) {
+            return true;
+        }
+        if (criterion instanceof EnterAndHoldCriterion) {
+            return isReturnCriterion(((EnterAndHoldCriterion) criterion).getCriterion());
+        }
+        return false;
+    }
+
+    private static void rejectRelativeReturnCriterion(String role, AnalysisCriterion criterion) {
+        if (criterion instanceof ActiveReturnCriterion) {
+            throw new IllegalArgumentException(role + " cannot be an instance of ActiveReturnCriterion.");
+        }
+        if (criterion instanceof ActiveReturnVersusEnterAndHoldCriterion) {
+            throw new IllegalArgumentException(
+                    role + " cannot be an instance of ActiveReturnVersusEnterAndHoldCriterion.");
+        }
+        if (criterion instanceof VersusEnterAndHoldCriterion) {
+            throw new IllegalArgumentException(role + " cannot be an instance of VersusEnterAndHoldCriterion.");
+        }
+    }
+
+    private static Optional<ReturnRepresentation> getReturnRepresentation(AnalysisCriterion criterion) {
+        if (criterion instanceof AbstractAnalysisCriterion) {
+            AbstractAnalysisCriterion abstractCriterion = (AbstractAnalysisCriterion) criterion;
+            return abstractCriterion.getReturnRepresentation();
+        }
+        return Optional.empty();
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnCriterion.java
@@ -34,9 +34,23 @@ import java.util.Optional;
  * negative value means underperformance.
  *
  * <p>
- * This criterion measures percentage-point active return. It does not divide by
- * the benchmark return magnitude. Use {@link VersusEnterAndHoldCriterion} for
- * the existing normalized enter-and-hold comparison.
+ * <b>When to use:</b> Use this criterion when the question is "how many return
+ * percentage points did the primary criterion add or lose versus the
+ * benchmark?" This is the common active-return interpretation used for
+ * benchmark-relative performance reporting: a strategy return of {@code 15%}
+ * versus a benchmark return of {@code 10%} produces {@code +5} percentage
+ * points of active return. It is also useful when the benchmark can be any
+ * return criterion, not only an enter-and-hold benchmark.
+ *
+ * <p>
+ * This differs from {@link VersusEnterAndHoldCriterion}, which answers "how
+ * large is the outperformance relative to the absolute enter-and-hold return?"
+ * by dividing the return difference by the benchmark return magnitude. That
+ * normalized ratio can be useful when you specifically want a multiple of the
+ * enter-and-hold return, but it can become large or hard to interpret when the
+ * benchmark return is small, zero, or negative. Use this criterion when you
+ * want the additive return spread; use {@link VersusEnterAndHoldCriterion} when
+ * you want the existing normalized enter-and-hold comparison.
  *
  * @see ActiveReturnVersusEnterAndHoldCriterion
  * @see ReturnCriterion

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnVersusEnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ActiveReturnVersusEnterAndHoldCriterion.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.num.Num;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Active return versus an enter-and-hold benchmark.
+ *
+ * <p>
+ * This criterion compares a strategy {@link ReturnCriterion return criterion}
+ * to the same criterion calculated over an {@link EnterAndHoldCriterion}. The
+ * result is the percentage-point active return:
+ *
+ * <pre>
+ * activeReturn = strategyReturn - enterAndHoldReturn
+ * </pre>
+ *
+ * <p>
+ * A value of {@code 0.0} in {@link ReturnRepresentation#DECIMAL} or {@code 0.0}
+ * in {@link ReturnRepresentation#PERCENTAGE} means the strategy matched
+ * enter-and-hold. A positive value means the strategy outperformed
+ * enter-and-hold, and a negative value means it underperformed.
+ * <p>
+ * <b>Examples:</b>
+ * <ul>
+ * <li>If the strategy returns {@code 15.5%} and enter-and-hold returns
+ * {@code 5.0%}, the active return is {@code 10.5} percentage points.
+ * {@link ReturnRepresentation#PERCENTAGE} returns {@code 10.5},
+ * {@link ReturnRepresentation#DECIMAL} returns {@code 0.105}, and
+ * {@link ReturnRepresentation#MULTIPLICATIVE} returns {@code 1.105}.
+ * <li>If the strategy returns {@code -33.5%} and enter-and-hold returns
+ * {@code -30.0%}, the active return is {@code -3.5} percentage points.
+ * {@link ReturnRepresentation#PERCENTAGE} returns {@code -3.5},
+ * {@link ReturnRepresentation#DECIMAL} returns {@code -0.035}, and
+ * {@link ReturnRepresentation#MULTIPLICATIVE} returns {@code 0.965}.
+ * <li>If both the strategy and enter-and-hold return {@code 5.0%}, the active
+ * return is parity. {@link ReturnRepresentation#PERCENTAGE} and
+ * {@link ReturnRepresentation#DECIMAL} return {@code 0.0}, while
+ * {@link ReturnRepresentation#MULTIPLICATIVE} returns {@code 1.0}.
+ * </ul>
+ *
+ * <p>
+ * This criterion delegates the active-return calculation to
+ * {@link ActiveReturnCriterion}. It intentionally differs from
+ * {@link VersusEnterAndHoldCriterion}, which divides the difference by the
+ * absolute enter-and-hold return.
+ *
+ * @see ActiveReturnCriterion
+ * @see EnterAndHoldCriterion
+ * @see VersusEnterAndHoldCriterion
+ * @since 0.22.7
+ */
+public class ActiveReturnVersusEnterAndHoldCriterion extends AbstractAnalysisCriterion {
+
+    private final ActiveReturnCriterion activeReturnCriterion;
+    private final ReturnRepresentation returnRepresentation;
+
+    /**
+     * Constructor with a buy-and-hold benchmark, an entry amount of {@code 1}, and
+     * {@link ReturnRepresentation#DECIMAL} output.
+     *
+     * @param criterion the return criterion to compare to enter-and-hold
+     * @throws IllegalArgumentException if {@code criterion} does not expose a
+     *                                  {@link ReturnRepresentation}, is not a
+     *                                  {@link ReturnCriterion}, or is itself a
+     *                                  relative-return criterion
+     * @throws NullPointerException     if {@code criterion} is {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnVersusEnterAndHoldCriterion(AnalysisCriterion criterion) {
+        this(TradeType.BUY, criterion);
+    }
+
+    /**
+     * Constructor with an entry amount of {@code 1} and
+     * {@link ReturnRepresentation#DECIMAL} output.
+     *
+     * @param tradeType the {@link TradeType} used to open the benchmark position
+     * @param criterion the return criterion to compare to enter-and-hold
+     * @throws IllegalArgumentException if {@code criterion} does not expose a
+     *                                  {@link ReturnRepresentation}, is not a
+     *                                  {@link ReturnCriterion}, or is itself a
+     *                                  relative-return criterion
+     * @throws NullPointerException     if {@code tradeType} or {@code criterion} is
+     *                                  {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnVersusEnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion) {
+        this(tradeType, criterion, BigDecimal.ONE);
+    }
+
+    /**
+     * Constructor with {@link ReturnRepresentation#DECIMAL} output.
+     *
+     * @param tradeType the {@link TradeType} used to open the benchmark position
+     * @param criterion the return criterion to compare to enter-and-hold
+     * @param amount    the amount to use for the benchmark position
+     * @throws IllegalArgumentException if {@code criterion} does not expose a
+     *                                  {@link ReturnRepresentation}, is not a
+     *                                  {@link ReturnCriterion}, or is itself a
+     *                                  relative-return criterion
+     * @throws NullPointerException     if any argument is {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnVersusEnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion,
+            BigDecimal amount) {
+        this(tradeType, criterion, amount, ReturnRepresentation.DECIMAL);
+    }
+
+    /**
+     * Constructor with explicit output representation.
+     *
+     * @param tradeType            the {@link TradeType} used to open the benchmark
+     *                             position
+     * @param criterion            the return criterion to compare to enter-and-hold
+     * @param amount               the amount to use for the benchmark position
+     * @param returnRepresentation the representation to use for the active-return
+     *                             output
+     * @throws IllegalArgumentException if {@code criterion} does not expose a
+     *                                  {@link ReturnRepresentation}, is not a
+     *                                  {@link ReturnCriterion}, or is itself a
+     *                                  relative-return criterion
+     * @throws NullPointerException     if any argument is {@code null}
+     * @since 0.22.7
+     */
+    public ActiveReturnVersusEnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion, BigDecimal amount,
+            ReturnRepresentation returnRepresentation) {
+        Objects.requireNonNull(tradeType, "tradeType");
+        Objects.requireNonNull(criterion, "criterion");
+        Objects.requireNonNull(amount, "amount");
+        Objects.requireNonNull(returnRepresentation, "returnRepresentation");
+
+        EnterAndHoldCriterion enterAndHoldCriterion = new EnterAndHoldCriterion(tradeType, criterion, amount);
+        this.activeReturnCriterion = new ActiveReturnCriterion(criterion, enterAndHoldCriterion, returnRepresentation);
+        this.returnRepresentation = returnRepresentation;
+    }
+
+    @Override
+    public Num calculate(BarSeries series, Position position) {
+        if (series.isEmpty()) {
+            return returnRepresentation.toRepresentationFromRateOfReturn(series.numFactory().zero());
+        }
+        return activeReturnCriterion.calculate(series, position);
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+        if (series.isEmpty()) {
+            return returnRepresentation.toRepresentationFromRateOfReturn(series.numFactory().zero());
+        }
+        return activeReturnCriterion.calculate(series, tradingRecord);
+    }
+
+    @Override
+    public Optional<ReturnRepresentation> getReturnRepresentation() {
+        return activeReturnCriterion.getReturnRepresentation();
+    }
+
+    /** The higher the active return, the better. */
+    @Override
+    public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+        return activeReturnCriterion.betterThan(criterionValue1, criterionValue2);
+    }
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/AverageReturnPerBarCriterion.java
@@ -26,7 +26,7 @@ import org.ta4j.core.num.NumFactory;
  * AverageReturnPerBar = pow({@link NetReturnCriterion net return}, 1/ {@link NumberOfBarsCriterion number of bars})
  * </pre>
  */
-public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion {
+public class AverageReturnPerBarCriterion extends AbstractAnalysisCriterion implements ReturnCriterion {
 
     private final NetReturnCriterion netReturn;
     private final ReturnRepresentation returnRepresentation;

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
@@ -58,9 +58,8 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      * Constructor for buy-and-hold strategy with an {@link #amount} of {@code 1}.
      *
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
-     * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or another
-     *                                  enter-and-hold relative criterion
+     * @throws IllegalArgumentException if {@code criterion} is itself an
+     *                                  enter-and-hold or relative-return criterion
      */
     public EnterAndHoldCriterion(AnalysisCriterion criterion) {
         this(TradeType.BUY, criterion);
@@ -71,9 +70,8 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      *
      * @param tradeType the {@link TradeType} used to open the position
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
-     * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or another
-     *                                  enter-and-hold relative criterion
+     * @throws IllegalArgumentException if {@code criterion} is itself an
+     *                                  enter-and-hold or relative-return criterion
      */
     public EnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion) {
         this(tradeType, criterion, BigDecimal.ONE);
@@ -85,9 +83,8 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      * @param tradeType the {@link TradeType} used to open the position
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
      * @param amount    the amount to be used to hold the entry position
-     * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or another
-     *                                  enter-and-hold relative criterion
+     * @throws IllegalArgumentException if {@code criterion} is itself an
+     *                                  enter-and-hold or relative-return criterion
      * @throws NullPointerException     if {@code amount} is {@code null}
      */
     public EnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion, BigDecimal amount) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/EnterAndHoldCriterion.java
@@ -59,8 +59,8 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      *
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
      * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or
-     *                                  {@code VersusEnterAndHoldCriterion}
+     *                                  {@code EnterAndHoldCriterion} or another
+     *                                  enter-and-hold relative criterion
      */
     public EnterAndHoldCriterion(AnalysisCriterion criterion) {
         this(TradeType.BUY, criterion);
@@ -72,8 +72,8 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      * @param tradeType the {@link TradeType} used to open the position
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
      * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or
-     *                                  {@code VersusEnterAndHoldCriterion}
+     *                                  {@code EnterAndHoldCriterion} or another
+     *                                  enter-and-hold relative criterion
      */
     public EnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion) {
         this(tradeType, criterion, BigDecimal.ONE);
@@ -86,13 +86,20 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
      * @param criterion the {@link AnalysisCriterion criterion} to calculate
      * @param amount    the amount to be used to hold the entry position
      * @throws IllegalArgumentException if {@code criterion} is an instance of
-     *                                  {@code EnterAndHoldCriterion} or
-     *                                  {@code VersusEnterAndHoldCriterion}
+     *                                  {@code EnterAndHoldCriterion} or another
+     *                                  enter-and-hold relative criterion
      * @throws NullPointerException     if {@code amount} is {@code null}
      */
     public EnterAndHoldCriterion(TradeType tradeType, AnalysisCriterion criterion, BigDecimal amount) {
         if (criterion instanceof EnterAndHoldCriterion) {
             throw new IllegalArgumentException("Criterion cannot be an instance of EnterAndHoldCriterion.");
+        }
+        if (criterion instanceof ActiveReturnCriterion) {
+            throw new IllegalArgumentException("Criterion cannot be an instance of ActiveReturnCriterion.");
+        }
+        if (criterion instanceof ActiveReturnVersusEnterAndHoldCriterion) {
+            throw new IllegalArgumentException(
+                    "Criterion cannot be an instance of ActiveReturnVersusEnterAndHoldCriterion.");
         }
         if (criterion instanceof VersusEnterAndHoldCriterion) {
             throw new IllegalArgumentException("Criterion cannot be an instance of VersusEnterAndHoldCriterion.");
@@ -128,6 +135,10 @@ public class EnterAndHoldCriterion extends AbstractAnalysisCriterion {
             return ((AbstractAnalysisCriterion) criterion).getReturnRepresentation();
         }
         return Optional.empty();
+    }
+
+    AnalysisCriterion getCriterion() {
+        return criterion;
     }
 
     private Position createEnterAndHoldTrade(BarSeries series, int beginIndex, int endIndex) {

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/ReturnCriterion.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import org.ta4j.core.AnalysisCriterion;
+
+/**
+ * Marker for criteria whose values are actual strategy or position returns.
+ *
+ * <p>
+ * Implementations represent a return using {@link ReturnRepresentation}.
+ * Criteria that expose {@link ReturnRepresentation} only to format ratios, hit
+ * rates, exposure percentages, risk measures, or other non-return quantities
+ * should not implement this interface.
+ *
+ * <p>
+ * {@link ActiveReturnCriterion} uses this marker, together with
+ * {@link AbstractAnalysisCriterion#getReturnRepresentation()}, to reject
+ * represented non-return ratios at construction time.
+ *
+ * @since 0.22.7
+ */
+public interface ReturnCriterion extends AnalysisCriterion {
+}

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/package-info.java
@@ -31,6 +31,13 @@
  * be changed globally via {@link ReturnRepresentationPolicy} or per-criterion
  * by passing a {@link ReturnRepresentation} to the criterion constructor.
  * <p>
+ * <b>Active-return criteria</b> (e.g., {@link ActiveReturnCriterion} and
+ * {@link ActiveReturnVersusEnterAndHoldCriterion}) normalize two
+ * {@link ReturnCriterion return criteria} to 0-based rates, subtract the
+ * benchmark rate from the primary rate, and default to <em>decimal</em>
+ * representation. Parity is {@code 0.0} in DECIMAL/PERCENTAGE output and
+ * {@code 1.0} in MULTIPLICATIVE output.
+ * <p>
  * <b>Ratio-producing criteria</b> (e.g., {@link VersusEnterAndHoldCriterion},
  * {@link org.ta4j.core.criteria.drawdown.ReturnOverMaxDrawdownCriterion},
  * {@link PositionsRatioCriterion}) default to <em>decimal</em> representation

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractProfitLossPercentageCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractProfitLossPercentageCriterion.java
@@ -10,6 +10,7 @@ import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.criteria.ReturnCriterion;
 import org.ta4j.core.criteria.ReturnRepresentation;
 import org.ta4j.core.criteria.ReturnRepresentationPolicy;
 import org.ta4j.core.num.Num;
@@ -24,7 +25,8 @@ import org.ta4j.core.num.NumFactory;
  * neutral value of {@code 0.0}). The representation is applied before values
  * are returned to callers.
  */
-public abstract class AbstractProfitLossPercentageCriterion extends AbstractAnalysisCriterion {
+public abstract class AbstractProfitLossPercentageCriterion extends AbstractAnalysisCriterion
+        implements ReturnCriterion {
 
     /**
      * Output representation used for this criterion.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractReturnCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/pnl/AbstractReturnCriterion.java
@@ -7,6 +7,7 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.criteria.AbstractAnalysisCriterion;
+import org.ta4j.core.criteria.ReturnCriterion;
 import org.ta4j.core.criteria.ReturnRepresentation;
 import org.ta4j.core.criteria.ReturnRepresentationPolicy;
 import org.ta4j.core.num.Num;
@@ -22,7 +23,7 @@ import java.util.Optional;
  * with total returns (a neutral value of {@code 1.0}). The representation is
  * applied before values are returned to callers.
  */
-public abstract class AbstractReturnCriterion extends AbstractAnalysisCriterion {
+public abstract class AbstractReturnCriterion extends AbstractAnalysisCriterion implements ReturnCriterion {
 
     /**
      * Output representation used for this criterion.

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ActiveReturnCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ActiveReturnCriterionTest.java
@@ -1,0 +1,279 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.criteria.commissions.CommissionsImpactPercentageCriterion;
+import org.ta4j.core.criteria.drawdown.ReturnOverMaxDrawdownCriterion;
+import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+public class ActiveReturnCriterionTest extends AbstractCriterionTest {
+
+    public ActiveReturnCriterionTest(NumFactory numFactory) {
+        super(params -> params.length == 2
+                ? new ActiveReturnCriterion((AnalysisCriterion) params[0], (AnalysisCriterion) params[1])
+                : new ActiveReturnCriterion((AnalysisCriterion) params[0], (AnalysisCriterion) params[1],
+                        (ReturnRepresentation) params[2]),
+                numFactory);
+    }
+
+    @Test
+    public void calculatesTradingRecordActiveReturnFromMixedInputRepresentations() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 105).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(15.5, ReturnRepresentation.PERCENTAGE);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(10.5, criterion.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void formatsOutputRepresentationFromActiveRate() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 105).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(0.155, ReturnRepresentation.DECIMAL);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion decimal = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.DECIMAL);
+        ActiveReturnCriterion percentage = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+        ActiveReturnCriterion multiplicative = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.MULTIPLICATIVE);
+        ActiveReturnCriterion log = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.LOG);
+
+        assertNumEquals(0.105, decimal.calculate(series, tradingRecord));
+        assertNumEquals(10.5, percentage.calculate(series, tradingRecord));
+        assertNumEquals(1.105, multiplicative.calculate(series, tradingRecord));
+        assertNumEquals(Math.log(1.105), log.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculatesNegativeActiveReturnWithoutBenchmarkMagnitudeNormalization() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(-33.5, ReturnRepresentation.PERCENTAGE);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(-0.30, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(-3.5, criterion.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void convertsLogInputRepresentationBeforeSubtractingBenchmark() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 112).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(Math.log(1.12), ReturnRepresentation.LOG);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(5.0, ReturnRepresentation.PERCENTAGE);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(7.0, criterion.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculatesPositionActiveReturn() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 110).build();
+        Position position = new Position();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(0.20, ReturnRepresentation.DECIMAL);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(0.10, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(10.0, criterion.calculate(series, position));
+    }
+
+    @Test
+    public void returnsNeutralValueWhenPrimaryAndBenchmarkMatch() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 105).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(5.0, ReturnRepresentation.PERCENTAGE);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion decimal = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.DECIMAL);
+        ActiveReturnCriterion percentage = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.PERCENTAGE);
+        ActiveReturnCriterion multiplicative = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.MULTIPLICATIVE);
+        ActiveReturnCriterion log = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion,
+                ReturnRepresentation.LOG);
+
+        assertNumEquals(0.0, decimal.calculate(series, tradingRecord));
+        assertNumEquals(0.0, percentage.calculate(series, tradingRecord));
+        assertNumEquals(1.0, multiplicative.calculate(series, tradingRecord));
+        assertNumEquals(0.0, log.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void defaultsToDecimalOutputRepresentation() {
+        AnalysisCriterion primaryCriterion = new ConstantReturnCriterion(0.12, ReturnRepresentation.DECIMAL);
+        AnalysisCriterion benchmarkCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(primaryCriterion, benchmarkCriterion);
+
+        assertTrue(criterion.getReturnRepresentation().isPresent());
+        assertEquals(ReturnRepresentation.DECIMAL, criterion.getReturnRepresentation().get());
+    }
+
+    @Test
+    public void rejectsCriteriaWithoutReturnRepresentation() {
+        AnalysisCriterion returnCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(new NumberOfBarsCriterion(), returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(returnCriterion, new NumberOfBarsCriterion()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(new PlainReturnlessCriterion(), returnCriterion));
+    }
+
+    @Test
+    public void rejectsRepresentedNonReturnCriteria() {
+        AnalysisCriterion returnCriterion = new GrossReturnCriterion(ReturnRepresentation.DECIMAL);
+
+        assertThrows(IllegalArgumentException.class, () -> new ActiveReturnCriterion(
+                new PositionsRatioCriterion(AnalysisCriterion.PositionFilter.PROFIT, ReturnRepresentation.DECIMAL),
+                returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(new InPositionPercentageCriterion(ReturnRepresentation.DECIMAL),
+                        returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(new CommissionsImpactPercentageCriterion(ReturnRepresentation.DECIMAL),
+                        returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(new ReturnOverMaxDrawdownCriterion(ReturnRepresentation.DECIMAL),
+                        returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(
+                        new EnterAndHoldCriterion(TradeType.BUY, new PositionsRatioCriterion(
+                                AnalysisCriterion.PositionFilter.PROFIT, ReturnRepresentation.DECIMAL), BigDecimal.ONE),
+                        returnCriterion));
+    }
+
+    @Test
+    public void acceptsEnterAndHoldWhenWrappedCriterionIsReturnCriterion() {
+        AnalysisCriterion returnCriterion = new GrossReturnCriterion(ReturnRepresentation.DECIMAL);
+        AnalysisCriterion enterAndHoldCriterion = new EnterAndHoldCriterion(TradeType.BUY, returnCriterion,
+                BigDecimal.ONE);
+
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(returnCriterion, enterAndHoldCriterion,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertEquals(ReturnRepresentation.PERCENTAGE, criterion.getReturnRepresentation().get());
+    }
+
+    @Test
+    public void rejectsRelativeCriteriaAsInputs() {
+        AnalysisCriterion returnCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+        ActiveReturnCriterion activeReturn = new ActiveReturnCriterion(returnCriterion, returnCriterion);
+        VersusEnterAndHoldCriterion versusEnterAndHold = new VersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.DECIMAL), BigDecimal.ONE, ReturnRepresentation.DECIMAL);
+        ActiveReturnVersusEnterAndHoldCriterion activeReturnVersusEnterAndHold = new ActiveReturnVersusEnterAndHoldCriterion(
+                TradeType.BUY, new GrossReturnCriterion(ReturnRepresentation.DECIMAL), BigDecimal.ONE,
+                ReturnRepresentation.DECIMAL);
+
+        assertThrows(IllegalArgumentException.class, () -> new ActiveReturnCriterion(activeReturn, returnCriterion));
+        assertThrows(IllegalArgumentException.class, () -> new ActiveReturnCriterion(returnCriterion, activeReturn));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(versusEnterAndHold, returnCriterion));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ActiveReturnCriterion(returnCriterion, activeReturnVersusEnterAndHold));
+    }
+
+    @Test
+    public void rejectsNullConstructorArguments() {
+        AnalysisCriterion returnCriterion = new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL);
+
+        assertThrows(NullPointerException.class, () -> new ActiveReturnCriterion(null, returnCriterion));
+        assertThrows(NullPointerException.class, () -> new ActiveReturnCriterion(returnCriterion, null));
+        assertThrows(NullPointerException.class,
+                () -> new ActiveReturnCriterion(returnCriterion, returnCriterion, null));
+    }
+
+    @Test
+    public void betterThanUsesHigherActiveReturn() {
+        ActiveReturnCriterion criterion = new ActiveReturnCriterion(
+                new ConstantReturnCriterion(0.10, ReturnRepresentation.DECIMAL),
+                new ConstantReturnCriterion(0.05, ReturnRepresentation.DECIMAL));
+
+        assertTrue(criterion.betterThan(numOf(0.10), numOf(0.05)));
+        assertFalse(criterion.betterThan(numOf(0.05), numOf(0.10)));
+    }
+
+    private static final class ConstantReturnCriterion extends AbstractAnalysisCriterion implements ReturnCriterion {
+
+        private final double value;
+        private final ReturnRepresentation returnRepresentation;
+
+        private ConstantReturnCriterion(double value, ReturnRepresentation returnRepresentation) {
+            this.value = value;
+            this.returnRepresentation = returnRepresentation;
+        }
+
+        @Override
+        public Num calculate(BarSeries series, Position position) {
+            return series.numFactory().numOf(value);
+        }
+
+        @Override
+        public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+            return series.numFactory().numOf(value);
+        }
+
+        @Override
+        public Optional<ReturnRepresentation> getReturnRepresentation() {
+            return Optional.of(returnRepresentation);
+        }
+
+        @Override
+        public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+            return criterionValue1.isGreaterThan(criterionValue2);
+        }
+    }
+
+    private static final class PlainReturnlessCriterion implements AnalysisCriterion {
+
+        @Override
+        public Num calculate(BarSeries series, Position position) {
+            return series.numFactory().zero();
+        }
+
+        @Override
+        public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+            return series.numFactory().zero();
+        }
+
+        @Override
+        public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+            return criterionValue1.isGreaterThan(criterionValue2);
+        }
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/ActiveReturnVersusEnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/ActiveReturnVersusEnterAndHoldCriterionTest.java
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.criteria;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.ta4j.core.TestUtils.assertNumEquals;
+
+import org.junit.Test;
+import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BaseTradingRecord;
+import org.ta4j.core.Position;
+import org.ta4j.core.Trade;
+import org.ta4j.core.Trade.TradeType;
+import org.ta4j.core.criteria.pnl.GrossReturnCriterion;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.NumFactory;
+
+import java.math.BigDecimal;
+
+public class ActiveReturnVersusEnterAndHoldCriterionTest extends AbstractCriterionTest {
+
+    public ActiveReturnVersusEnterAndHoldCriterionTest(NumFactory numFactory) {
+        super(params -> params.length == 1 ? new ActiveReturnVersusEnterAndHoldCriterion((AnalysisCriterion) params[0])
+                : new ActiveReturnVersusEnterAndHoldCriterion((TradeType) params[0], (AnalysisCriterion) params[1]),
+                numFactory);
+    }
+
+    @Test
+    public void calculatesTradingRecordActiveReturnVersusBuyAndHold() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 110, 100, 95, 105)
+                .build();
+        var tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
+                Trade.buyAt(3, series), Trade.sellAt(5, series));
+
+        ActiveReturnVersusEnterAndHoldCriterion decimal = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.DECIMAL), BigDecimal.ONE, ReturnRepresentation.DECIMAL);
+        ActiveReturnVersusEnterAndHoldCriterion percentage = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+        ActiveReturnVersusEnterAndHoldCriterion multiplicative = new ActiveReturnVersusEnterAndHoldCriterion(
+                TradeType.BUY, new GrossReturnCriterion(ReturnRepresentation.MULTIPLICATIVE), BigDecimal.ONE,
+                ReturnRepresentation.MULTIPLICATIVE);
+
+        assertNumEquals(0.105, decimal.calculate(series, tradingRecord));
+        assertNumEquals(10.5, percentage.calculate(series, tradingRecord));
+        assertNumEquals(1.105, multiplicative.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculatesNegativeActiveReturnWithoutBenchmarkMagnitudeNormalization() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95, 100, 80, 85, 70).build();
+        var tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(1, series),
+                Trade.buyAt(2, series), Trade.sellAt(5, series));
+
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(-3.5, criterion.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculatesPositionActiveReturnVersusBuyAndHold() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95, 100, 80, 85, 70).build();
+        var position = new Position(Trade.buyAt(0, series), Trade.sellAt(1, series));
+
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(25.0, criterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculatesActiveReturnWithNoPositions() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95, 100, 80, 85, 70).build();
+
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(30.0, criterion.calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void calculatesNeutralActiveReturnWithEmptySeries() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        var tradingRecord = new BaseTradingRecord();
+        var position = new Position();
+
+        ActiveReturnVersusEnterAndHoldCriterion decimal = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.DECIMAL), BigDecimal.ONE, ReturnRepresentation.DECIMAL);
+        ActiveReturnVersusEnterAndHoldCriterion percentage = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+        ActiveReturnVersusEnterAndHoldCriterion multiplicative = new ActiveReturnVersusEnterAndHoldCriterion(
+                TradeType.BUY, new GrossReturnCriterion(ReturnRepresentation.MULTIPLICATIVE), BigDecimal.ONE,
+                ReturnRepresentation.MULTIPLICATIVE);
+
+        assertNumEquals(0.0, decimal.calculate(series, tradingRecord));
+        assertNumEquals(0.0, percentage.calculate(series, tradingRecord));
+        assertNumEquals(1.0, multiplicative.calculate(series, tradingRecord));
+        assertNumEquals(0.0, decimal.calculate(series, position));
+    }
+
+    @Test
+    public void supportsSellAndHoldBenchmark() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(100, 95, 100, 80, 85, 70).build();
+
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.SELL,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertNumEquals(-30.0, criterion.calculate(series, new BaseTradingRecord()));
+    }
+
+    @Test
+    public void defaultsToDecimalOutputRepresentation() {
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE);
+
+        assertTrue(criterion.getReturnRepresentation().isPresent());
+        assertEquals(ReturnRepresentation.DECIMAL, criterion.getReturnRepresentation().get());
+    }
+
+    @Test
+    public void shortConstructorsDefaultToDecimalOutputRepresentation() {
+        ActiveReturnVersusEnterAndHoldCriterion buyAndHold = new ActiveReturnVersusEnterAndHoldCriterion(
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE));
+        ActiveReturnVersusEnterAndHoldCriterion sellAndHold = new ActiveReturnVersusEnterAndHoldCriterion(
+                TradeType.SELL, new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE));
+
+        assertTrue(buyAndHold.getReturnRepresentation().isPresent());
+        assertEquals(ReturnRepresentation.DECIMAL, buyAndHold.getReturnRepresentation().get());
+        assertTrue(sellAndHold.getReturnRepresentation().isPresent());
+        assertEquals(ReturnRepresentation.DECIMAL, sellAndHold.getReturnRepresentation().get());
+    }
+
+    @Test
+    public void rejectsCriteriaWithoutReturnRepresentation() {
+        assertThrows(IllegalArgumentException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new NumberOfBarsCriterion(), BigDecimal.ONE, ReturnRepresentation.DECIMAL));
+    }
+
+    @Test
+    public void rejectsRepresentedNonReturnCriteria() {
+        assertThrows(IllegalArgumentException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new PositionsRatioCriterion(AnalysisCriterion.PositionFilter.PROFIT, ReturnRepresentation.DECIMAL),
+                BigDecimal.ONE, ReturnRepresentation.DECIMAL));
+    }
+
+    @Test
+    public void rejectsNullConstructorArguments() {
+        AnalysisCriterion returnCriterion = new GrossReturnCriterion(ReturnRepresentation.DECIMAL);
+
+        assertThrows(NullPointerException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(null,
+                returnCriterion, BigDecimal.ONE, ReturnRepresentation.DECIMAL));
+        assertThrows(NullPointerException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY, null,
+                BigDecimal.ONE, ReturnRepresentation.DECIMAL));
+        assertThrows(NullPointerException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                returnCriterion, null, ReturnRepresentation.DECIMAL));
+        assertThrows(NullPointerException.class, () -> new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                returnCriterion, BigDecimal.ONE, null));
+    }
+
+    @Test
+    public void betterThanUsesHigherActiveReturn() {
+        ActiveReturnVersusEnterAndHoldCriterion criterion = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY,
+                new GrossReturnCriterion(ReturnRepresentation.PERCENTAGE), BigDecimal.ONE,
+                ReturnRepresentation.PERCENTAGE);
+
+        assertTrue(criterion.betterThan(numOf(10.0), numOf(5.0)));
+        assertFalse(criterion.betterThan(numOf(5.0), numOf(10.0)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/EnterAndHoldCriterionTest.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -360,6 +361,17 @@ public class EnterAndHoldCriterionTest extends AbstractCriterionTest {
 
         EnterAndHoldCriterion criterionWithoutRepresentation = new EnterAndHoldCriterion(new NumberOfBarsCriterion());
         assertFalse(criterionWithoutRepresentation.getReturnRepresentation().isPresent());
+    }
+
+    @Test
+    public void rejectsRelativeActiveReturnCriteria() {
+        var returnCriterion = new GrossReturnCriterion(ReturnRepresentation.DECIMAL);
+        var activeReturn = new ActiveReturnCriterion(returnCriterion, returnCriterion);
+        var activeReturnVersusEnterAndHold = new ActiveReturnVersusEnterAndHoldCriterion(TradeType.BUY, returnCriterion,
+                BigDecimal.ONE, ReturnRepresentation.DECIMAL);
+
+        assertThrows(IllegalArgumentException.class, () -> new EnterAndHoldCriterion(activeReturn));
+        assertThrows(IllegalArgumentException.class, () -> new EnterAndHoldCriterion(activeReturnVersusEnterAndHold));
     }
 
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `ActiveReturnCriterion` for active return between two return criteria.
- Add `ActiveReturnVersusEnterAndHoldCriterion` for percentage-point active return against enter-and-hold.
- Add `ReturnCriterion` so active-return APIs reject represented non-return ratios, with Javadocs, CHANGELOG coverage, and regression tests.

- [x] I ran the repo-required full verification gate: `scripts/run-full-build-quiet.sh` (6537 tests, 0 failures, 0 errors, 16 skipped)
- [x] I ran `mvn -pl ta4j-core formatter:format`
- [x] I have added an entry to the appropriate unreleased section of `CHANGELOG.md`