### PR TITLE
Harden release scheduler AI diagnostics

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -558,7 +558,10 @@ jobs:
             printf '%s\n' "$fallback"
             echo "$delim"
           } >> $GITHUB_OUTPUT
-          echo "::error::$err_msg"
+          error_annotation="${err_msg//'%'/'%25'}"
+          error_annotation="${error_annotation//$'\r'/'%0D'}"
+          error_annotation="${error_annotation//$'\n'/'%0A'}"
+          echo "::error::$error_annotation"
           exit 1
 
       - name: Extract AI response content

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -23,6 +23,15 @@ on:
         required: false
         default: true
         type: boolean
+      aiMode:
+        description: "AI execution mode: probe sends a tiny request; full sends the release dossier; skip avoids GitHub Models"
+        required: false
+        default: probe
+        type: choice
+        options:
+          - probe
+          - full
+          - skip
 
 permissions:
   contents: write
@@ -41,13 +50,14 @@ jobs:
       reason: ${{ steps.parsed.outputs.reason }}
       warning: ${{ steps.parsed.outputs.warning }}
       dryRun: ${{ steps.run_meta.outputs.dryRun }}
+      ai_mode: ${{ steps.ai_mode.outputs.mode }}
       binary_lines: ${{ steps.diff.outputs.lines }}
       binary_changes: ${{ steps.diff.outputs.binary_changes }}
       changelog_len: ${{ steps.changelog.outputs.length }}
       gate_proceed: ${{ steps.gate.outputs.proceed }}
       token_present: ${{ steps.model_token.outputs.present }}
       token_gate: ${{ steps.token_gate.outputs.proceed }}
-      model: ${{ steps.model_catalog.outputs.model_id }}
+      model: ${{ steps.model_config.outputs.model_id }}
       model_max_input_tokens: ${{ steps.model_catalog.outputs.model_max_input_tokens }}
       model_max_output_tokens: ${{ steps.model_catalog.outputs.model_max_output_tokens }}
       dossier_chars: ${{ steps.build_request.outputs.dossier_chars }}
@@ -121,6 +131,48 @@ jobs:
           echo "audit:dry_run_input_raw='${raw}'"
           echo "audit:dry_run_normalized=$dry_run"
           echo "dryRun=$dry_run" >> $GITHUB_OUTPUT
+
+      - name: Resolve AI execution mode
+        id: ai_mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          AI_MODE_INPUT: ${{ github.event.inputs.aiMode }}
+        run: |
+          set -euo pipefail
+          event="${EVENT_NAME:-}"
+          if [ "$event" = "workflow_dispatch" ]; then
+            raw="${AI_MODE_INPUT:-probe}"
+          else
+            raw="full"
+          fi
+
+          normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')
+          case "$normalized" in
+            full|probe|skip) mode="$normalized" ;;
+            "") mode="probe" ;;
+            *)
+              echo "Unsupported aiMode '$raw'. Expected one of: full, probe, skip." >&2
+              exit 1
+              ;;
+          esac
+
+          echo "audit:ai_mode_input_raw='${raw}'"
+          echo "audit:ai_mode_normalized=$mode"
+          echo "mode=$mode" >> $GITHUB_OUTPUT
+
+      - name: Resolve AI model
+        id: model_config
+        env:
+          RELEASE_AI_MODEL: ${{ vars.RELEASE_AI_MODEL }}
+        run: |
+          set -euo pipefail
+          model="${RELEASE_AI_MODEL:-openai/gpt-4.1}"
+          if [ -z "$model" ]; then
+            echo "RELEASE_AI_MODEL resolved to an empty value." >&2
+            exit 1
+          fi
+          echo "audit:model_config model=$model"
+          echo "model_id=$model" >> $GITHUB_OUTPUT
 
       - name: Read version from pom.xml
         id: pom_version
@@ -270,9 +322,13 @@ jobs:
         if: steps.gate.outputs.proceed != 'true'
         run: echo "No release recommended (no binary-impacting changes)."
 
+      - name: No release - AI execution skipped
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode == 'skip'
+        run: echo "No release recommended (AI execution skipped by aiMode=skip)."
+
       - name: Check for GH_MODELS_TOKEN
         id: model_token
-        if: steps.gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip'
         env:
           GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: |
@@ -289,7 +345,7 @@ jobs:
 
       - name: Check token gate
         id: token_gate
-        if: steps.gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip'
         run: |
           present="${{ steps.model_token.outputs.present }}"
           present=${present:-false}
@@ -303,7 +359,7 @@ jobs:
           fi
 
       - name: No release - missing GH_MODELS_TOKEN
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed != 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip' && steps.token_gate.outputs.proceed != 'true'
         run: echo "GH_MODELS_TOKEN not provided; skipping release."
 
       # -----------------------
@@ -311,12 +367,12 @@ jobs:
       # -----------------------
       - name: Preflight GitHub Models catalog
         id: model_catalog
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode == 'full' && steps.token_gate.outputs.proceed == 'true'
         env:
           RELEASE_AI_MODEL: ${{ vars.RELEASE_AI_MODEL }}
         run: |
           set -euo pipefail
-          model="${RELEASE_AI_MODEL:-openai/gpt-4.1}"
+          model="${{ steps.model_config.outputs.model_id }}"
           echo "::group::GitHub Models catalog preflight"
           attempts=3
           backoff=5
@@ -342,7 +398,7 @@ jobs:
 
       - name: Build release dossier
         id: dossier
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode == 'full' && steps.token_gate.outputs.proceed == 'true'
         run: |
           set -euo pipefail
           echo "::group::Build release dossier"
@@ -357,15 +413,43 @@ jobs:
 
       - name: Build and validate AI request JSON
         id: build_request
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip' && steps.token_gate.outputs.proceed == 'true'
+        env:
+          AI_MODE: ${{ steps.ai_mode.outputs.mode }}
         run: |
           set -euo pipefail
           echo "::group::Build AI request"
-          python3 scripts/release/release_helpers.py build-ai-request \
-            --model "${{ steps.model_catalog.outputs.model_id }}" \
-            --dossier release-dossier.md \
-            --semver-rules .github/workflows/semver-rules-override.txt \
-            --output request.json
+          if [ "${AI_MODE:-full}" = "probe" ]; then
+            jq -n --arg model "${{ steps.model_config.outputs.model_id }}" \
+              '{
+                model: $model,
+                temperature: 0,
+                max_tokens: 64,
+                messages: [
+                  {
+                    role: "system",
+                    content: "You are a GitHub Models connectivity probe. Return JSON only."
+                  },
+                  {
+                    role: "user",
+                    content: "Return exactly this JSON object: {\"should_release\":false,\"bump\":\"patch\",\"confidence\":1.0,\"reason\":\"AI probe succeeded; full release analysis was not requested\",\"evidence\":[],\"risks\":[],\"missing\":[]}"
+                  }
+                ]
+              }' > request.json
+            request_size=$(wc -c < request.json | tr -d ' ')
+            echo "audit:ai_probe_request file=request.json model=${{ steps.model_config.outputs.model_id }} request_json_size_bytes=$request_size"
+            echo "request_json_size_bytes=$request_size" >> $GITHUB_OUTPUT
+            echo "dossier_chars=0" >> $GITHUB_OUTPUT
+          elif [ "${AI_MODE:-full}" = "full" ]; then
+            python3 scripts/release/release_helpers.py build-ai-request \
+              --model "${{ steps.model_config.outputs.model_id }}" \
+              --dossier release-dossier.md \
+              --semver-rules .github/workflows/semver-rules-override.txt \
+              --output request.json
+          else
+            echo "Unsupported aiMode '${AI_MODE:-}' for AI request build." >&2
+            exit 1
+          fi
           if ! jq -e '.model and .messages and (.messages | length > 0)' request.json > /dev/null; then
             echo "audit:request_json_valid=false" >&2
             exit 1
@@ -376,20 +460,26 @@ jobs:
 
       - name: Call AI API with retry
         id: ai_call
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip' && steps.token_gate.outputs.proceed == 'true'
         env:
+          AI_MODE: ${{ steps.ai_mode.outputs.mode }}
           GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: |
           set -uo pipefail
           echo "::group::Call GitHub Models inference"
+          echo "audit:ai_mode=${AI_MODE:-full}"
           echo "audit:request_json_size_bytes=$(wc -c < request.json | tr -d ' ')"
           echo "audit:dossier_chars=${{ steps.build_request.outputs.dossier_chars }}"
-          echo "audit:model=${{ steps.model_catalog.outputs.model_id }}"
+          echo "audit:model=${{ steps.model_config.outputs.model_id }}"
           echo "audit:model_max_input_tokens=${{ steps.model_catalog.outputs.model_max_input_tokens }}"
           echo "audit:model_max_output_tokens=${{ steps.model_catalog.outputs.model_max_output_tokens }}"
           echo "audit:external_call target=models.github.ai payload=request.json sanitized=true"
 
-          attempts=3
+          if [ "${AI_MODE:-full}" = "full" ]; then
+            attempts=2
+          else
+            attempts=1
+          fi
           backoff=5
           response_status=000
           curl_exit_code=0
@@ -401,7 +491,6 @@ jobs:
             : > "$attempt_error"
             if response_status=$(curl --silent --show-error --location --http1.1 \
               --connect-timeout 10 --max-time 120 \
-              --retry 2 --retry-delay 2 --retry-max-time 120 --retry-all-errors \
               -o response.json -w '%{http_code}' \
               -X POST \
               -H "Content-Type: application/json" \
@@ -437,22 +526,24 @@ jobs:
 
           echo "response_status=$response_status" >> $GITHUB_OUTPUT
           echo "curl_exit_code=$curl_exit_code" >> $GITHUB_OUTPUT
+          echo "attempts=$attempts" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
       - name: Handle AI API failure
         id: ai_failure
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true' && steps.ai_call.outputs.response_status != '200'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip' && steps.token_gate.outputs.proceed == 'true' && steps.ai_call.outputs.response_status != '200'
         env:
+          AI_MODE: ${{ steps.ai_mode.outputs.mode }}
           RESPONSE_STATUS: ${{ steps.ai_call.outputs.response_status }}
           CURL_EXIT_CODE: ${{ steps.ai_call.outputs.curl_exit_code }}
-          ATTEMPTS: 3
+          ATTEMPTS: ${{ steps.ai_call.outputs.attempts }}
         run: |
           err_msg=$(jq -r '.error.message // empty' response.json 2>/dev/null || true)
           if [ -z "$err_msg" ] && [ "${RESPONSE_STATUS:-}" = "000" ]; then
             err_msg="AI call failed before an HTTP response (curl exit ${CURL_EXIT_CODE:-unknown})"
           fi
           err_msg=${err_msg:-"AI call failed (http ${RESPONSE_STATUS})"}
-          echo "audit:ai_request_failed attempts=$ATTEMPTS status=$RESPONSE_STATUS curl_exit=${CURL_EXIT_CODE:-unknown}" >&2
+          echo "audit:ai_request_failed mode=${AI_MODE:-unknown} attempts=${ATTEMPTS:-unknown} status=$RESPONSE_STATUS curl_exit=${CURL_EXIT_CODE:-unknown}" >&2
           echo "response (truncated to 500 chars):"
           head -c 500 response.json || true
           echo ""
@@ -472,7 +563,7 @@ jobs:
 
       - name: Extract AI response content
         id: ai
-        if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true' && steps.ai_call.outputs.response_status == '200'
+        if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip' && steps.token_gate.outputs.proceed == 'true' && steps.ai_call.outputs.response_status == '200'
         run: |
           resp_size=$(wc -c < response.json | tr -d ' ')
           echo "audit:ai_response_bytes=$resp_size saved_to=response.json"
@@ -501,6 +592,7 @@ jobs:
         id: parsed
         if: always()
         env:
+          AI_MODE: ${{ steps.ai_mode.outputs.mode }}
           GATE_PROCEED: ${{ steps.gate.outputs.proceed }}
           MODEL_TOKEN_PRESENT: ${{ steps.model_token.outputs.present }}
         run: |
@@ -509,8 +601,11 @@ jobs:
           if [ "$gate_proceed" != "true" ]; then
             echo '{"should_release":false,"bump":"patch","confidence":1.0,"warning":"No binary changes","reason":"No binary-impacting changes detected"}' > ai-content.txt
           else
+            ai_mode="${AI_MODE:-full}"
             model_token_present="${MODEL_TOKEN_PRESENT:-false}"
-            if [ "$model_token_present" != "true" ]; then
+            if [ "$ai_mode" = "skip" ]; then
+              echo '{"should_release":false,"bump":"patch","confidence":1.0,"warning":"AI execution skipped","reason":"aiMode=skip was requested; GitHub Models was not called"}' > ai-content.txt
+            elif [ "$model_token_present" != "true" ]; then
               echo "AI call skipped because GH_MODELS_TOKEN is missing." >&2
               echo '{"should_release":false,"bump":"patch","confidence":1.0,"warning":"GH_MODELS_TOKEN missing","reason":"GH_MODELS_TOKEN secret missing; cannot call AI"}' > ai-content.txt
             elif [ ! -s ai-content.txt ]; then
@@ -634,10 +729,11 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DRY_RUN_INPUT: ${{ github.event.inputs.dryRun }}
           DRY_RUN: ${{ steps.run_meta.outputs.dryRun }}
+          AI_MODE: ${{ steps.ai_mode.outputs.mode }}
           PROCEED: ${{ steps.gate.outputs.proceed }}
           TOKEN_PRESENT: ${{ steps.model_token.outputs.present }}
           TOKEN_GATE: ${{ steps.token_gate.outputs.proceed }}
-          MODEL: ${{ steps.model_catalog.outputs.model_id }}
+          MODEL: ${{ steps.model_config.outputs.model_id }}
           MODEL_MAX_INPUT_TOKENS: ${{ steps.model_catalog.outputs.model_max_input_tokens }}
           MODEL_MAX_OUTPUT_TOKENS: ${{ steps.model_catalog.outputs.model_max_output_tokens }}
           DOSSIER_CHARS: ${{ steps.build_request.outputs.dossier_chars }}
@@ -661,6 +757,7 @@ jobs:
 
           cat > release-scheduler-mutation-plan.txt <<EOF
           dryRun=${DRY_RUN:-}
+          aiMode=${AI_MODE:-}
           computedVersion=${VERSION:-}
           bump=${BUMP:-}
           mutationPlan=${mutation_plan}
@@ -669,6 +766,7 @@ jobs:
 
           echo "decision:event_name=${EVENT_NAME:-}"
           echo "decision:dry_run_input='${DRY_RUN_INPUT:-}' normalized=${DRY_RUN:-}"
+          echo "decision:ai_mode=${AI_MODE:-}"
           echo "decision:gate_proceed=${PROCEED:-}"
           echo "decision:token_present=${TOKEN_PRESENT:-}"
           echo "decision:token_gate_proceed=${TOKEN_GATE:-}"
@@ -689,6 +787,7 @@ jobs:
             echo "## Release Scheduler Decision"
             echo ""
             echo "- model: ${MODEL:-unknown}"
+            echo "- AI mode: ${AI_MODE:-unknown}"
             echo "- model max input tokens: ${MODEL_MAX_INPUT_TOKENS:-unknown}"
             echo "- model max output tokens: ${MODEL_MAX_OUTPUT_TOKENS:-unknown}"
             echo "- dossier chars: ${DOSSIER_CHARS:-0}"
@@ -848,6 +947,7 @@ jobs:
           REASON: ${{ needs.analyze.outputs.reason }}
           WARNING: ${{ needs.analyze.outputs.warning }}
           DRY_RUN: ${{ needs.analyze.outputs.dryRun }}
+          AI_MODE: ${{ needs.analyze.outputs.ai_mode }}
           BINARY_LINES: ${{ needs.analyze.outputs.binary_lines }}
           BINARY_CHANGES: ${{ needs.analyze.outputs.binary_changes }}
           CHANGELOG_LEN: ${{ needs.analyze.outputs.changelog_len }}
@@ -890,6 +990,7 @@ jobs:
           reason="${REASON:-}"
           warning="${WARNING:-}"
           dry_run="${DRY_RUN:-unknown}"
+          ai_mode="${AI_MODE:-unknown}"
           last_tag="${LAST_TAG:-}"
           last_first_parent_tag="${LAST_FIRST_PARENT_TAG:-}"
           pom_version="${POM_VERSION:-}"
@@ -977,6 +1078,7 @@ jobs:
           - reason: ${reason}
           - warning: ${warning}
           - dryRun: ${dry_run}
+          - ai mode: ${ai_mode}
           - last reachable tag: ${last_tag}
           - last first-parent tag: ${last_first_parent_tag}
           - pom version: ${pom_version}

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -318,10 +318,27 @@ jobs:
           set -euo pipefail
           model="${RELEASE_AI_MODEL:-openai/gpt-4.1}"
           echo "::group::GitHub Models catalog preflight"
-          python3 scripts/release/release_helpers.py catalog-preflight \
-            --model "$model" \
-            --output release-ai-model.json
+          attempts=3
+          backoff=5
+          status=1
+          for attempt in $(seq 1 "$attempts"); do
+            if python3 scripts/release/release_helpers.py catalog-preflight \
+              --model "$model" \
+              --output release-ai-model.json; then
+              status=0
+              break
+            else
+              status=$?
+            fi
+
+            echo "audit:model_catalog_retry attempt=$attempt exit_code=$status backoff=${backoff}s" >&2
+            if [ "$attempt" -lt "$attempts" ]; then
+              sleep "$backoff"
+              backoff=$((backoff * 2))
+            fi
+          done
           echo "::endgroup::"
+          exit "$status"
 
       - name: Build release dossier
         id: dossier
@@ -373,27 +390,45 @@ jobs:
           echo "audit:external_call target=models.github.ai payload=request.json sanitized=true"
 
           attempts=3
-          backoff=2
-          response_status=0
+          backoff=5
+          response_status=000
+          curl_exit_code=0
           : > response.json
+          : > curl-error.log
 
           for attempt in $(seq 1 "$attempts"); do
-            if response_status=$(curl -s -o response.json -w '%{http_code}' \
-              -X POST --max-time 30 \
+            attempt_error="curl-error-attempt-${attempt}.log"
+            : > "$attempt_error"
+            if response_status=$(curl --silent --show-error --location \
+              --connect-timeout 10 --max-time 120 \
+              --retry 2 --retry-delay 2 --retry-max-time 120 --retry-all-errors \
+              -o response.json -w '%{http_code}' \
+              -X POST \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer $GH_MODELS_TOKEN" \
               https://models.github.ai/inference/chat/completions \
-              --data-binary @request.json); then
-              :
+              --data-binary @request.json 2>"$attempt_error"); then
+              curl_exit_code=0
             else
+              curl_exit_code=$?
               response_status="000"
             fi
 
-            if [ "$response_status" -eq 200 ]; then
+            {
+              echo "attempt=$attempt curl_exit_code=$curl_exit_code response_status=$response_status"
+              if [ -s "$attempt_error" ]; then
+                cat "$attempt_error"
+              else
+                echo "stderr=<empty>"
+              fi
+            } >> curl-error.log
+            response_bytes=$(wc -c < response.json | tr -d ' ')
+
+            if [ "$curl_exit_code" -eq 0 ] && [ "$response_status" = "200" ]; then
               break
             fi
 
-            echo "audit:ai_request_retry attempt=$attempt status=$response_status backoff=${backoff}s" >&2
+            echo "audit:ai_request_retry attempt=$attempt status=$response_status curl_exit=$curl_exit_code response_bytes=$response_bytes backoff=${backoff}s" >&2
             if [ "$attempt" -lt "$attempts" ]; then
               sleep "$backoff"
               backoff=$((backoff * 2))
@@ -401,6 +436,7 @@ jobs:
           done
 
           echo "response_status=$response_status" >> $GITHUB_OUTPUT
+          echo "curl_exit_code=$curl_exit_code" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
       - name: Handle AI API failure
@@ -408,13 +444,20 @@ jobs:
         if: steps.gate.outputs.proceed == 'true' && steps.token_gate.outputs.proceed == 'true' && steps.ai_call.outputs.response_status != '200'
         env:
           RESPONSE_STATUS: ${{ steps.ai_call.outputs.response_status }}
+          CURL_EXIT_CODE: ${{ steps.ai_call.outputs.curl_exit_code }}
           ATTEMPTS: 3
         run: |
           err_msg=$(jq -r '.error.message // empty' response.json 2>/dev/null || true)
+          if [ -z "$err_msg" ] && [ "${RESPONSE_STATUS:-}" = "000" ]; then
+            err_msg="AI call failed before an HTTP response (curl exit ${CURL_EXIT_CODE:-unknown})"
+          fi
           err_msg=${err_msg:-"AI call failed (http ${RESPONSE_STATUS})"}
-          echo "audit:ai_request_failed attempts=$ATTEMPTS status=$RESPONSE_STATUS" >&2
+          echo "audit:ai_request_failed attempts=$ATTEMPTS status=$RESPONSE_STATUS curl_exit=${CURL_EXIT_CODE:-unknown}" >&2
           echo "response (truncated to 500 chars):"
           head -c 500 response.json || true
+          echo ""
+          echo "curl diagnostics (last 20 lines):"
+          tail -n 20 curl-error.log || true
           fallback=$(jq -n --arg msg "$err_msg" --arg status "$RESPONSE_STATUS" \
             '{should_release:false,bump:"patch",warning:$msg,reason:$msg}')
           printf '%s\n' "$fallback" > ai-content.txt
@@ -424,6 +467,8 @@ jobs:
             printf '%s\n' "$fallback"
             echo "$delim"
           } >> $GITHUB_OUTPUT
+          echo "::error::$err_msg"
+          exit 1
 
       - name: Extract AI response content
         id: ai
@@ -669,6 +714,7 @@ jobs:
             release-audit.json
             request.json
             response.json
+            curl-error.log
             ai-content.txt
             release-decision.json
             release-scheduler-mutation-plan.txt

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -399,7 +399,7 @@ jobs:
           for attempt in $(seq 1 "$attempts"); do
             attempt_error="curl-error-attempt-${attempt}.log"
             : > "$attempt_error"
-            if response_status=$(curl --silent --show-error --location \
+            if response_status=$(curl --silent --show-error --location --http1.1 \
               --connect-timeout 10 --max-time 120 \
               --retry 2 --retry-delay 2 --retry-max-time 120 --retry-all-errors \
               -o response.json -w '%{http_code}' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **PULL_REQUESTS.md guidance for AI agents**: New rules were added for handling pull requests.
 
 ### Changed
+- **AI release scheduling is safer to debug**: Manual `release-scheduler.yml` runs now default to a tiny GitHub Models probe, can explicitly skip AI calls, and keep full release-dossier analysis on the scheduled path, while failed required AI calls now preserve curl diagnostics and fail visibly instead of silently falling back.
 - **Agent PR handoff guidance is more explicit**: ta4j PR overrides now clarify when changelog entries are required, require `@coderabbitai full review` after opening a PR, and tell agents to delete temporary `.agents/plans/` PRD/checklist files before final handoff unless explicitly retained.
 - **Contributor full-build feedback is faster**: Slow cached-indicator, chart workflow, paginated data-source, streaming-bot, and XLS-backed indicator checks now avoid real waits and repeated fixture parsing while keeping their production paths and assertions covered.
 - **Rule trace diagnostics are now explicit and safer for shared strategies**: enabling SLF4J `TRACE` on a rule or strategy logger now emits default verbose diagnostics without mutating shared instances, one-shot `SUMMARY` / `VERBOSE` calls scope noisy child logs, and output uses stable flat `key=value` fields for path/depth, compared values, cross/slope windows, risk/reward math, short-circuit reasons, unstable strategy decisions, and stop-rule prices.

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -342,8 +342,10 @@ test_release_scheduler_ai_failures_remain_diagnostic_and_red() {
   ai_failure_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Handle AI API failure" "Extract AI response content")"
   expect_section_contains "$ai_failure_section" "curl diagnostics (last 20 lines)" \
     "release scheduler failure path should print bounded curl diagnostics"
-  expect_section_contains "$ai_failure_section" 'echo "::error::$err_msg"' \
-    "release scheduler should surface AI failure as a GitHub Actions error"
+  expect_section_contains "$ai_failure_section" 'error_annotation="${err_msg//' \
+    "release scheduler should escape AI failure messages before creating workflow annotations"
+  expect_section_contains "$ai_failure_section" 'echo "::error::$error_annotation"' \
+    "release scheduler should surface escaped AI failure text as a GitHub Actions error"
   expect_section_contains "$ai_failure_section" "exit 1" \
     "release scheduler should fail when required AI inference does not answer"
 

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -250,6 +250,42 @@ test_dry_run_summaries_and_audits_show_rerun_guidance() {
   pass "test_dry_run_summaries_and_audits_show_rerun_guidance"
 }
 
+test_release_scheduler_ai_failures_remain_diagnostic_and_red() {
+  echo "Running test_release_scheduler_ai_failures_remain_diagnostic_and_red"
+
+  local catalog_section
+  catalog_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Preflight GitHub Models catalog" "Build release dossier")"
+  expect_section_contains "$catalog_section" "audit:model_catalog_retry" \
+    "release scheduler catalog preflight should retry transient GitHub Models failures"
+
+  local ai_call_section
+  ai_call_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Call AI API with retry" "Handle AI API failure")"
+  expect_section_contains "$ai_call_section" "curl-error.log" \
+    "release scheduler should retain curl diagnostics for AI calls"
+  expect_section_contains "$ai_call_section" "--show-error" \
+    "release scheduler curl invocation should preserve transport errors"
+  expect_section_contains "$ai_call_section" "curl_exit_code=\$?" \
+    "release scheduler should capture curl exit status"
+  expect_section_contains "$ai_call_section" "audit:ai_request_retry attempt=\$attempt status=\$response_status curl_exit=\$curl_exit_code response_bytes=\$response_bytes" \
+    "release scheduler AI retry audit should include status, curl exit, and response bytes"
+
+  local ai_failure_section
+  ai_failure_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Handle AI API failure" "Extract AI response content")"
+  expect_section_contains "$ai_failure_section" "curl diagnostics (last 20 lines)" \
+    "release scheduler failure path should print bounded curl diagnostics"
+  expect_section_contains "$ai_failure_section" 'echo "::error::$err_msg"' \
+    "release scheduler should surface AI failure as a GitHub Actions error"
+  expect_section_contains "$ai_failure_section" "exit 1" \
+    "release scheduler should fail when required AI inference does not answer"
+
+  local artifact_section
+  artifact_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Upload release scheduler audit artifacts" "retention-days")"
+  expect_section_contains "$artifact_section" "curl-error.log" \
+    "release scheduler audit artifact should include curl diagnostics"
+
+  pass "test_release_scheduler_ai_failures_remain_diagnostic_and_red"
+}
+
 test_snapshot_and_health_manual_dry_runs_do_not_mutate() {
   echo "Running test_snapshot_and_health_manual_dry_runs_do_not_mutate"
 
@@ -369,6 +405,7 @@ test_official_triggers_normalize_to_non_dry_run
 test_downstream_dispatches_explicitly_pass_dry_run
 test_mutating_steps_remain_dry_run_gated
 test_dry_run_summaries_and_audits_show_rerun_guidance
+test_release_scheduler_ai_failures_remain_diagnostic_and_red
 test_snapshot_and_health_manual_dry_runs_do_not_mutate
 test_line_of_reports_missing_needles_cleanly
 test_publish_release_existing_tag_only_fails_real_runs

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -58,6 +58,15 @@ expect_section_contains() {
   fi
 }
 
+expect_section_not_contains() {
+  local section="$1"
+  local needle="$2"
+  local msg="$3"
+  if grep -Fq -- "$needle" <<<"$section"; then
+    fail "$msg (unexpected: '$needle')"
+  fi
+}
+
 assert_no_github_script_injected_binding_redeclarations() {
   local workflow="$1"
   awk -v file="${workflow#"$ROOT"/}" '
@@ -250,6 +259,64 @@ test_dry_run_summaries_and_audits_show_rerun_guidance() {
   pass "test_dry_run_summaries_and_audits_show_rerun_guidance"
 }
 
+test_release_scheduler_ai_modes_protect_manual_debug_budget() {
+  echo "Running test_release_scheduler_ai_modes_protect_manual_debug_budget"
+
+  local input_section
+  input_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "aiMode:" "permissions:")"
+  expect_section_contains "$input_section" "default: probe" \
+    "release scheduler manual AI mode should default to probe"
+  expect_section_contains "$input_section" "type: choice" \
+    "release scheduler AI mode should be a choice input"
+  expect_section_contains "$input_section" "- probe" \
+    "release scheduler AI mode should support probe"
+  expect_section_contains "$input_section" "- full" \
+    "release scheduler AI mode should support full"
+  expect_section_contains "$input_section" "- skip" \
+    "release scheduler AI mode should support skip"
+
+  local mode_section
+  mode_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Resolve AI execution mode" "Read version from pom.xml")"
+  expect_section_contains "$mode_section" 'raw="${AI_MODE_INPUT:-probe}"' \
+    "manual release scheduler runs should default AI mode to probe"
+  expect_section_contains "$mode_section" 'raw="full"' \
+    "scheduled release scheduler runs should keep full AI analysis"
+  expect_section_contains "$mode_section" 'full|probe|skip)' \
+    "release scheduler should validate supported AI modes"
+
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "No release - AI execution skipped" \
+    "release scheduler should expose an explicit no-model-call skip path"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "Resolve AI model" \
+    "release scheduler should resolve the configured model without a remote catalog call"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode != 'skip'" \
+    "release scheduler model token checks should skip aiMode=skip"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "if: steps.gate.outputs.proceed == 'true' && steps.ai_mode.outputs.mode == 'full'" \
+    "release scheduler should only run full-analysis setup in full AI mode"
+
+  local request_section
+  request_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Build and validate AI request JSON" "Call AI API with retry")"
+  expect_section_contains "$request_section" "audit:ai_probe_request" \
+    "release scheduler probe mode should build a tiny probe request"
+  expect_section_contains "$request_section" "max_tokens: 64" \
+    "release scheduler probe request should cap response size"
+
+  local call_section
+  call_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Call AI API with retry" "Handle AI API failure")"
+  expect_section_not_contains "$call_section" "--retry" \
+    "release scheduler should avoid nested curl retries that multiply model calls"
+  expect_section_contains "$call_section" 'attempts=2' \
+    "release scheduler full AI mode should keep a small bounded retry"
+  expect_section_contains "$call_section" 'attempts=1' \
+    "release scheduler probe mode should make only one model call"
+
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "decision:ai_mode=" \
+    "release scheduler summaries should include AI mode"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "- ai mode: \${ai_mode}" \
+    "release scheduler notification should include AI mode"
+
+  pass "test_release_scheduler_ai_modes_protect_manual_debug_budget"
+}
+
 test_release_scheduler_ai_failures_remain_diagnostic_and_red() {
   echo "Running test_release_scheduler_ai_failures_remain_diagnostic_and_red"
 
@@ -407,6 +474,7 @@ test_official_triggers_normalize_to_non_dry_run
 test_downstream_dispatches_explicitly_pass_dry_run
 test_mutating_steps_remain_dry_run_gated
 test_dry_run_summaries_and_audits_show_rerun_guidance
+test_release_scheduler_ai_modes_protect_manual_debug_budget
 test_release_scheduler_ai_failures_remain_diagnostic_and_red
 test_snapshot_and_health_manual_dry_runs_do_not_mutate
 test_line_of_reports_missing_needles_cleanly

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -264,6 +264,8 @@ test_release_scheduler_ai_failures_remain_diagnostic_and_red() {
     "release scheduler should retain curl diagnostics for AI calls"
   expect_section_contains "$ai_call_section" "--show-error" \
     "release scheduler curl invocation should preserve transport errors"
+  expect_section_contains "$ai_call_section" "--http1.1" \
+    "release scheduler should avoid GitHub Models HTTP/2 stream cancellations"
   expect_section_contains "$ai_call_section" "curl_exit_code=\$?" \
     "release scheduler should capture curl exit status"
   expect_section_contains "$ai_call_section" "audit:ai_request_retry attempt=\$attempt status=\$response_status curl_exit=\$curl_exit_code response_bytes=\$response_bytes" \


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Add release scheduler AI modes for probe, full, and skip so manual debugging can avoid full GitHub Models payloads.
- Preserve curl diagnostics and fail required AI inference visibly when the model call does not return a usable response.
- Document the release scheduler maintainer workflow change.

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control options for AI execution mode in manual release runs (probe/full/skip).
  * Manual releases now default to lightweight AI probe mode for safer debugging.

* **Bug Fixes**
  * AI failures now exit with diagnostic information instead of silently falling back.

* **Tests**
  * Added validation tests for AI mode behavior and failure handling safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->