### PR TITLE
CF-303 restore full build under three minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Cached indicator stress coverage is less scheduler-sensitive**: `CachedIndicatorTest` now waits for a bounded minimum-read signal before ending the concurrent mutation phase, so the full-build gate continues to exercise cache invalidation under contention without failing because reader threads were scheduled late.
 
 ### Fixed
+- **Day-of-week rule descriptors are deterministic**: `DayOfWeekRule` now canonicalizes its configured enum set so descriptor and JSON serialization round trips cannot fail or change output when hash iteration order varies between runs.
 - **Source position labels remain accurate in isolated chart renders**: Trading-record
   chart callers can now provide a 1-based source position start, so position bands
   and buy/sell annotations retain their original ordinal when a focused chart

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -465,6 +465,9 @@ public class BacktestExecutor {
      * @param action    action invoked once for every index
      */
     static void forEachBatchIndex(int itemCount, int batchSize, IntConsumer action) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be positive");
+        }
         for (int batchStart = 0; batchStart < itemCount; batchStart += batchSize) {
             int batchEnd = Math.min(batchStart + batchSize, itemCount);
             IntStream.range(batchStart, batchEnd).parallel().forEach(action);

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
 /**
@@ -409,9 +410,8 @@ public class BacktestExecutor {
 
         // For large strategy counts, use batched processing to prevent memory
         // exhaustion. Use smaller batches for very large counts.
-        if (strategyCount > PARALLEL_THRESHOLD) {
-            int effectiveBatchSize = strategyCount > LARGE_COUNT_THRESHOLD ? Math.min(batchSize, SMALL_BATCH_SIZE)
-                    : batchSize;
+        if (usesBatchedExecution(strategyCount)) {
+            int effectiveBatchSize = effectiveBatchSize(strategyCount, batchSize);
             executeBatched(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback,
                     effectiveBatchSize);
         } else {
@@ -433,6 +433,42 @@ public class BacktestExecutor {
 
         BacktestRuntimeReport runtimeReport = buildRuntimeReport(durations, overallRuntime, strategyRuntimes);
         return new BacktestExecutionResult(seriesManager.getBarSeries(), tradingStatements, runtimeReport);
+    }
+
+    /**
+     * Determines whether an execution should use bounded batches.
+     *
+     * @param strategyCount number of strategies in the execution
+     * @return {@code true} when bounded batching is required
+     */
+    static boolean usesBatchedExecution(int strategyCount) {
+        return strategyCount > PARALLEL_THRESHOLD;
+    }
+
+    /**
+     * Selects the requested batch size, capped for exceptionally large workloads.
+     *
+     * @param strategyCount      number of strategies in the execution
+     * @param requestedBatchSize caller-provided batch size
+     * @return effective batch size for the execution
+     */
+    static int effectiveBatchSize(int strategyCount, int requestedBatchSize) {
+        return strategyCount > LARGE_COUNT_THRESHOLD ? Math.min(requestedBatchSize, SMALL_BATCH_SIZE)
+                : requestedBatchSize;
+    }
+
+    /**
+     * Visits every item index in bounded parallel batches.
+     *
+     * @param itemCount number of item indexes to visit
+     * @param batchSize maximum number of indexes processed in one batch
+     * @param action    action invoked once for every index
+     */
+    static void forEachBatchIndex(int itemCount, int batchSize, IntConsumer action) {
+        for (int batchStart = 0; batchStart < itemCount; batchStart += batchSize) {
+            int batchEnd = Math.min(batchStart + batchSize, itemCount);
+            IntStream.range(batchStart, batchEnd).parallel().forEach(action);
+        }
     }
 
     /**
@@ -937,25 +973,19 @@ public class BacktestExecutor {
         int strategyCount = strategyArray.length;
         ProgressTracker progressTracker = ProgressTracker.create(progressCallback);
 
-        for (int batchStart = 0; batchStart < strategyCount; batchStart += batchSize) {
-            int batchEnd = Math.min(batchStart + batchSize, strategyCount);
-            final int batchStartFinal = batchStart;
+        forEachBatchIndex(strategyCount, batchSize, index -> {
+            Strategy strategy = strategyArray[index];
+            long strategyStart = System.nanoTime();
+            TradingRecord tradingRecord = tradingRecordRunner.apply(strategy);
+            TradingStatement statement = tradingStatementGenerator.generate(strategy, tradingRecord,
+                    seriesManager.getBarSeries());
+            statements[index] = statement;
+            durations[index] = System.nanoTime() - strategyStart;
 
-            IntStream.range(0, batchEnd - batchStart).parallel().forEach(localIndex -> {
-                int globalIndex = batchStartFinal + localIndex;
-                Strategy strategy = strategyArray[globalIndex];
-                long strategyStart = System.nanoTime();
-                TradingRecord tradingRecord = tradingRecordRunner.apply(strategy);
-                TradingStatement statement = tradingStatementGenerator.generate(strategy, tradingRecord,
-                        seriesManager.getBarSeries());
-                statements[globalIndex] = statement;
-                durations[globalIndex] = System.nanoTime() - strategyStart;
-
-                if (progressTracker != null) {
-                    progressTracker.reportCompletion();
-                }
-            });
-        }
+            if (progressTracker != null) {
+                progressTracker.reportCompletion();
+            }
+        });
     }
 
     private static final class ProgressTracker {

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -7,7 +7,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -51,7 +51,7 @@ public class DayOfWeekRule extends AbstractRule {
         DateTimeIndicator validatedTimeIndicator = Objects.requireNonNull(timeIndicator, "timeIndicator");
         Objects.requireNonNull(daysOfWeek, "daysOfWeek");
         DayOfWeek[] copiedDays = Arrays.copyOf(daysOfWeek, daysOfWeek.length);
-        Set<DayOfWeek> copiedDaySet = new HashSet<>(copiedDays.length);
+        Set<DayOfWeek> copiedDaySet = EnumSet.noneOf(DayOfWeek.class);
         for (DayOfWeek day : copiedDays) {
             copiedDaySet.add(Objects.requireNonNull(day, "dayOfWeek"));
         }

--- a/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/rules/DayOfWeekRule.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class DayOfWeekRule extends AbstractRule {
         for (DayOfWeek day : copiedDays) {
             copiedDaySet.add(Objects.requireNonNull(day, "dayOfWeek"));
         }
-        return new Config(validatedTimeIndicator, Set.copyOf(copiedDaySet));
+        return new Config(validatedTimeIndicator, Collections.unmodifiableSet(copiedDaySet));
     }
 
     /** This rule does not use the {@code tradingRecord}. */

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import org.junit.Test;
 import org.ta4j.core.AnalysisCriterion;
@@ -144,43 +145,28 @@ public class BacktestExecutorTest extends AbstractIndicatorTest<BarSeries, Num> 
     }
 
     @Test
-    public void executeWithLargeStrategyCountUsesBatchProcessing() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(10, 11, 12, 13, 14).build();
-
-        // Create more than PARALLEL_THRESHOLD (1000) strategies to trigger batched
-        // processing
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 1500; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        AtomicInteger progressUpdateCount = new AtomicInteger(0);
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, numOf(1), Trade.TradeType.BUY,
-                completed -> progressUpdateCount.incrementAndGet());
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-        assertEquals(strategies.size(), result.runtimeReport().strategyCount());
-        assertEquals(strategies.size(), progressUpdateCount.get());
+    public void batchingDecisionUsesConfiguredThreshold() {
+        assertFalse(BacktestExecutor.usesBatchedExecution(1000));
+        assertTrue(BacktestExecutor.usesBatchedExecution(1001));
     }
 
     @Test
-    public void executeWithCustomBatchSize() {
-        var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(10, 11, 12, 13, 14).build();
+    public void effectiveBatchSizeCapsVeryLargeWorkloads() {
+        assertEquals(500, BacktestExecutor.effectiveBatchSize(1500, 500));
+        assertEquals(250, BacktestExecutor.effectiveBatchSize(5001, 500));
+        assertEquals(100, BacktestExecutor.effectiveBatchSize(5001, 100));
+    }
 
-        // Create more than PARALLEL_THRESHOLD strategies
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 1500; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
+    @Test
+    public void batchedExecutionVisitsEveryIndexExactlyOnce() {
+        int itemCount = 7;
+        AtomicIntegerArray visits = new AtomicIntegerArray(itemCount);
+
+        BacktestExecutor.forEachBatchIndex(itemCount, 3, index -> visits.incrementAndGet(index));
+
+        for (int index = 0; index < itemCount; index++) {
+            assertEquals(1, visits.get(index));
         }
-
-        int customBatchSize = 250;
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, numOf(1), Trade.TradeType.BUY,
-                null, customBatchSize);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-        assertEquals(strategies.size(), result.runtimeReport().strategyCount());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -167,6 +168,14 @@ public class BacktestExecutorTest extends AbstractIndicatorTest<BarSeries, Num> 
         for (int index = 0; index < itemCount; index++) {
             assertEquals(1, visits.get(index));
         }
+    }
+
+    @Test
+    public void batchedExecutionRejectsInvalidBatchSizes() {
+        assertThrows(IllegalArgumentException.class, () -> BacktestExecutor.forEachBatchIndex(1, 0, index -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> BacktestExecutor.forEachBatchIndex(1, -1, index -> {
+        }));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/ProgressCompletionTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/ProgressCompletionTest.java
@@ -7,24 +7,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.ta4j.core.BarSeries;
-import org.ta4j.core.BaseStrategy;
-import org.ta4j.core.Strategy;
-import org.ta4j.core.Trade;
-import org.ta4j.core.backtest.BacktestExecutionResult;
-import org.ta4j.core.backtest.BacktestExecutor;
-import org.ta4j.core.mocks.MockBarSeriesBuilder;
-import org.ta4j.core.num.DecimalNum;
-import org.ta4j.core.num.DecimalNumFactory;
-import org.ta4j.core.rules.FixedRule;
 
 public class ProgressCompletionTest {
 
@@ -116,50 +104,6 @@ public class ProgressCompletionTest {
         wrapped.accept(100); // Interval and 50% milestone
         wrapped.accept(150); // Interval and 75% milestone
         wrapped.accept(200); // Interval and 100% milestone
-    }
-
-    @Test
-    public void loggingWithAutoDetectionWorksWithBacktestExecutor() {
-        // Integration test to ensure auto-detection works with actual BacktestExecutor
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 150; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        // Use auto-detection convenience method
-        Consumer<Integer> callback = ProgressCompletion.logging();
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
-
-    @Test
-    public void loggingWithAutoDetectionAndIntervalWorksWithBacktestExecutor() {
-        // Integration test with custom interval
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 200; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        // Use auto-detection with custom interval
-        Consumer<Integer> callback = ProgressCompletion.logging(50);
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
     }
 
     @Test
@@ -359,50 +303,6 @@ public class ProgressCompletionTest {
     }
 
     @Test
-    public void loggingWithMemoryWorksWithBacktestExecutor() {
-        // Integration test to ensure memory logging works with actual BacktestExecutor
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 150; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        // Use memory logging convenience method
-        Consumer<Integer> callback = ProgressCompletion.loggingWithMemory();
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
-
-    @Test
-    public void loggingWithMemoryAndIntervalWorksWithBacktestExecutor() {
-        // Integration test with custom interval
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 200; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        // Use memory logging with custom interval
-        Consumer<Integer> callback = ProgressCompletion.loggingWithMemory(50);
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
-
-    @Test
     public void loggingWithMemoryFromHelperClass() {
         // Test that memory logging auto-detection works when called from helper class
         MemoryTestHelper helper = new MemoryTestHelper();
@@ -588,65 +488,4 @@ public class ProgressCompletionTest {
         callback.accept(200); // 50%
     }
 
-    @Test
-    public void loggingWorksWithBacktestExecutor() {
-        // Integration test to ensure it works with actual BacktestExecutor
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 250; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        Consumer<Integer> callback = ProgressCompletion.logging(ProgressCompletionTest.class);
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
-
-    @Test
-    public void noOpWorksWithBacktestExecutor() {
-        // Integration test to ensure noOp works with actual BacktestExecutor
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        Consumer<Integer> callback = ProgressCompletion.noOp();
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, callback);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
-
-    @Test
-    public void defaultNoOpWhenNullCallback() {
-        // Integration test to verify default noOp behavior
-        BarSeries series = new MockBarSeriesBuilder().withNumFactory(DecimalNumFactory.getInstance())
-                .withData(10, 11, 12, 13, 14)
-                .build();
-
-        List<Strategy> strategies = new ArrayList<>();
-        for (int i = 0; i < 50; i++) {
-            strategies.add(new BaseStrategy(new FixedRule(0, 2), new FixedRule(1, 3)));
-        }
-
-        BacktestExecutor executor = new BacktestExecutor(series);
-        // Pass null - should use default noOp
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, DecimalNum.valueOf(1),
-                Trade.TradeType.BUY, null);
-
-        assertEquals(strategies.size(), result.tradingStatements().size());
-    }
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -3,6 +3,7 @@
  */
 package org.ta4j.core.rules;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -15,6 +16,9 @@ import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.helpers.DateTimeIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.NumFactory;
+import org.ta4j.core.serialization.ComponentDescriptor;
+import org.ta4j.core.serialization.ComponentSerialization;
+import org.ta4j.core.serialization.RuleSerialization;
 
 public class DayOfWeekRuleTest extends AbstractIndicatorTest<Object, Object> {
 
@@ -53,9 +57,16 @@ public class DayOfWeekRuleTest extends AbstractIndicatorTest<Object, Object> {
         series.barBuilder().endTime(Instant.parse("2019-09-17T12:00:00Z")).add();
         series.barBuilder().endTime(Instant.parse("2019-09-18T12:00:00Z")).add();
         var dateTime = new DateTimeIndicator(series, Bar::getEndTime);
-        DayOfWeekRule rule = new DayOfWeekRule(dateTime, DayOfWeek.WEDNESDAY, DayOfWeek.MONDAY);
-        RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, rule);
-        RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, rule);
+        DayOfWeekRule mondayFirst = new DayOfWeekRule(dateTime, DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY);
+        DayOfWeekRule wednesdayFirst = new DayOfWeekRule(dateTime, DayOfWeek.WEDNESDAY, DayOfWeek.MONDAY);
+        ComponentDescriptor mondayFirstDescriptor = RuleSerialization.describe(mondayFirst);
+        ComponentDescriptor wednesdayFirstDescriptor = RuleSerialization.describe(wednesdayFirst);
+
+        assertEquals(mondayFirstDescriptor, wednesdayFirstDescriptor);
+        assertEquals(ComponentSerialization.toJson(mondayFirstDescriptor),
+                ComponentSerialization.toJson(wednesdayFirstDescriptor));
+        RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, wednesdayFirst);
+        RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, wednesdayFirst);
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/rules/DayOfWeekRuleTest.java
@@ -53,7 +53,7 @@ public class DayOfWeekRuleTest extends AbstractIndicatorTest<Object, Object> {
         series.barBuilder().endTime(Instant.parse("2019-09-17T12:00:00Z")).add();
         series.barBuilder().endTime(Instant.parse("2019-09-18T12:00:00Z")).add();
         var dateTime = new DateTimeIndicator(series, Bar::getEndTime);
-        DayOfWeekRule rule = new DayOfWeekRule(dateTime, DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY);
+        DayOfWeekRule rule = new DayOfWeekRule(dateTime, DayOfWeek.WEDNESDAY, DayOfWeek.MONDAY);
         RuleSerializationRoundTripTestSupport.assertRuleRoundTrips(series, rule);
         RuleSerializationRoundTripTestSupport.assertRuleJsonRoundTrips(series, rule);
     }


### PR DESCRIPTION
Fixes CF-303.

Changes proposed in this pull request:
- Replace integration-style progress callback checks with direct unit coverage.
- Test batching thresholds, size selection, and traversal without thousands of real backtests.
- Keep day-of-week serialization descriptors deterministic across repeated full builds.

- [x] I have run `mvn -B clean license:format formatter:format verify install` (or `scripts/run-full-build-quiet.sh`) to test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured `DayOfWeekRule` produces deterministic configuration/JSON outputs, avoiding round-trip mismatches and run-to-run variations.

* **Performance**
  * Improved bounded backtest execution by using batched processing with capped batch sizes for very large workloads, while still covering all indexes.

* **Tests**
  * Added unit coverage for batching decisions, batch size capping, and index traversal correctness.
  * Strengthened rule serialization tests to confirm identical results regardless of input day order.
  * Removed executor-based integration-style tests for progress completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->