### PR TITLE
Silence expected test warnings during verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
-- _No changes yet._
+### Changed
+
+- **Quiet Maven verify stays focused on failures**: `ta4j-core` test logging now keeps intentional `TimeBarBuilder` missing-bar warnings and invalid `ReturnRepresentation` parse warnings out of `mvn verify -q` output while preserving explicit log-capture assertions for those expected paths.
+- **Cached indicator stress coverage is less scheduler-sensitive**: `CachedIndicatorTest` now waits for a bounded minimum-read signal before ending the concurrent mutation phase, so the full-build gate continues to exercise cache invalidation under contention without failing because reader threads were scheduled late.
 
 ## 0.22.8 (2026-06-29)
 

--- a/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/bars/TimeBarBuilderTest.java
@@ -337,6 +337,7 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
         Configuration config = loggerContext.getConfiguration();
         LoggerConfig loggerConfig = config.getLoggerConfig(TimeBarBuilder.class.getName());
         Level originalLevel = loggerConfig.getLevel();
+        boolean originalAdditivity = loggerConfig.isAdditive();
 
         StringWriter logOutput = new StringWriter();
         PatternLayout layout = PatternLayout.newBuilder().withPattern("%msg%n").build();
@@ -349,6 +350,7 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
 
         loggerConfig.addAppender(appender, Level.WARN, null);
         loggerConfig.setLevel(Level.WARN);
+        loggerConfig.setAdditive(false);
         loggerContext.updateLoggers();
 
         try {
@@ -358,6 +360,7 @@ public class TimeBarBuilderTest extends AbstractIndicatorTest<BarSeries, Num> {
             loggerConfig.removeAppender(appender.getName());
             appender.stop();
             loggerConfig.setLevel(originalLevel);
+            loggerConfig.setAdditive(originalAdditivity);
             loggerContext.updateLoggers();
         }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CachedIndicatorTest.java
@@ -894,8 +894,10 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
 
         int readers = 8;
         int iterations = 50;
+        int minimumReads = 100;
         AtomicInteger totalReads = new AtomicInteger(0);
         AtomicBoolean mutationsDone = new AtomicBoolean(false);
+        CountDownLatch readsObserved = new CountDownLatch(minimumReads);
 
         ExecutorService executor = Executors.newFixedThreadPool(readers + 1);
         CountDownLatch ready = new CountDownLatch(readers + 1);
@@ -910,7 +912,10 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
                     start.await();
                     while (!mutationsDone.get()) {
                         indicator.getValue(endIndex);
-                        totalReads.incrementAndGet();
+                        int readCount = totalReads.incrementAndGet();
+                        if (readCount <= minimumReads) {
+                            readsObserved.countDown();
+                        }
                         Thread.yield();
                     }
                 } catch (InterruptedException e) {
@@ -930,6 +935,7 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
                     barSeries.getLastBar().addTrade(numOf(1), numOf(i + 10));
                     Thread.sleep(1);
                 }
+                readsObserved.await(5, TimeUnit.SECONDS);
                 mutationsDone.set(true);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -944,7 +950,7 @@ public class CachedIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         executor.shutdownNow();
 
         // Should have performed many reads
-        assertTrue("Should have performed many concurrent reads", totalReads.get() > 100);
+        assertTrue("Should have performed many concurrent reads", totalReads.get() >= minimumReads);
 
         // Each mutation should trigger a recomputation
         assertTrue("Should have recomputed after mutations", indicator.getCalculationCount() > 1);

--- a/ta4j-core/src/test/resources/log4j2-test.xml
+++ b/ta4j-core/src/test/resources/log4j2-test.xml
@@ -12,6 +12,8 @@
         </Root>
         <!-- Gap-fill tests intentionally trigger missing-bar WARNs; keep them off test output. -->
         <Logger name="org.ta4j.core.bars.TimeBarBuilder" level="error"/>
+        <!-- Parse tests intentionally trigger invalid-representation WARNs; keep them off test output. -->
+        <Logger name="org.ta4j.core.criteria.ReturnRepresentation" level="error"/>
         <Logger name="org.apache.poi" level="warn" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Suppress expected TimeBarBuilder missing-bar warnings and ReturnRepresentation parse warnings from ta4j-core test console output.
- Keep TimeBarBuilder warning assertions isolated from the root console appender.
- Make CachedIndicator concurrent mutation stress coverage wait for a bounded minimum-read signal before ending the mutation phase.

- [x] I have run `./mvnw -B verify`, `mvnw.cmd -B verify`, `mvn -B verify`, or the quiet build script to test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability for concurrent indicator updates, reducing flakiness in stress scenarios.
  * Kept expected warning messages out of routine test output while preserving log checks for known edge cases.
* **Chores**
  * Updated the changelog with the latest testing and logging refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->