### PR TITLE
Add position status filtering to NumberOfPositionsCriterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   than repeated mild deviations.
 
 ### Added
+- **Position-count criteria can include open positions**: `NumberOfPositionsCriterion` now accepts a `PositionStatusFilter` so callers can count closed positions, open positions, or both while preserving the existing closed-position default.
 - **Active return criteria for benchmark comparisons**: Added `ActiveReturnCriterion` and `ActiveReturnVersusEnterAndHoldCriterion` so return-like criteria can report benchmark-relative active return in decimal, percentage, multiplicative, or log form without changing the established normalized `VersusEnterAndHoldCriterion` behavior.
 - **Composable regime and edge primitives**: Added `StretchZScoreIndicator`, `CompressionIndicator`, `TrendScoreIndicator`, `TrendConclusionIndicator`, `EntryEdgeIndicator`, `EdgeDecaySlopeIndicator`, `LossTriggeredCooldownRule`, and `EdgeHealthyRule` so strategies can model stretch, compression, trend state, realized entry edge, edge decay, and post-loss cooldowns with reusable ta4j-native building blocks (`CF-86`).
 - **Rolling advanced correlation indicators**: Added Spearman rank correlation, Kendall tau-b, lag-aware cross-correlation, distance correlation, mutual information, and regime-segmented correlation indicators under `org.ta4j.core.indicators.statistics`, with NaN handling for undefined windows and documentation for choosing the right metric.

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -44,12 +44,13 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
     private final boolean lessIsBetter;
 
     private final PositionStatusFilter statusFilter;
+    private final boolean filterSinglePositions;
 
     /**
      * Constructor with {@link #lessIsBetter} = true.
      */
     public NumberOfPositionsCriterion() {
-        this(true, PositionStatusFilter.CLOSED);
+        this(true, PositionStatusFilter.CLOSED, false);
     }
 
     /**
@@ -58,7 +59,7 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
      * @param lessIsBetter the {@link #lessIsBetter}
      */
     public NumberOfPositionsCriterion(boolean lessIsBetter) {
-        this(lessIsBetter, PositionStatusFilter.CLOSED);
+        this(lessIsBetter, PositionStatusFilter.CLOSED, false);
     }
 
     /**
@@ -68,7 +69,7 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
      * @since 0.22.7
      */
     public NumberOfPositionsCriterion(PositionStatusFilter statusFilter) {
-        this(true, statusFilter);
+        this(true, statusFilter, true);
     }
 
     /**
@@ -79,16 +80,28 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
      * @since 0.22.7
      */
     public NumberOfPositionsCriterion(boolean lessIsBetter, PositionStatusFilter statusFilter) {
+        this(lessIsBetter, statusFilter, true);
+    }
+
+    private NumberOfPositionsCriterion(boolean lessIsBetter, PositionStatusFilter statusFilter,
+            boolean filterSinglePositions) {
         this.lessIsBetter = lessIsBetter;
         this.statusFilter = Objects.requireNonNull(statusFilter, "statusFilter");
+        this.filterSinglePositions = filterSinglePositions;
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return switch (statusFilter) {
-        case CLOSED, ALL -> series.numFactory().one();
-        case OPEN -> position != null && position.isOpened() ? series.numFactory().one() : series.numFactory().zero();
+        if (!filterSinglePositions) {
+            return series.numFactory().one();
+        }
+
+        boolean countPosition = switch (statusFilter) {
+        case CLOSED -> position != null && position.isClosed();
+        case OPEN -> position != null && position.isOpened();
+        case ALL -> position != null && (position.isClosed() || position.isOpened());
         };
+        return countPosition ? series.numFactory().one() : series.numFactory().zero();
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/criteria/NumberOfPositionsCriterion.java
@@ -3,9 +3,15 @@
  */
 package org.ta4j.core.criteria;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.Position;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.AnalysisContext;
+import org.ta4j.core.analysis.AnalysisWindow;
+import org.ta4j.core.analysis.OpenPositionHandling;
 import org.ta4j.core.num.Num;
 
 /**
@@ -14,17 +20,36 @@ import org.ta4j.core.num.Num;
 public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
 
     /**
+     * Position status filter for counted positions.
+     *
+     * @since 0.22.7
+     */
+    public enum PositionStatusFilter {
+        /**
+         * Count closed positions. This is the default and preserves historical
+         * behavior.
+         */
+        CLOSED,
+        /** Count open positions. */
+        OPEN,
+        /** Count both closed and open positions. */
+        ALL
+    }
+
+    /**
      * If true, then the lower the criterion value the better, otherwise the higher
      * the criterion value the better. This property is only used for
      * {@link #betterThan(Num, Num)}.
      */
     private final boolean lessIsBetter;
 
+    private final PositionStatusFilter statusFilter;
+
     /**
      * Constructor with {@link #lessIsBetter} = true.
      */
     public NumberOfPositionsCriterion() {
-        this.lessIsBetter = true;
+        this(true, PositionStatusFilter.CLOSED);
     }
 
     /**
@@ -33,17 +58,65 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
      * @param lessIsBetter the {@link #lessIsBetter}
      */
     public NumberOfPositionsCriterion(boolean lessIsBetter) {
+        this(lessIsBetter, PositionStatusFilter.CLOSED);
+    }
+
+    /**
+     * Constructor with {@link #lessIsBetter} = true.
+     *
+     * @param statusFilter position status filter to count
+     * @since 0.22.7
+     */
+    public NumberOfPositionsCriterion(PositionStatusFilter statusFilter) {
+        this(true, statusFilter);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param lessIsBetter the {@link #lessIsBetter}
+     * @param statusFilter position status filter to count
+     * @since 0.22.7
+     */
+    public NumberOfPositionsCriterion(boolean lessIsBetter, PositionStatusFilter statusFilter) {
         this.lessIsBetter = lessIsBetter;
+        this.statusFilter = Objects.requireNonNull(statusFilter, "statusFilter");
     }
 
     @Override
     public Num calculate(BarSeries series, Position position) {
-        return series.numFactory().one();
+        return switch (statusFilter) {
+        case CLOSED, ALL -> series.numFactory().one();
+        case OPEN -> position != null && position.isOpened() ? series.numFactory().one() : series.numFactory().zero();
+        };
     }
 
     @Override
     public Num calculate(BarSeries series, TradingRecord tradingRecord) {
-        return series.numFactory().numOf(tradingRecord.getPositionCount());
+        return series.numFactory().numOf(countPositions(series, tradingRecord));
+    }
+
+    @Override
+    public Num calculate(BarSeries series, TradingRecord tradingRecord, AnalysisWindow window,
+            AnalysisContext context) {
+        Objects.requireNonNull(series, "series");
+        Objects.requireNonNull(tradingRecord, "tradingRecord");
+        Objects.requireNonNull(window, "window");
+        Objects.requireNonNull(context, "context");
+
+        if (series.isEmpty()) {
+            return calculate(series, tradingRecord);
+        }
+        if (statusFilter == PositionStatusFilter.CLOSED) {
+            return super.calculate(series, tradingRecord, window, context);
+        }
+
+        TradingRecord projectedRecord = projectClosedPositions(series, tradingRecord, window, context);
+        int closedPositions = projectedRecord.getPositionCount();
+        int openPositions = countOpenPositionsBetween(tradingRecord, projectedRecord.getStartIndex(series),
+                projectedRecord.getEndIndex(series));
+        int positionCount = statusFilter == PositionStatusFilter.OPEN ? openPositions : closedPositions + openPositions;
+        return series.numFactory().numOf(positionCount);
     }
 
     /**
@@ -54,5 +127,88 @@ public class NumberOfPositionsCriterion extends AbstractAnalysisCriterion {
     public boolean betterThan(Num criterionValue1, Num criterionValue2) {
         return lessIsBetter ? criterionValue1.isLessThan(criterionValue2)
                 : criterionValue1.isGreaterThan(criterionValue2);
+    }
+
+    private int countPositions(BarSeries series, TradingRecord tradingRecord) {
+        int closedPositions = tradingRecord.getPositionCount();
+        if (statusFilter == PositionStatusFilter.CLOSED) {
+            return closedPositions;
+        }
+
+        int openPositions = countOpenPositionsAtOrBefore(tradingRecord, tradingRecord.getEndIndex(series));
+        return statusFilter == PositionStatusFilter.OPEN ? openPositions : closedPositions + openPositions;
+    }
+
+    private TradingRecord projectClosedPositions(BarSeries series, TradingRecord tradingRecord, AnalysisWindow window,
+            AnalysisContext context) {
+        AtomicReference<TradingRecord> projectedRecordRef = new AtomicReference<>();
+        AnalysisContext closedOnlyContext = context.withOpenPositionHandling(OpenPositionHandling.IGNORE);
+        new ProjectionCaptureCriterion(projectedRecordRef).calculate(series, tradingRecord, window, closedOnlyContext);
+        return Objects.requireNonNull(projectedRecordRef.get(), "projectedRecord");
+    }
+
+    private static int countOpenPositionsAtOrBefore(TradingRecord tradingRecord, int endIndex) {
+        List<Position> openPositions = tradingRecord.getOpenPositions();
+        if (openPositions != null && !openPositions.isEmpty()) {
+            int count = 0;
+            for (Position openPosition : openPositions) {
+                if (isOpenedAtOrBefore(openPosition, endIndex)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        Position currentPosition = tradingRecord.getCurrentPosition();
+        return isOpenedAtOrBefore(currentPosition, endIndex) ? 1 : 0;
+    }
+
+    private static int countOpenPositionsBetween(TradingRecord tradingRecord, int startIndex, int endIndex) {
+        List<Position> openPositions = tradingRecord.getOpenPositions();
+        if (openPositions != null && !openPositions.isEmpty()) {
+            int count = 0;
+            for (Position openPosition : openPositions) {
+                if (isOpenedBetween(openPosition, startIndex, endIndex)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        Position currentPosition = tradingRecord.getCurrentPosition();
+        return isOpenedBetween(currentPosition, startIndex, endIndex) ? 1 : 0;
+    }
+
+    private static boolean isOpenedAtOrBefore(Position position, int endIndex) {
+        return position != null && position.isOpened() && position.getEntry() != null
+                && position.getEntry().getIndex() <= endIndex;
+    }
+
+    private static boolean isOpenedBetween(Position position, int startIndex, int endIndex) {
+        return isOpenedAtOrBefore(position, endIndex) && position.getEntry().getIndex() >= startIndex;
+    }
+
+    private static final class ProjectionCaptureCriterion extends AbstractAnalysisCriterion {
+        private final AtomicReference<TradingRecord> projectedRecordRef;
+
+        private ProjectionCaptureCriterion(AtomicReference<TradingRecord> projectedRecordRef) {
+            this.projectedRecordRef = Objects.requireNonNull(projectedRecordRef, "projectedRecordRef");
+        }
+
+        @Override
+        public Num calculate(BarSeries series, Position position) {
+            return series.numFactory().zero();
+        }
+
+        @Override
+        public Num calculate(BarSeries series, TradingRecord tradingRecord) {
+            projectedRecordRef.set(tradingRecord);
+            return series.numFactory().zero();
+        }
+
+        @Override
+        public boolean betterThan(Num criterionValue1, Num criterionValue2) {
+            return false;
+        }
     }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
@@ -9,6 +9,7 @@ import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.AnalysisCriterion;
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
@@ -26,7 +27,7 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithNoPositions() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
                 .build();
 
@@ -36,7 +37,7 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithTwoPositions() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
                 .build();
         TradingRecord tradingRecord = new BaseTradingRecord(Trade.buyAt(0, series), Trade.sellAt(2, series),
@@ -48,7 +49,7 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithStatusFilters() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
                 .build();
         TradingRecord tradingRecord = new BaseTradingRecord();
@@ -72,7 +73,7 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithStatusFiltersAndLookbackWindow() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
                 .build();
         TradingRecord tradingRecord = new BaseTradingRecord();
@@ -98,7 +99,7 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithStatusFiltersAndEmptySeriesWindow() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         TradingRecord tradingRecord = new BaseTradingRecord();
         tradingRecord.enter(0, numFactory.one(), numFactory.one());
 
@@ -114,28 +115,48 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
 
     @Test
     public void calculateWithOnePosition() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
-                .withData(100, 105, 110, 100, 95, 105)
-                .build();
-        Position position = new Position();
-        AnalysisCriterion positionsCriterion = getCriterion();
-
-        assertNumEquals(1, positionsCriterion.calculate(series, position));
-    }
-
-    @Test
-    public void calculatePositionWithOpenStatusFilter() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
                 .build();
         Position emptyPosition = new Position();
         Position openPosition = new Position();
         openPosition.operate(0, series.getBar(0).getClosePrice(), numFactory.one());
+        Position closedPosition = new Position();
+        closedPosition.operate(0, series.getBar(0).getClosePrice(), numFactory.one());
+        closedPosition.operate(2, series.getBar(2).getClosePrice(), numFactory.one());
+        AnalysisCriterion positionsCriterion = getCriterion();
+
+        assertNumEquals(1, positionsCriterion.calculate(series, emptyPosition));
+        assertNumEquals(1, positionsCriterion.calculate(series, openPosition));
+        assertNumEquals(1, positionsCriterion.calculate(series, closedPosition));
+    }
+
+    @Test
+    public void calculatePositionWithOpenStatusFilter() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 110, 100, 95, 105)
+                .build();
+        Position emptyPosition = new Position();
+        Position openPosition = new Position();
+        openPosition.operate(0, series.getBar(0).getClosePrice(), numFactory.one());
+        Position closedPosition = new Position();
+        closedPosition.operate(0, series.getBar(0).getClosePrice(), numFactory.one());
+        closedPosition.operate(2, series.getBar(2).getClosePrice(), numFactory.one());
+        AnalysisCriterion closedCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.CLOSED);
         AnalysisCriterion openCriterion = new NumberOfPositionsCriterion(
                 NumberOfPositionsCriterion.PositionStatusFilter.OPEN);
+        AnalysisCriterion allCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.ALL);
 
+        assertNumEquals(0, closedCriterion.calculate(series, emptyPosition));
+        assertNumEquals(0, closedCriterion.calculate(series, openPosition));
+        assertNumEquals(1, closedCriterion.calculate(series, closedPosition));
         assertNumEquals(0, openCriterion.calculate(series, emptyPosition));
         assertNumEquals(1, openCriterion.calculate(series, openPosition));
+        assertNumEquals(0, allCriterion.calculate(series, emptyPosition));
+        assertNumEquals(1, allCriterion.calculate(series, openPosition));
+        assertNumEquals(1, allCriterion.calculate(series, closedPosition));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/criteria/NumberOfPositionsCriterionTest.java
@@ -13,6 +13,7 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Position;
 import org.ta4j.core.Trade;
 import org.ta4j.core.TradingRecord;
+import org.ta4j.core.analysis.AnalysisWindow;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.NumFactory;
 
@@ -46,6 +47,72 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
     }
 
     @Test
+    public void calculateWithStatusFilters() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 110, 100, 95, 105)
+                .build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        tradingRecord.enter(0, series.getBar(0).getClosePrice(), numFactory.one());
+        tradingRecord.exit(2, series.getBar(2).getClosePrice(), numFactory.one());
+        tradingRecord.enter(3, series.getBar(3).getClosePrice(), numFactory.one());
+
+        AnalysisCriterion defaultCriterion = getCriterion();
+        AnalysisCriterion closedCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.CLOSED);
+        AnalysisCriterion openCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.OPEN);
+        AnalysisCriterion allCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.ALL);
+
+        assertNumEquals(1, defaultCriterion.calculate(series, tradingRecord));
+        assertNumEquals(1, closedCriterion.calculate(series, tradingRecord));
+        assertNumEquals(1, openCriterion.calculate(series, tradingRecord));
+        assertNumEquals(2, allCriterion.calculate(series, tradingRecord));
+    }
+
+    @Test
+    public void calculateWithStatusFiltersAndLookbackWindow() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 110, 100, 95, 105)
+                .build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        tradingRecord.enter(0, series.getBar(0).getClosePrice(), numFactory.one());
+        tradingRecord.exit(2, series.getBar(2).getClosePrice(), numFactory.one());
+        tradingRecord.enter(3, series.getBar(3).getClosePrice(), numFactory.one());
+
+        AnalysisWindow lookbackWindow = AnalysisWindow.lookbackBars(2);
+        AnalysisWindow lookbackWindowWithOpenEntry = AnalysisWindow.lookbackBars(3);
+        AnalysisCriterion closedCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.CLOSED);
+        AnalysisCriterion openCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.OPEN);
+        AnalysisCriterion allCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.ALL);
+
+        assertNumEquals(0, closedCriterion.calculate(series, tradingRecord, lookbackWindow));
+        assertNumEquals(0, openCriterion.calculate(series, tradingRecord, lookbackWindow));
+        assertNumEquals(0, allCriterion.calculate(series, tradingRecord, lookbackWindow));
+        assertNumEquals(1, openCriterion.calculate(series, tradingRecord, lookbackWindowWithOpenEntry));
+        assertNumEquals(1, allCriterion.calculate(series, tradingRecord, lookbackWindowWithOpenEntry));
+    }
+
+    @Test
+    public void calculateWithStatusFiltersAndEmptySeriesWindow() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        TradingRecord tradingRecord = new BaseTradingRecord();
+        tradingRecord.enter(0, numFactory.one(), numFactory.one());
+
+        AnalysisWindow lookbackWindow = AnalysisWindow.lookbackBars(1);
+        AnalysisCriterion openCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.OPEN);
+        AnalysisCriterion allCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.ALL);
+
+        assertNumEquals(0, openCriterion.calculate(series, tradingRecord, lookbackWindow));
+        assertNumEquals(0, allCriterion.calculate(series, tradingRecord, lookbackWindow));
+    }
+
+    @Test
     public void calculateWithOnePosition() {
         var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
                 .withData(100, 105, 110, 100, 95, 105)
@@ -54,6 +121,21 @@ public class NumberOfPositionsCriterionTest extends AbstractCriterionTest {
         AnalysisCriterion positionsCriterion = getCriterion();
 
         assertNumEquals(1, positionsCriterion.calculate(series, position));
+    }
+
+    @Test
+    public void calculatePositionWithOpenStatusFilter() {
+        var series = new MockBarSeriesBuilder().withNumFactory(numFactory)
+                .withData(100, 105, 110, 100, 95, 105)
+                .build();
+        Position emptyPosition = new Position();
+        Position openPosition = new Position();
+        openPosition.operate(0, series.getBar(0).getClosePrice(), numFactory.one());
+        AnalysisCriterion openCriterion = new NumberOfPositionsCriterion(
+                NumberOfPositionsCriterion.PositionStatusFilter.OPEN);
+
+        assertNumEquals(0, openCriterion.calculate(series, emptyPosition));
+        assertNumEquals(1, openCriterion.calculate(series, openPosition));
     }
 
     @Test


### PR DESCRIPTION
Fixes: n/a.

Changes proposed in this pull request:
- Add `NumberOfPositionsCriterion.PositionStatusFilter` with closed, open, and all counting modes.
- Preserve the existing closed-position default while allowing open positions to be counted in full-series and analysis-window calculations.
- Cover status filtering, null validation, and windowed open-position counting.

- [x] I have run `mvn -B clean license:format formatter:format test install` to format and test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

Additional verification:
- `mvn -pl ta4j-core test -Dtest=NumberOfPositionsCriterionTest -Dsurefire.failIfNoSpecifiedTests=false`
- `scripts/run-full-build-quiet.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position counting now supports filtering by status, enabling you to count closed positions, open positions, or both. Default behavior (closed positions only) is preserved for backward compatibility.

* **Tests**
  * Added comprehensive test coverage for position-status filtering across trading records, lookback windows, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->