### PR TITLE
Add configurable applicability to LinearBorrowingCostModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **Report-producing analysis demos can run on demand or on schedule**: The new standalone `analysis-demo` JUnit tag starts with a live Elliott Wave BTC/USD macro report backed by Coinbase daily candles, plus a dedicated GitHub Actions workflow that can be manually run for provider-qualified instruments like `coinbase:BTC-USD` and uploads the resulting JSON, chart, and cached data artifacts.
 - **Elliott macro-cycle replay has a dedicated runner path**: The BTC macro-cycle replay regression now uses the explicit `elliott-macro-cycle-replay` JUnit tag and a manual-only self-hosted GitHub Actions workflow, keeping the multi-hour replay out of hosted PR verification and report-producing analysis-demo runs.
 - **PULL_REQUESTS.md guidance for AI agents**: New rules were added for handling pull requests.
+- **Configurable borrowing-cost applicability**: `LinearBorrowingCostModel` now accepts a `LinearBorrowingCostModel.Applicability` (`SHORT_ONLY`, `LONG_ONLY`, `BOTH`) so borrowing costs can apply to short, long, or both position sides. The existing single-argument constructor keeps the prior short-only behavior, so the change is backward compatible (`#1235`).
 
 ### Changed
 - **Build and test dependencies were refreshed**: The parent POM now pins SpotBugs `4.9.8.3`, JaCoCo `0.8.14`, Gson `2.14.0`, JUnit Jupiter `6.0.3`, Mockito `5.23.0`, and SLF4J `2.0.18`.

--- a/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModel.java
@@ -9,21 +9,51 @@ import org.ta4j.core.Trade;
 import org.ta4j.core.num.Num;
 
 /**
- * With this cost model, the trading costs for borrowing a position (i.e.
- * selling a position short) accrue linearly.
+ * With this cost model, the trading costs for borrowing a position accrue
+ * linearly.
+ *
+ * <p>
+ * By default borrowing costs apply to short positions only (the historical
+ * behavior). Use {@link #LinearBorrowingCostModel(double, Applicability)} to
+ * apply them to long positions, or to both sides.
  */
 public class LinearBorrowingCostModel implements CostModel {
+
+    /** Defines which position sides incur borrowing costs. */
+    public enum Applicability {
+        /** Borrowing costs apply to short positions only (default). */
+        SHORT_ONLY,
+        /** Borrowing costs apply to long positions only. */
+        LONG_ONLY,
+        /** Borrowing costs apply to both long and short positions. */
+        BOTH
+    }
 
     /** The slope of the linear model (fee per period). */
     private final double feePerPeriod;
 
+    /** Which position sides incur borrowing costs. */
+    private final Applicability applicability;
+
     /**
-     * Constructor with {@code feePerPeriod * nPeriod}.
+     * Constructor with {@code feePerPeriod * nPeriod}. Borrowing costs apply to
+     * short positions only (backward-compatible default).
      *
      * @param feePerPeriod the coefficient (e.g. 0.0001 for 1bp per period)
      */
     public LinearBorrowingCostModel(double feePerPeriod) {
+        this(feePerPeriod, Applicability.SHORT_ONLY);
+    }
+
+    /**
+     * Constructor with {@code feePerPeriod * nPeriod}.
+     *
+     * @param feePerPeriod  the coefficient (e.g. 0.0001 for 1bp per period)
+     * @param applicability which position sides incur borrowing costs
+     */
+    public LinearBorrowingCostModel(double feePerPeriod, Applicability applicability) {
         this.feePerPeriod = feePerPeriod;
+        this.applicability = applicability;
     }
 
     /**
@@ -56,8 +86,8 @@ public class LinearBorrowingCostModel implements CostModel {
         Trade exitTrade = position.getExit();
         Num borrowingCost = position.getEntry().getNetPrice().getNumFactory().zero();
 
-        // Borrowing costs only apply to short positions.
-        if (entryTrade != null && entryTrade.getType().equals(TradeType.SELL) && entryTrade.getAmount() != null) {
+        // Borrowing costs apply according to the configured applicability.
+        if (entryTrade != null && entryTrade.getAmount() != null && appliesTo(entryTrade.getType())) {
             int tradingPeriods = 0;
             if (position.isClosed()) {
                 tradingPeriods = exitTrade.getIndex() - entryTrade.getIndex();
@@ -67,6 +97,19 @@ public class LinearBorrowingCostModel implements CostModel {
             borrowingCost = getHoldingCostForPeriods(tradingPeriods, position.getEntry().getValue());
         }
         return borrowingCost;
+    }
+
+    /**
+     * @param type the entry {@link TradeType} of the position
+     * @return {@code true} if borrowing costs apply to a position entered with this
+     *         trade type
+     */
+    private boolean appliesTo(TradeType type) {
+        return switch (applicability) {
+        case BOTH -> true;
+        case LONG_ONLY -> type == TradeType.BUY;
+        case SHORT_ONLY -> type == TradeType.SELL;
+        };
     }
 
     /**
@@ -84,7 +127,8 @@ public class LinearBorrowingCostModel implements CostModel {
     public boolean equals(CostModel otherModel) {
         boolean equality = false;
         if (this.getClass().equals(otherModel.getClass())) {
-            equality = ((LinearBorrowingCostModel) otherModel).feePerPeriod == this.feePerPeriod;
+            LinearBorrowingCostModel other = (LinearBorrowingCostModel) otherModel;
+            equality = other.feePerPeriod == this.feePerPeriod && other.applicability == this.applicability;
         }
         return equality;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/analysis/cost/LinearBorrowingCostModelTest.java
@@ -95,4 +95,43 @@ public class LinearBorrowingCostModelTest {
         assertFalse(inequality1);
         assertFalse(inequality2);
     }
+
+    @Test
+    public void buyPositionIncursCostWithBothApplicability() {
+        CostModel model = new LinearBorrowingCostModel(0.01, LinearBorrowingCostModel.Applicability.BOTH);
+        int holdingPeriod = 2;
+        Trade entry = Trade.buyAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        Trade exit = Trade.sellAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1));
+        Position position = new Position(entry, exit, new ZeroCostModel(), model);
+        // 100 value * 2 periods * 0.01 fee = 2
+        assertNumEquals(DoubleNum.valueOf(2), model.calculate(position, holdingPeriod));
+    }
+
+    @Test
+    public void buyPositionIncursCostWithLongOnlyApplicability() {
+        CostModel model = new LinearBorrowingCostModel(0.01, LinearBorrowingCostModel.Applicability.LONG_ONLY);
+        int holdingPeriod = 2;
+        Trade entry = Trade.buyAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        Trade exit = Trade.sellAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1));
+        Position position = new Position(entry, exit, new ZeroCostModel(), model);
+        assertNumEquals(DoubleNum.valueOf(2), model.calculate(position, holdingPeriod));
+    }
+
+    @Test
+    public void sellPositionHasNoCostWithLongOnlyApplicability() {
+        CostModel model = new LinearBorrowingCostModel(0.01, LinearBorrowingCostModel.Applicability.LONG_ONLY);
+        int holdingPeriod = 2;
+        Trade entry = Trade.sellAt(0, DoubleNum.valueOf(100), DoubleNum.valueOf(1));
+        Trade exit = Trade.buyAt(holdingPeriod, DoubleNum.valueOf(110), DoubleNum.valueOf(1));
+        Position position = new Position(entry, exit, new ZeroCostModel(), model);
+        assertNumEquals(DoubleNum.valueOf(0), model.calculate(position, holdingPeriod));
+    }
+
+    @Test
+    public void equalsConsidersApplicability() {
+        CostModel shortOnly = new LinearBorrowingCostModel(0.01);
+        CostModel both = new LinearBorrowingCostModel(0.01, LinearBorrowingCostModel.Applicability.BOTH);
+        assertFalse(shortOnly.equals(both));
+        assertTrue(shortOnly.equals(new LinearBorrowingCostModel(0.01)));
+    }
 }


### PR DESCRIPTION
Fixes #1235

Changes proposed in this pull request:
- Add a `LinearBorrowingCostModel.Applicability` enum (`SHORT_ONLY`, `LONG_ONLY`, `BOTH`) plus a new `LinearBorrowingCostModel(double, Applicability)` constructor; the existing single-argument constructor delegates to `SHORT_ONLY`, so default behavior is unchanged (backward compatible).
- Make the borrowing-cost calculation honor the configured applicability instead of the hardcoded short-only (`SELL`) check, and include the new field in `equals()`.
- Add tests for `BOTH` and `LONG_ONLY` modes and for `equals()` distinguishing applicability; existing tests stay unchanged, confirming default behavior.

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

Note: `ta4j-core` builds and tests clean. Two pre-existing `ta4j-examples` tests (`TradingBotOnMovingBarSeriesTest`, `JsonBarSeriesDataSourceTest`) fail locally on my machine, unrelated to this change — different module, and one is a timing-flaky test.