### PR TITLE
CF-299 preserve chart source ordinals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - **Cached indicator stress coverage is less scheduler-sensitive**: `CachedIndicatorTest` now waits for a bounded minimum-read signal before ending the concurrent mutation phase, so the full-build gate continues to exercise cache invalidation under contention without failing because reader threads were scheduled late.
 
 ### Fixed
+- **Source position labels remain accurate in isolated chart renders**: Trading-record
+  chart callers can now provide a 1-based source position start, so position bands
+  and buy/sell annotations retain their original ordinal when a focused chart
+  contains only a later source position (CF-299).
 - **CF-207/208/209/210/211/236 SpotBugs closure**: Cleared the historical SpotBugs baseline across constructor safety, cache concurrency, representation ownership, examples IO/reporting, serialization, indicator/rule/backtest accessors, and Elliott analysis paths; Maven `verify`, standalone SpotBugs scans, and GitHub CI now run SpotBugs without an exclude filter and fail on new findings.
 
 ## 0.22.8 (2026-06-29)

--- a/ta4j-examples/src/main/java/ta4jexamples/charting/compose/TradingChartFactory.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/charting/compose/TradingChartFactory.java
@@ -88,6 +88,7 @@ public final class TradingChartFactory {
     private static final Font TRADE_LABEL_FONT = new Font(Font.SANS_SERIF, Font.BOLD, 13);
     private static final Font POSITION_LABEL_FONT = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
     private static final Font OVERLAY_LABEL_FONT = new Font(Font.SANS_SERIF, Font.BOLD, 12);
+    private static final int FIRST_POSITION_NUMBER = 1;
     private static final int LABEL_EDGE_BARS = 5;
     private static final int MAX_AXIS_LABEL_LENGTH = 30;
     private static final String DATE_AXIS_LABEL = "Date";
@@ -245,33 +246,98 @@ public final class TradingChartFactory {
         return Objects.requireNonNull(timeAxisMode, "Time axis mode cannot be null");
     }
 
+    private int requireSourcePositionStart(int sourcePositionStart, TradingRecord tradingRecord) {
+        if (sourcePositionStart < FIRST_POSITION_NUMBER) {
+            throw new IllegalArgumentException("Source position start must be at least 1");
+        }
+        if (tradingRecord != null) {
+            long renderedPositionCount = tradingRecord.getPositions().size();
+            Position currentPosition = tradingRecord.getCurrentPosition();
+            if (currentPosition != null && currentPosition.isOpened()) {
+                renderedPositionCount++;
+            }
+            if (renderedPositionCount > 0
+                    && (long) sourcePositionStart + renderedPositionCount - FIRST_POSITION_NUMBER > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException("Source position start cannot represent every rendered position");
+            }
+        }
+        return sourcePositionStart;
+    }
+
     public JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord) {
-        return createTradingRecordChart(series, strategyName, tradingRecord, TimeAxisMode.REAL_TIME);
+        return createTradingRecordChart(series, strategyName, tradingRecord, TimeAxisMode.REAL_TIME,
+                FIRST_POSITION_NUMBER);
     }
 
     public JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
+        return createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER);
+    }
+
+    /**
+     * Creates a trading-record chart using labels that begin at the supplied source
+     * position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @return a chart with position bands and trade labels using source position
+     *         numbers
+     * @since 0.22.9
+     */
+    public JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
         TimeAxisMode resolvedTimeAxisMode = requireTimeAxisMode(timeAxisMode);
+        int resolvedSourcePositionStart = requireSourcePositionStart(sourcePositionStart, tradingRecord);
         DefaultOHLCDataset data = datasetFactory.createChartDataset(series, resolvedTimeAxisMode);
         String chartTitle = buildChartTitle(series.getName(), strategyName);
         JFreeChart chart = buildChart(chartTitle, series, series.getFirstBar().getTimePeriod(), data,
                 resolvedTimeAxisMode);
-        addTradingRecordToChart((XYPlot) chart.getPlot(), series, tradingRecord, resolvedTimeAxisMode);
+        addTradingRecordToChart((XYPlot) chart.getPlot(), series, tradingRecord, resolvedTimeAxisMode,
+                resolvedSourcePositionStart);
         return chart;
     }
 
     @SafeVarargs
     public final JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             Indicator<Num>... indicators) {
-        return createTradingRecordChart(series, strategyName, tradingRecord, TimeAxisMode.REAL_TIME, indicators);
+        return createTradingRecordChart(series, strategyName, tradingRecord, TimeAxisMode.REAL_TIME,
+                FIRST_POSITION_NUMBER, indicators);
     }
 
     @SafeVarargs
     public final JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode, Indicator<Num>... indicators) {
+        return createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER,
+                indicators);
+    }
+
+    /**
+     * Creates a trading-record chart with indicator subplots using labels that
+     * begin at the supplied source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @param indicators          optional indicators rendered in subplots
+     * @return a chart with position bands and trade labels using source position
+     *         numbers
+     * @since 0.22.9
+     */
+    @SafeVarargs
+    public final JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart, Indicator<Num>... indicators) {
         TimeAxisMode resolvedTimeAxisMode = requireTimeAxisMode(timeAxisMode);
+        int resolvedSourcePositionStart = requireSourcePositionStart(sourcePositionStart, tradingRecord);
         if (indicators == null || indicators.length == 0) {
-            return createTradingRecordChart(series, strategyName, tradingRecord, resolvedTimeAxisMode);
+            return createTradingRecordChart(series, strategyName, tradingRecord, resolvedTimeAxisMode,
+                    resolvedSourcePositionStart);
         }
 
         JFreeChart chart = createIndicatorChart(series, resolvedTimeAxisMode, indicators);
@@ -288,10 +354,11 @@ public final class TradingChartFactory {
         if (chart.getPlot() instanceof CombinedDomainXYPlot combinedPlot) {
             List<XYPlot> subplots = combinedPlot.getSubplots();
             if (subplots != null && !subplots.isEmpty()) {
-                addTradingRecordToChart(subplots.get(0), series, tradingRecord, resolvedTimeAxisMode);
+                addTradingRecordToChart(subplots.get(0), series, tradingRecord, resolvedTimeAxisMode,
+                        resolvedSourcePositionStart);
             }
         } else if (chart.getPlot() instanceof XYPlot plot) {
-            addTradingRecordToChart(plot, series, tradingRecord, resolvedTimeAxisMode);
+            addTradingRecordToChart(plot, series, tradingRecord, resolvedTimeAxisMode, resolvedSourcePositionStart);
         }
 
         return chart;
@@ -848,25 +915,36 @@ public final class TradingChartFactory {
 
     private void addTradingRecordToChart(XYPlot plot, BarSeries series, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
+        addTradingRecordToChart(plot, series, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER);
+    }
+
+    private void addTradingRecordToChart(XYPlot plot, BarSeries series, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
         try {
             XYSeries buyMarkers = createTradeSeries("Buy trades");
             XYSeries sellMarkers = createTradeSeries("Sell trades");
-            int positionIndex = 1;
+            int localPositionIndex = FIRST_POSITION_NUMBER;
 
             for (Position position : tradingRecord.getPositions()) {
-                addTradeMarker(buyMarkers, sellMarkers, plot, series, position.getEntry(), positionIndex, timeAxisMode);
-                addTradeMarker(buyMarkers, sellMarkers, plot, series, position.getExit(), positionIndex, timeAxisMode);
-                addPositionBand(plot, series, positionIndex, position.getEntry(), position.getExit(), timeAxisMode);
-                positionIndex++;
+                int displayPositionNumber = sourcePositionStart + localPositionIndex - FIRST_POSITION_NUMBER;
+                addTradeMarker(buyMarkers, sellMarkers, plot, series, position.getEntry(), displayPositionNumber,
+                        timeAxisMode);
+                addTradeMarker(buyMarkers, sellMarkers, plot, series, position.getExit(), displayPositionNumber,
+                        timeAxisMode);
+                addPositionBand(plot, series, localPositionIndex, displayPositionNumber, position.getEntry(),
+                        position.getExit(), timeAxisMode);
+                localPositionIndex++;
             }
 
             if (tradingRecord.getCurrentPosition().isOpened()) {
+                int displayPositionNumber = sourcePositionStart + localPositionIndex - FIRST_POSITION_NUMBER;
                 Trade lastTrade = tradingRecord.getLastTrade();
                 if (lastTrade != null) {
-                    addTradeMarker(buyMarkers, sellMarkers, plot, series, lastTrade, positionIndex, timeAxisMode);
+                    addTradeMarker(buyMarkers, sellMarkers, plot, series, lastTrade, displayPositionNumber,
+                            timeAxisMode);
                 }
-                addPositionBand(plot, series, positionIndex, tradingRecord.getCurrentPosition().getEntry(), null,
-                        timeAxisMode);
+                addPositionBand(plot, series, localPositionIndex, displayPositionNumber,
+                        tradingRecord.getCurrentPosition().getEntry(), null, timeAxisMode);
             }
 
             attachTradeDataset(plot, buyMarkers, sellMarkers);
@@ -876,7 +954,7 @@ public final class TradingChartFactory {
     }
 
     private void addTradeMarker(XYSeries buyMarkers, XYSeries sellMarkers, XYPlot plot, BarSeries series, Trade trade,
-            int positionIndex, TimeAxisMode timeAxisMode) {
+            int displayPositionNumber, TimeAxisMode timeAxisMode) {
         if (trade == null) {
             return;
         }
@@ -900,13 +978,13 @@ public final class TradingChartFactory {
             sellMarkers.add(orderDateTime, price);
         }
 
-        annotateTrade(plot, series, trade, positionIndex, orderDateTime, price);
+        annotateTrade(plot, series, trade, displayPositionNumber, orderDateTime, price);
     }
 
-    private void annotateTrade(XYPlot plot, BarSeries series, Trade trade, int positionIndex, double orderDateTime,
-            double price) {
+    private void annotateTrade(XYPlot plot, BarSeries series, Trade trade, int displayPositionNumber,
+            double orderDateTime, double price) {
         String labelPrefix = trade.isBuy() ? "B" : "S";
-        String label = labelPrefix + positionIndex + " @" + PRICE_FORMAT.get().format(price);
+        String label = labelPrefix + displayPositionNumber + " @" + PRICE_FORMAT.get().format(price);
 
         XYTextAnnotation annotation = new XYTextAnnotation(label, orderDateTime, price);
         annotation.setFont(TRADE_LABEL_FONT);
@@ -968,8 +1046,8 @@ public final class TradingChartFactory {
         return new XYSeries(key, false, true);
     }
 
-    private void addPositionBand(XYPlot plot, BarSeries series, int positionIndex, Trade entry, Trade exit,
-            TimeAxisMode timeAxisMode) {
+    private void addPositionBand(XYPlot plot, BarSeries series, int localPositionIndex, int displayPositionNumber,
+            Trade entry, Trade exit, TimeAxisMode timeAxisMode) {
         if (entry == null) {
             return;
         }
@@ -986,9 +1064,10 @@ public final class TradingChartFactory {
         }
 
         IntervalMarker marker = new IntervalMarker(start, end);
-        Color baseColor = POSITION_BAND_COLORS[(positionIndex - 1) % POSITION_BAND_COLORS.length];
+        Color baseColor = POSITION_BAND_COLORS[(localPositionIndex - FIRST_POSITION_NUMBER)
+                % POSITION_BAND_COLORS.length];
         marker.setPaint(withAlpha(baseColor, POSITION_BAND_ALPHA));
-        marker.setLabel("Position " + positionIndex);
+        marker.setLabel("Position " + displayPositionNumber);
         marker.setLabelFont(POSITION_LABEL_FONT);
         marker.setLabelPaint(Color.LIGHT_GRAY);
         setPositionLabelAnchors(marker, entry.getIndex(), series);

--- a/ta4j-examples/src/main/java/ta4jexamples/charting/workflow/ChartWorkflow.java
+++ b/ta4j-examples/src/main/java/ta4jexamples/charting/workflow/ChartWorkflow.java
@@ -81,6 +81,7 @@ public final class ChartWorkflow {
     static final int DEFAULT_CHART_IMAGE_HEIGHT = 2160;
 
     private static final Logger LOG = LogManager.getLogger(ChartWorkflow.class);
+    private static final int FIRST_POSITION_NUMBER = 1;
 
     private final TradingChartFactory chartFactory;
     private final ChartDisplayer chartDisplayer;
@@ -356,7 +357,28 @@ public final class ChartWorkflow {
      */
     public JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
-        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, null, false);
+        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER, null,
+                false);
+    }
+
+    /**
+     * Builds a chart that overlays a trading record on top of OHLC data using
+     * labels that begin at the supplied source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @return a chart with position bands and trade labels using source position
+     *         numbers
+     * @since 0.22.9
+     */
+    public JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
+        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, sourcePositionStart, null,
+                false);
     }
 
     /**
@@ -380,7 +402,31 @@ public final class ChartWorkflow {
     @SafeVarargs
     public final JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode, Indicator<Num>... indicators) {
-        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, indicators, true);
+        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER,
+                indicators, true);
+    }
+
+    /**
+     * Builds a chart that overlays a trading record on top of OHLC data, appends
+     * indicator subplots, and uses labels that begin at the supplied source
+     * position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @param indicators          optional indicators rendered in subplots
+     * @return a chart with position bands and trade labels using source position
+     *         numbers
+     * @since 0.22.9
+     */
+    @SafeVarargs
+    public final JFreeChart createTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart, Indicator<Num>... indicators) {
+        return buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, sourcePositionStart,
+                indicators, true);
     }
 
     /**
@@ -402,7 +448,26 @@ public final class ChartWorkflow {
      */
     public Optional<Path> saveTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
-        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, null, false);
+        return saveTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER);
+    }
+
+    /**
+     * Persists a trading-record chart using labels that begin at the supplied
+     * source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @return an optional path to the stored chart
+     * @since 0.22.9
+     */
+    public Optional<Path> saveTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
+        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, null, false);
         String chartTitle = resolveChartTitle(chart, series, strategyName);
         return chartStorage.save(chart, series, chartTitle, DEFAULT_CHART_IMAGE_WIDTH, DEFAULT_CHART_IMAGE_HEIGHT);
     }
@@ -430,7 +495,30 @@ public final class ChartWorkflow {
     @SafeVarargs
     public final Optional<Path> saveTradingRecordChart(BarSeries series, String strategyName,
             TradingRecord tradingRecord, TimeAxisMode timeAxisMode, Indicator<Num>... indicators) {
-        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, indicators, true);
+        return saveTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER,
+                indicators);
+    }
+
+    /**
+     * Persists a trading-record chart with indicator subplots using labels that
+     * begin at the supplied source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @param indicators          optional indicators rendered in subplots
+     * @return an optional path to the stored chart
+     * @since 0.22.9
+     */
+    @SafeVarargs
+    public final Optional<Path> saveTradingRecordChart(BarSeries series, String strategyName,
+            TradingRecord tradingRecord, TimeAxisMode timeAxisMode, int sourcePositionStart,
+            Indicator<Num>... indicators) {
+        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, indicators, true);
         String chartTitle = resolveChartTitle(chart, series, strategyName);
         return chartStorage.save(chart, series, chartTitle, DEFAULT_CHART_IMAGE_WIDTH, DEFAULT_CHART_IMAGE_HEIGHT);
     }
@@ -452,11 +540,29 @@ public final class ChartWorkflow {
      */
     public void displayTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
+        displayTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER);
+    }
+
+    /**
+     * Displays a trading-record chart using labels that begin at the supplied
+     * source position number, logging any presentation exceptions.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @since 0.22.9
+     */
+    public void displayTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
         validateTradingInputs(series, strategyName, tradingRecord);
         validateTimeAxisMode(timeAxisMode);
-        displayChartSafely(
-                () -> chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode), null,
-                "Failed to display trading record chart for {}@{}", strategyName, safeSeriesName(series));
+        JFreeChart chart = chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart);
+        displayChartSafely(() -> chart, null, "Failed to display trading record chart for {}@{}", strategyName,
+                safeSeriesName(series));
     }
 
     /**
@@ -480,13 +586,33 @@ public final class ChartWorkflow {
     @SafeVarargs
     public final void displayTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode, Indicator<Num>... indicators) {
+        displayTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER, indicators);
+    }
+
+    /**
+     * Displays a trading-record chart with indicator subplots using labels that
+     * begin at the supplied source position number, logging any presentation
+     * exceptions.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @param indicators          optional indicators rendered in subplots
+     * @since 0.22.9
+     */
+    @SafeVarargs
+    public final void displayTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart, Indicator<Num>... indicators) {
         validateTradingInputs(series, strategyName, tradingRecord);
         validateTimeAxisMode(timeAxisMode);
         validateIndicators(indicators);
-        displayChartSafely(
-                () -> chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
-                        indicators),
-                null, "Failed to display trading record chart for {}@{}", strategyName, safeSeriesName(series));
+        JFreeChart chart = chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, indicators);
+        displayChartSafely(() -> chart, null, "Failed to display trading record chart for {}@{}", strategyName,
+                safeSeriesName(series));
     }
 
     /**
@@ -506,7 +632,26 @@ public final class ChartWorkflow {
      */
     public byte[] createTradingRecordChartBytes(BarSeries series, String strategyName, TradingRecord tradingRecord,
             TimeAxisMode timeAxisMode) {
-        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, null, false);
+        return createTradingRecordChartBytes(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER);
+    }
+
+    /**
+     * Produces a PNG representation of a trading-record chart using labels that
+     * begin at the supplied source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @return the encoded PNG bytes
+     * @since 0.22.9
+     */
+    public byte[] createTradingRecordChartBytes(BarSeries series, String strategyName, TradingRecord tradingRecord,
+            TimeAxisMode timeAxisMode, int sourcePositionStart) {
+        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, null, false);
         return getChartAsByteArray(chart);
     }
 
@@ -531,7 +676,30 @@ public final class ChartWorkflow {
     @SafeVarargs
     public final byte[] createTradingRecordChartBytes(BarSeries series, String strategyName,
             TradingRecord tradingRecord, TimeAxisMode timeAxisMode, Indicator<Num>... indicators) {
-        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, indicators, true);
+        return createTradingRecordChartBytes(series, strategyName, tradingRecord, timeAxisMode, FIRST_POSITION_NUMBER,
+                indicators);
+    }
+
+    /**
+     * Produces a PNG representation of a trading-record chart with indicator
+     * subplots using labels that begin at the supplied source position number.
+     *
+     * @param series              the bar series to chart
+     * @param strategyName        the strategy name shown in the chart title
+     * @param tradingRecord       the trading record to render
+     * @param timeAxisMode        the chart time-axis mode
+     * @param sourcePositionStart the 1-based source number for the first rendered
+     *                            position
+     * @param indicators          optional indicators rendered in subplots
+     * @return the encoded PNG bytes
+     * @since 0.22.9
+     */
+    @SafeVarargs
+    public final byte[] createTradingRecordChartBytes(BarSeries series, String strategyName,
+            TradingRecord tradingRecord, TimeAxisMode timeAxisMode, int sourcePositionStart,
+            Indicator<Num>... indicators) {
+        JFreeChart chart = buildTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, indicators, true);
         return getChartAsByteArray(chart);
     }
 
@@ -974,13 +1142,15 @@ public final class ChartWorkflow {
     }
 
     private JFreeChart buildTradingRecordChart(BarSeries series, String strategyName, TradingRecord tradingRecord,
-            TimeAxisMode timeAxisMode, Indicator<Num>[] indicators, boolean validateIndicators) {
+            TimeAxisMode timeAxisMode, int sourcePositionStart, Indicator<Num>[] indicators,
+            boolean validateIndicators) {
         validateTradingInputs(series, strategyName, tradingRecord);
         validateTimeAxisMode(timeAxisMode);
         if (validateIndicators) {
             validateIndicators(indicators);
         }
-        return chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode, indicators);
+        return chartFactory.createTradingRecordChart(series, strategyName, tradingRecord, timeAxisMode,
+                sourcePositionStart, indicators);
     }
 
     @SafeVarargs

--- a/ta4j-examples/src/test/java/ta4jexamples/charting/compose/TradingChartFactoryTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/charting/compose/TradingChartFactoryTest.java
@@ -20,6 +20,7 @@ import org.jfree.chart.ui.TextAnchor;
 import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.xy.OHLCDataset;
 import org.jfree.data.xy.XYSeriesCollection;
+import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.ta4j.core.BarSeries;
@@ -44,6 +45,7 @@ import org.ta4j.core.num.Num;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.GraphicsEnvironment;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -120,6 +122,96 @@ class TradingChartFactoryTest {
         assertFalse(domainMarkers.isEmpty(), "Should have position markers");
         assertTrue(domainMarkers.stream().anyMatch(marker -> marker instanceof IntervalMarker),
                 "Should use IntervalMarker for positions");
+    }
+
+    @Test
+    void tradingRecordLabelsDefaultToFirstSourcePosition() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        JFreeChart chart = factory.createTradingRecordChart(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX);
+        XYPlot plot = (XYPlot) chart.getPlot();
+
+        assertTradeLabelPrefixPresent(plot, "B1 @");
+        assertTradeLabelPrefixPresent(plot, "S1 @");
+        assertEquals(List.of("Position 1"),
+                extractPositionMarkers(plot).stream().map(IntervalMarker::getLabel).toList());
+    }
+
+    @Test
+    void tradingRecordLabelsUseSuppliedSourcePositionStart() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        JFreeChart chart = factory.createTradingRecordChart(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX, 2);
+        XYPlot plot = (XYPlot) chart.getPlot();
+
+        assertTradeLabelPrefixPresent(plot, "B2 @");
+        assertTradeLabelPrefixPresent(plot, "S2 @");
+        assertEquals(List.of("Position 2"),
+                extractPositionMarkers(plot).stream().map(IntervalMarker::getLabel).toList());
+    }
+
+    @Test
+    void defaultSourcePositionStartKeepsMultiPositionLabelsSequential() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        BaseTradingRecord record = new BaseTradingRecord();
+        Num amount = barSeries.numFactory().numOf(1);
+        addPosition(record, 1, 3, amount);
+        addPosition(record, 5, 7, amount);
+
+        JFreeChart chart = factory.createTradingRecordChart(barSeries, "Test Strategy", record, TimeAxisMode.BAR_INDEX);
+        XYPlot plot = (XYPlot) chart.getPlot();
+
+        assertTradeLabelPrefixPresent(plot, "B1 @");
+        assertTradeLabelPrefixPresent(plot, "S1 @");
+        assertTradeLabelPrefixPresent(plot, "B2 @");
+        assertTradeLabelPrefixPresent(plot, "S2 @");
+        assertEquals(List.of("Position 1", "Position 2"),
+                extractPositionMarkers(plot).stream().map(IntervalMarker::getLabel).toList());
+    }
+
+    @Test
+    void sourcePositionStartKeepsMultiPositionLabelsSequentialIncludingOpenPosition() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        BaseTradingRecord record = new BaseTradingRecord();
+        Num amount = barSeries.numFactory().numOf(1);
+        addPosition(record, 1, 3, amount);
+        record.enter(5, barSeries.getBar(5).getClosePrice(), amount);
+
+        JFreeChart chart = factory.createTradingRecordChart(barSeries, "Test Strategy", record, TimeAxisMode.BAR_INDEX,
+                2);
+        XYPlot plot = (XYPlot) chart.getPlot();
+
+        assertTradeLabelPrefixPresent(plot, "B2 @");
+        assertTradeLabelPrefixPresent(plot, "S2 @");
+        assertTradeLabelPrefixPresent(plot, "B3 @");
+        assertEquals(List.of("Position 2", "Position 3"),
+                extractPositionMarkers(plot).stream().map(IntervalMarker::getLabel).toList());
+    }
+
+    @Test
+    void sourcePositionStartRejectsValuesBelowOne() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> factory
+                .createTradingRecordChart(barSeries, "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 0));
+
+        assertEquals("Source position start must be at least 1", exception.getMessage());
+    }
+
+    @Test
+    void sourcePositionStartRejectsRangesThatOverflowWithAnOpenPosition() {
+        BaseTradingRecord record = new BaseTradingRecord();
+        Num amount = barSeries.numFactory().numOf(1);
+        addPosition(record, 1, 3, amount);
+        record.enter(5, barSeries.getBar(5).getClosePrice(), amount);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> factory.createTradingRecordChart(barSeries, "Test Strategy", record, TimeAxisMode.BAR_INDEX,
+                        Integer.MAX_VALUE));
+
+        assertEquals("Source position start cannot represent every rendered position", exception.getMessage());
     }
 
     @Test
@@ -1213,6 +1305,17 @@ class TradingChartFactoryTest {
                 .filter(IntervalMarker.class::isInstance)
                 .map(IntervalMarker.class::cast)
                 .collect(Collectors.toList());
+    }
+
+    private void assertTradeLabelPrefixPresent(XYPlot plot, String expectedPrefix) {
+        List<String> annotationTexts = plot.getAnnotations()
+                .stream()
+                .filter(XYTextAnnotation.class::isInstance)
+                .map(XYTextAnnotation.class::cast)
+                .map(XYTextAnnotation::getText)
+                .toList();
+        assertTrue(annotationTexts.stream().anyMatch(text -> text.startsWith(expectedPrefix)),
+                () -> "Expected trade label prefix " + expectedPrefix + " but found " + annotationTexts);
     }
 
     // ========== NaN Gap Handling Tests ==========

--- a/ta4j-examples/src/test/java/ta4jexamples/charting/workflow/ChartWorkflowTest.java
+++ b/ta4j-examples/src/test/java/ta4jexamples/charting/workflow/ChartWorkflowTest.java
@@ -12,6 +12,7 @@ import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.ui.Layer;
+import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.ta4j.core.BarSeries;
@@ -19,16 +20,19 @@ import org.ta4j.core.BaseTradingRecord;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.TradingRecord;
 import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
 import org.ta4j.core.indicators.averages.SMAIndicator;
 import org.ta4j.core.num.Num;
 
 import ta4jexamples.charting.display.SwingChartDisplayer;
 
 import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Arrays;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -158,6 +162,56 @@ public class ChartWorkflowTest {
 
         assertTrue(plot.getAnnotations().stream().anyMatch(XYTextAnnotation.class::isInstance),
                 "Trade annotations should contain readable labels");
+    }
+
+    @Test
+    public void testCustomSourcePositionStartFlowsThroughPlainAndVolumeCharts() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        JFreeChart plainChart = chartWorkflow.createTradingRecordChart(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX, 2);
+        assertSourceOrdinalLabels(plainChart.getXYPlot(), 2);
+
+        VolumeIndicator volume = new VolumeIndicator(barSeries);
+        JFreeChart volumeChart = chartWorkflow.createTradingRecordChart(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX, 2, volume);
+        CombinedDomainXYPlot combinedPlot = assertInstanceOf(CombinedDomainXYPlot.class, volumeChart.getPlot());
+        assertSourceOrdinalLabels(combinedPlot.getSubplots().get(0), 2);
+    }
+
+    @Test
+    public void testCustomSourcePositionStartFlowsThroughSavedAndEncodedCharts() throws IOException {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        RecordingChartStorage storage = new RecordingChartStorage();
+        ChartWorkflow persistentWorkflow = new ChartWorkflow(new TradingChartFactory(), new MockChartDisplayer(),
+                storage);
+
+        persistentWorkflow.saveTradingRecordChart(barSeries, "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 2);
+        assertSourceOrdinalLabels(storage.lastChart.getXYPlot(), 2);
+
+        VolumeIndicator volume = new VolumeIndicator(barSeries);
+        persistentWorkflow.saveTradingRecordChart(barSeries, "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 2,
+                volume);
+        CombinedDomainXYPlot savedVolumePlot = assertInstanceOf(CombinedDomainXYPlot.class,
+                storage.lastChart.getPlot());
+        assertSourceOrdinalLabels(savedVolumePlot.getSubplots().get(0), 2);
+
+        byte[] defaultBytes = chartWorkflow.createTradingRecordChartBytes(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX);
+        byte[] shiftedBytes = chartWorkflow.createTradingRecordChartBytes(barSeries, "Test Strategy", tradingRecord,
+                TimeAxisMode.BAR_INDEX, 2);
+        assertNotNull(decodeImage(shiftedBytes));
+        assertFalse(Arrays.equals(defaultBytes, shiftedBytes),
+                "Shifted trade labels should change encoded chart output");
+
+        byte[] defaultVolumeBytes = chartWorkflow.createTradingRecordChartBytes(barSeries, "Test Strategy",
+                tradingRecord, TimeAxisMode.BAR_INDEX, volume);
+        byte[] shiftedVolumeBytes = chartWorkflow.createTradingRecordChartBytes(barSeries, "Test Strategy",
+                tradingRecord, TimeAxisMode.BAR_INDEX, 2, volume);
+        assertNotNull(decodeImage(shiftedVolumeBytes));
+        assertFalse(Arrays.equals(defaultVolumeBytes, shiftedVolumeBytes),
+                "Shifted trade labels should change encoded volume chart output");
     }
 
     @Test
@@ -513,6 +567,48 @@ public class ChartWorkflowTest {
         assertNotNull(spyDisplayer.getLastChart(), "Chart should have been passed to displayer");
         assertTrue(spyDisplayer.getLastChart().getTitle().getText().contains("Test Strategy"),
                 "Chart title should contain strategy name");
+    }
+
+    @Test
+    public void testDisplayTradingRecordChartUsesCustomSourcePositionStart() {
+        Assume.assumeFalse("Headless environment", GraphicsEnvironment.isHeadless());
+
+        MockChartDisplayer displayer = new MockChartDisplayer();
+        ChartWorkflow workflow = new ChartWorkflow(new TradingChartFactory(), displayer, ChartStorage.noOp());
+
+        workflow.displayTradingRecordChart(barSeries, "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 2);
+        assertSourceOrdinalLabels(displayer.getLastChart().getXYPlot(), 2);
+
+        VolumeIndicator volume = new VolumeIndicator(barSeries);
+        workflow.displayTradingRecordChart(barSeries, "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 2,
+                volume);
+        CombinedDomainXYPlot combinedPlot = assertInstanceOf(CombinedDomainXYPlot.class,
+                displayer.getLastChart().getPlot());
+        assertSourceOrdinalLabels(combinedPlot.getSubplots().get(0), 2);
+    }
+
+    @Test
+    public void testDisplayTradingRecordChartRejectsInvalidSourcePositionStart() {
+        MockChartDisplayer displayer = new MockChartDisplayer();
+        ChartWorkflow workflow = new ChartWorkflow(new TradingChartFactory(), displayer, ChartStorage.noOp());
+        VolumeIndicator volume = new VolumeIndicator(barSeries);
+
+        assertThrows(IllegalArgumentException.class, () -> workflow.displayTradingRecordChart(barSeries,
+                "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 0));
+        assertThrows(IllegalArgumentException.class, () -> workflow.displayTradingRecordChart(barSeries,
+                "Test Strategy", tradingRecord, TimeAxisMode.BAR_INDEX, 0, volume));
+
+        BaseTradingRecord overflowRecord = new BaseTradingRecord();
+        Num amount = barSeries.numFactory().numOf(1);
+        overflowRecord.enter(1, barSeries.getBar(1).getClosePrice(), amount);
+        overflowRecord.exit(3, barSeries.getBar(3).getClosePrice(), amount);
+        overflowRecord.enter(5, barSeries.getBar(5).getClosePrice(), amount);
+
+        assertThrows(IllegalArgumentException.class, () -> workflow.displayTradingRecordChart(barSeries,
+                "Test Strategy", overflowRecord, TimeAxisMode.BAR_INDEX, Integer.MAX_VALUE));
+        assertThrows(IllegalArgumentException.class, () -> workflow.displayTradingRecordChart(barSeries,
+                "Test Strategy", overflowRecord, TimeAxisMode.BAR_INDEX, Integer.MAX_VALUE, volume));
+        assertNull(displayer.getLastChart(), "Invalid source positions must not reach the displayer");
     }
 
     @Test
@@ -1378,6 +1474,37 @@ public class ChartWorkflowTest {
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
         assertNotNull(image, "Encoded chart bytes should decode into an image");
         return image;
+    }
+
+    private static void assertSourceOrdinalLabels(XYPlot plot, int sourcePositionNumber) {
+        String buyPrefix = "B" + sourcePositionNumber + " @";
+        String sellPrefix = "S" + sourcePositionNumber + " @";
+        assertTrue(
+                plot.getAnnotations()
+                        .stream()
+                        .filter(XYTextAnnotation.class::isInstance)
+                        .map(XYTextAnnotation.class::cast)
+                        .map(XYTextAnnotation::getText)
+                        .anyMatch(text -> text.startsWith(buyPrefix)),
+                "Buy annotation should use the source position number");
+        assertTrue(
+                plot.getAnnotations()
+                        .stream()
+                        .filter(XYTextAnnotation.class::isInstance)
+                        .map(XYTextAnnotation.class::cast)
+                        .map(XYTextAnnotation::getText)
+                        .anyMatch(text -> text.startsWith(sellPrefix)),
+                "Sell annotation should use the source position number");
+
+        Collection<?> markers = plot.getDomainMarkers(Layer.BACKGROUND);
+        assertNotNull(markers, "Position band should be present");
+        assertTrue(
+                markers.stream()
+                        .filter(IntervalMarker.class::isInstance)
+                        .map(IntervalMarker.class::cast)
+                        .map(IntervalMarker::getLabel)
+                        .anyMatch(("Position " + sourcePositionNumber)::equals),
+                "Position band should use the source position number");
     }
 
     private static final class RecordingChartStorage implements ChartStorage {


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Adds backwards-compatible 1-based source-position-start overloads for trading-record charts.
- Preserves source ordinals in position-band and buy/sell labels across create, save, display, and PNG chart paths.
- Adds overflow and headless-safe regression coverage, and documents the behavior in the Unreleased changelog.

- [x] I have run `mvn -B clean license:format formatter:format verify install` (or `scripts/run-full-build-quiet.sh`) to test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`