### PR TITLE
Release 0.22.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- _No changes yet._
+
+## 0.22.8 (2026-06-29)
+
 ### Changed
 - **AI release scheduling now uses an exact biweekly cadence**: `release-scheduler.yml` now runs a weekly Monday trigger through a 14-day guard anchored at June 29, 2026, so scheduled `aiMode=full` production checks happen every other Monday instead of on day-of-month slots that could double-bill across month boundaries. Off-cadence scheduled runs short-circuit before GitHub Models setup or inference and skip scheduler discussion posts, while due runs still dispatch PR-based release prep.
 - **CF-250: AI release scheduler full runs are transport-resilient**: `release-scheduler.yml` now keeps full GitHub Models requests under a configurable transport budget, compacts oversized dossiers into artifact-backed prompts, captures response headers and curl metrics, and writes structured transport diagnostics so maintainers can recover from curl-level failures without blindly rerunning a billed full request.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Add Ta4j from Maven Central:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.22.7</version>
+  <version>0.22.8</version>
 </dependency>
 ```
 
@@ -86,7 +86,7 @@ Prefer living on the edge? Use the snapshot repository and version:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.22.8-SNAPSHOT</version>
+  <version>0.22.9-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -100,7 +100,7 @@ Sample applications are also published so you can copy/paste entire flows:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.22.7</version>
+  <version>0.22.8</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ Like living on the edge? Use the snapshot version of ta4j-examples for the lates
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.22.8-SNAPSHOT</version>
+  <version>0.22.9-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.22.8</version>
+    <version>0.22.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.22.8-SNAPSHOT</version>
+    <version>0.22.8</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/release/0.22.8.md
+++ b/release/0.22.8.md
@@ -1,0 +1,10 @@
+## 0.22.8 (2026-06-29)
+
+### Changed
+- **AI release scheduling now uses an exact biweekly cadence**: `release-scheduler.yml` now runs a weekly Monday trigger through a 14-day guard anchored at June 29, 2026, so scheduled `aiMode=full` production checks happen every other Monday instead of on day-of-month slots that could double-bill across month boundaries. Off-cadence scheduled runs short-circuit before GitHub Models setup or inference and skip scheduler discussion posts, while due runs still dispatch PR-based release prep.
+- **CF-250: AI release scheduler full runs are transport-resilient**: `release-scheduler.yml` now keeps full GitHub Models requests under a configurable transport budget, compacts oversized dossiers into artifact-backed prompts, captures response headers and curl metrics, and writes structured transport diagnostics so maintainers can recover from curl-level failures without blindly rerunning a billed full request.
+- **Quiet full-build verification now wraps Maven `verify`**: `scripts/run-full-build-quiet.sh` now defaults to the canonical `verify` goal, supports `--goals` overrides plus normal Maven argument pass-through for focused modules and tagged tests, and has a Windows PowerShell counterpart. The repository now commits Maven Wrapper scripts pinned to Maven `3.9.16`, so contributors can use `./mvnw -B verify`, `mvnw.cmd -B verify`, system Maven, or the quiet scripts for the same contributor gate. The quiet scripts keep the full Maven log under `.agents/logs/` while surfacing bounded warning, error, exception, stack-trace, and unexpected-output summaries in stdout.
+
+### Fixed
+
+- **Prepare-release no longer asks release PR authors to review themselves**: `prepare-release.yml` now filters the PR author out of release reviewer requests, supports fallback reviewer users or teams, and leaves a warning-only audit path when no eligible reviewer remains instead of failing the review request.

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.8-SNAPSHOT</version>
+        <version>0.22.8</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.8</version>
+        <version>0.22.9-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.8</version>
+        <version>0.22.9-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.8-SNAPSHOT</version>
+        <version>0.22.8</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 


### PR DESCRIPTION
Automated release PR for 0.22.8.

Contains:
- Set version to 0.22.8
- Generated release notes: release/0.22.8.md
- Bump to next snapshot: 0.22.9-SNAPSHOT
- Synced removal-ready deprecation issues: 0 plan(s), 0 created, 0 updated, 0 reopened, 0 stale closed

<!-- release-meta
releaseVersion: 0.22.8
nextVersion: 0.22.9-SNAPSHOT
releaseCommit: d1c3953931f499b1c062c913025fbd1a228ce8e3
-->