### PR TITLE
Add FXMacroData read data integration

### DIFF
--- a/ta4j-examples/src/main/java/ta4jexamples/datasources/FxMacroDataClient.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/datasources/FxMacroDataClient.java
@@ -1,0 +1,243 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package ta4jexamples.datasources;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Raw JSON client for FXMacroData's public read/data endpoints.
+ */
+public final class FxMacroDataClient {
+
+    public static final String DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1";
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final String apiKey;
+    private final Gson gson = new Gson();
+
+    public FxMacroDataClient() {
+        this(HttpClient.newHttpClient(), DEFAULT_BASE_URL, System.getenv("FXMACRODATA_API_KEY"));
+    }
+
+    public FxMacroDataClient(HttpClient httpClient, String baseUrl, String apiKey) {
+        this.httpClient = httpClient;
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.apiKey = apiKey != null && !apiKey.isBlank() ? apiKey : System.getenv("FXMD_API_KEY");
+    }
+
+    public JsonObject dataCatalogue(String currency, boolean includeCapabilities, boolean includeCoverage)
+            throws IOException, InterruptedException {
+        return get("data_catalogue/" + currency.toLowerCase(), params(
+                "include_capabilities", includeCapabilities,
+                "include_coverage", includeCoverage));
+    }
+
+    public JsonObject announcements(String currency, String indicator, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("announcements/" + currency.toLowerCase() + "/" + indicator, params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "series_mode", "raw",
+                "revisions", "latest",
+                "official_only", true,
+                "limit", limit));
+    }
+
+    public JsonObject latestAnnouncements(String currency) throws IOException, InterruptedException {
+        return get("announcements/" + currency.toLowerCase() + "/latest", params());
+    }
+
+    public JsonObject announcementChanges(String currencies, String indicators, String since, int limit)
+            throws IOException, InterruptedException {
+        return get("announcements/changes", params(
+                "currencies", currencies,
+                "indicators", indicators,
+                "since", since,
+                "limit", limit,
+                "payload", "compact"));
+    }
+
+    public JsonObject predictions(String currency, String indicator, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("predictions/" + currency.toLowerCase() + "/" + indicator, params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject releaseCalendar(String currency, String indicator, LocalDate startDate, LocalDate endDate,
+            String timezone) throws IOException, InterruptedException {
+        return get("calendar/" + currency.toLowerCase(), params(
+                "indicator", indicator,
+                "start_date", startDate,
+                "end_date", endDate,
+                "timezone", timezone));
+    }
+
+    public JsonObject forex(String base, String quote, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("forex/" + base.toLowerCase() + "/" + quote.toLowerCase(), params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject cot(String currency, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("cot/" + currency.toLowerCase(), params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject commodity(String indicator, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("commodities/" + indicator, params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject latestCommodities() throws IOException, InterruptedException {
+        return get("commodities/latest", params());
+    }
+
+    public JsonObject curves(String currency, String curveFamily, String metric, LocalDate date)
+            throws IOException, InterruptedException {
+        return get("curves/" + currency.toLowerCase(), params(
+                "curve_family", defaultValue(curveFamily, "government_nominal"),
+                "metric", defaultValue(metric, "spot"),
+                "date", date));
+    }
+
+    public JsonObject curveProxies(String currency, String curveFamily, LocalDate date)
+            throws IOException, InterruptedException {
+        return get("curve_proxies/" + currency.toLowerCase(), params(
+                "curve_family", defaultValue(curveFamily, "government_nominal"),
+                "date", date));
+    }
+
+    public JsonObject forwardCurves(String currency, String curveFamily, String method, LocalDate date)
+            throws IOException, InterruptedException {
+        return get("forward_curves/" + currency.toLowerCase(), params(
+                "curve_family", defaultValue(curveFamily, "government_nominal"),
+                "method", defaultValue(method, "derived_from_spot_nodes"),
+                "date", date));
+    }
+
+    public JsonObject rateDifferentials(String base, String quote, String measure, LocalDate startDate, LocalDate endDate,
+            int limit) throws IOException, InterruptedException {
+        return get("rate_differentials/" + base.toLowerCase() + "/" + quote.toLowerCase(), params(
+                "measure", defaultValue(measure, "auto"),
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject forwardDifferentials(String base, String quote, LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("forward_differentials/" + base.toLowerCase() + "/" + quote.toLowerCase(), params(
+                "curve_family", "government_nominal",
+                "start_tenor_years", 2,
+                "end_tenor_years", 5,
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject marketSessions(String at) throws IOException, InterruptedException {
+        return get("market_sessions", params("at", at));
+    }
+
+    public JsonObject riskSentiment(LocalDate startDate, LocalDate endDate, int limit)
+            throws IOException, InterruptedException {
+        return get("risk_sentiment", params(
+                "start_date", startDate,
+                "end_date", endDate,
+                "limit", limit));
+    }
+
+    public JsonObject news(String currency, int limit) throws IOException, InterruptedException {
+        return get("news/" + currency.toLowerCase(), params("limit", limit));
+    }
+
+    public JsonObject pressReleases(String currency, int limit) throws IOException, InterruptedException {
+        return get("press-releases/" + currency.toLowerCase(), params("limit", limit));
+    }
+
+    public JsonObject graphQl(String query, JsonObject variables) throws IOException, InterruptedException {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("query", query);
+        payload.add("variables", variables == null ? new JsonObject() : variables);
+        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl + "/graphql"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload)))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        ensureSuccess(response);
+        return gson.fromJson(response.body(), JsonObject.class);
+    }
+
+    private JsonObject get(String path, Map<String, Object> query) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(buildUri(path, query)).GET().build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        ensureSuccess(response);
+        return gson.fromJson(response.body(), JsonObject.class);
+    }
+
+    private URI buildUri(String path, Map<String, Object> query) {
+        Map<String, Object> params = new LinkedHashMap<>(query);
+        if (apiKey != null && !apiKey.isBlank()) {
+            params.put("api_key", apiKey);
+        }
+        String queryString = params.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> encode(entry.getKey()) + "=" + encode(format(entry.getValue())))
+                .reduce((left, right) -> left + "&" + right)
+                .orElse("");
+        String url = baseUrl + "/" + path;
+        return URI.create(queryString.isBlank() ? url : url + "?" + queryString);
+    }
+
+    private static Map<String, Object> params(Object... pairs) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        for (int index = 0; index < pairs.length; index += 2) {
+            params.put(Objects.toString(pairs[index]), pairs[index + 1]);
+        }
+        return params;
+    }
+
+    private static void ensureSuccess(HttpResponse<String> response) throws IOException {
+        if (response.statusCode() >= 400) {
+            throw new IOException("FXMacroData request failed with HTTP status " + response.statusCode());
+        }
+    }
+
+    private static String defaultValue(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static String format(Object value) {
+        return value instanceof LocalDate ? value.toString() : Objects.toString(value);
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}
+

--- a/ta4j-examples/src/main/java/ta4jexamples/datasources/FxMacroDataReleaseCalendarDataSource.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/datasources/FxMacroDataReleaseCalendarDataSource.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package ta4jexamples.datasources;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads FXMacroData economic release-calendar events for event-aware backtests.
+ * <p>
+ * The data source returns macro and central-bank events such as CPI, payrolls,
+ * and policy decisions. Strategies can use the returned dates to skip entries,
+ * size down around tier-1 events, or evaluate event-window performance.
+ */
+public final class FxMacroDataReleaseCalendarDataSource {
+
+    public static final String DEFAULT_BASE_URL = "https://fxmacrodata.com/api/v1";
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final String apiKey;
+
+    public FxMacroDataReleaseCalendarDataSource() {
+        this(HttpClient.newHttpClient(), DEFAULT_BASE_URL, System.getenv("FXMACRODATA_API_KEY"));
+    }
+
+    public FxMacroDataReleaseCalendarDataSource(HttpClient httpClient, String baseUrl, String apiKey) {
+        this.httpClient = httpClient;
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.apiKey = apiKey;
+    }
+
+    public List<ReleaseEvent> fetch(String currency, int limit) throws IOException, InterruptedException {
+        return fetch(currency, limit, null);
+    }
+
+    public List<ReleaseEvent> fetch(String currency, int limit, Integer minTier)
+            throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(buildUri(currency, limit)).GET().build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 400) {
+            throw new IOException("FXMacroData request failed with HTTP status " + response.statusCode());
+        }
+
+        JsonObject payload = JsonParser.parseString(response.body()).getAsJsonObject();
+        List<ReleaseEvent> events = new ArrayList<>();
+        for (JsonElement element : payload.getAsJsonArray("data")) {
+            JsonObject row = element.getAsJsonObject();
+            int marketTier = getInt(row, "market_tier", 99);
+            if (minTier != null && marketTier > minTier) {
+                continue;
+            }
+            events.add(new ReleaseEvent(getString(row, "release"), getString(row, "name"),
+                    getString(row, "currency"), getString(row, "date"), parseAnnouncementTime(row), marketTier,
+                    getBoolean(row, "top_tier_for_currency"), getString(row, "source"),
+                    getString(row, "source_url")));
+        }
+        return events;
+    }
+
+    private URI buildUri(String currency, int limit) {
+        StringBuilder query = new StringBuilder("limit=").append(Math.max(1, limit));
+        if (apiKey != null && !apiKey.isBlank()) {
+            query.append("&api_key=").append(URLEncoder.encode(apiKey, StandardCharsets.UTF_8));
+        }
+        return URI.create(baseUrl + "/calendar/" + currency.toLowerCase() + "?" + query);
+    }
+
+    private static Instant parseAnnouncementTime(JsonObject row) {
+        String isoTimestamp = getString(row, "announcement_datetime_utc");
+        if (!isoTimestamp.isBlank()) {
+            return Instant.parse(isoTimestamp);
+        }
+        if (row.has("announcement_datetime") && !row.get("announcement_datetime").isJsonNull()) {
+            return Instant.ofEpochSecond(row.get("announcement_datetime").getAsLong());
+        }
+        return LocalDate.parse(getString(row, "date")).atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
+
+    private static String getString(JsonObject row, String key) {
+        return row.has(key) && !row.get(key).isJsonNull() ? row.get(key).getAsString() : "";
+    }
+
+    private static int getInt(JsonObject row, String key, int defaultValue) {
+        return row.has(key) && !row.get(key).isJsonNull() ? row.get(key).getAsInt() : defaultValue;
+    }
+
+    private static boolean getBoolean(JsonObject row, String key) {
+        return row.has(key) && !row.get(key).isJsonNull() && row.get(key).getAsBoolean();
+    }
+
+    public static final class ReleaseEvent {
+        private final String release;
+        private final String name;
+        private final String currency;
+        private final String date;
+        private final Instant announcementTime;
+        private final int marketTier;
+        private final boolean topTierForCurrency;
+        private final String source;
+        private final String sourceUrl;
+
+        private ReleaseEvent(String release, String name, String currency, String date, Instant announcementTime,
+                int marketTier, boolean topTierForCurrency, String source, String sourceUrl) {
+            this.release = release;
+            this.name = name;
+            this.currency = currency;
+            this.date = date;
+            this.announcementTime = announcementTime;
+            this.marketTier = marketTier;
+            this.topTierForCurrency = topTierForCurrency;
+            this.source = source;
+            this.sourceUrl = sourceUrl;
+        }
+
+        public String getRelease() {
+            return release;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getCurrency() {
+            return currency;
+        }
+
+        public String getDate() {
+            return date;
+        }
+
+        public Instant getAnnouncementTime() {
+            return announcementTime;
+        }
+
+        public int getMarketTier() {
+            return marketTier;
+        }
+
+        public boolean isTopTierForCurrency() {
+            return topTierForCurrency;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getSourceUrl() {
+            return sourceUrl;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Expands the FXMacroData integration beyond release-calendar-only helpers to the public read/data API surface.
- Covers catalogue discovery, macro announcements/latest/changes, predictions, release calendar, FX spot, COT, commodities/latest, curves/rates/forwards, market sessions, risk sentiment, news, press releases, and GraphQL where the host repo exposes a generic client shape.
- Keeps the existing calendar helper as a compatibility wrapper and supports `FXMACRODATA_API_KEY` / `FXMD_API_KEY` for authenticated datasets.

## Validation
- `git diff --check` passed across the external integration batch.
- Changed Python files were formatted with `black` and checked with `python -m py_compile`.
- Live smoke checks passed against production for catalogue, calendar, announcements, predictions, FX, COT, commodities latest, market sessions, and risk sentiment using a local API key without printing it.

## Local environment notes
- Java and .NET builds were not run locally because this machine does not have `javac`, `JAVA_HOME`, or `dotnet` configured.
- Some full package imports still require repo-specific generated files or optional dependencies in an installed environment.