### PR TITLE
Preserve absolute indices when restoring bar series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 ### Changed
 - **Retained bar series can resume at their absolute index**: `BaseBarSeriesBuilder` and
   `ConcurrentBarSeriesBuilder` now accept `withBeginIndex(int)`, allowing persisted windows to
-  append, prune, create subseries, and serialize without rebasing their surviving bars to zero.
+  append, prune, create subseries, and serialize without rebasing their surviving bars to zero;
+  `BarSeries.clear()` resets a restored series for intentional reinitialization while preserving
+  its configuration.
 - **Finite `Num` validation is reusable across indicators**: Added `Num.isFinite(...)` for indicator-safe checks that reject null, NaN, and primitive-backed infinities without misclassifying finite high-precision `DecimalNum` values whose `doubleValue()` overflows; internal indicator code now uses this shared contract directly, and `IndicatorUtils.isInvalid(...)` is deprecated as a compatibility shim.
 - **Elliott anchor calibration is harness-only**: Long BTC anchor calibration now lives behind `ElliottWaveAnchorCalibrationHarness` as a dedicated CLI/job entrypoint, while the remaining harness unit tests exercise registry, windowing, report, and artifact contracts with synthetic inputs. Active docs warn that full anchor calibration can run for 8+ hours.
 - **Daily live Elliott preset runs now use the generic macro snapshot path**: `ElliottWavePresetDemo` routes any daily live instrument through the macro-cycle preset so non-BTC symbols receive the same base case plus four alternate outlooks with instrument-aware filenames and scenario-outlook JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Pluggable execution-target estimation for dynamic sizing**: Added `TradeExecutionModel#estimateEntryTarget(...)` so custom execution models can provide sizing-aware fill timing and pricing. Dynamic sizing now defaults to conservative next-open estimation for models that do not override this API, and falls back safely when no target is resolvable to keep runs defined.
 
 ### Changed
+- **Retained bar series can resume at their absolute index**: `BaseBarSeriesBuilder` and
+  `ConcurrentBarSeriesBuilder` now accept `withBeginIndex(int)`, allowing persisted windows to
+  append, prune, create subseries, and serialize without rebasing their surviving bars to zero.
 - **Finite `Num` validation is reusable across indicators**: Added `Num.isFinite(...)` for indicator-safe checks that reject null, NaN, and primitive-backed infinities without misclassifying finite high-precision `DecimalNum` values whose `doubleValue()` overflows; internal indicator code now uses this shared contract directly, and `IndicatorUtils.isInvalid(...)` is deprecated as a compatibility shim.
 - **Elliott anchor calibration is harness-only**: Long BTC anchor calibration now lives behind `ElliottWaveAnchorCalibrationHarness` as a dedicated CLI/job entrypoint, while the remaining harness unit tests exercise registry, windowing, report, and artifact contracts with synthetic inputs. Active docs warn that full anchor calibration can run for 8+ hours.
 - **Daily live Elliott preset runs now use the generic macro snapshot path**: `ElliottWavePresetDemo` routes any daily live instrument through the macro-cycle preset so non-BTC symbols receive the same base case plus four alternate outlooks with instrument-aware filenames and scenario-outlook JSON.

--- a/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BarSeries.java
@@ -105,6 +105,22 @@ public interface BarSeries extends Serializable {
     List<Bar> getBarData();
 
     /**
+     * Removes every retained bar and resets the series to its initial empty index
+     * state.
+     *
+     * <p>
+     * The configured name, number factory, bar builder, and maximum bar count are
+     * preserved. The next appended bar receives index {@code 0}. Implementations
+     * that cannot safely clear their storage may retain the default behavior, which
+     * throws {@link UnsupportedOperationException}.
+     *
+     * @since 0.22.9
+     */
+    default void clear() {
+        throw new UnsupportedOperationException("This bar series does not support clearing");
+    }
+
+    /**
      * @return the begin index of the series
      */
     int getBeginIndex();

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -95,7 +95,8 @@ public class BaseBarSeries implements BarSeries {
      */
     BaseBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,
             final boolean constrained, final NumFactory numFactory, final BarBuilderFactory barBuilderFactory) {
-        this(name, bars, seriesBeginIndex, seriesEndIndex, 0, constrained, numFactory, barBuilderFactory);
+        this(validatedConfig(name, bars, seriesBeginIndex, seriesEndIndex, 0, constrained, numFactory,
+                barBuilderFactory));
     }
 
     BaseBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -139,7 +139,7 @@ public class BaseBarSeries implements BarSeries {
         if (removedBarsCount < 0 || seriesBeginIndex < removedBarsCount) {
             throw new IllegalArgumentException("Removed bars count must be between zero and the begin index");
         }
-        if (seriesEndIndex >= removedBarsCount + copiedBars.size()) {
+        if ((long) seriesEndIndex >= (long) removedBarsCount + copiedBars.size()) {
             throw new IllegalArgumentException("End index must be within the offset bar list");
         }
         return new Config(name, copiedBars, seriesBeginIndex, seriesEndIndex, removedBarsCount, constrained, numFactory,
@@ -182,13 +182,14 @@ public class BaseBarSeries implements BarSeries {
             throw new IllegalArgumentException(
                     String.format("the endIndex: %s must be greater than startIndex: %s", endIndex, startIndex));
         }
+        final int retainedStartIndex = Math.max(startIndex, this.seriesBeginIndex);
         var builder = new BaseBarSeriesBuilder().withName(getName())
                 .withNumFactory(this.numFactory)
                 .withMaxBarCount(this.maximumBarCount)
-                .withBeginIndex(this.removedBarsCount > 0 ? startIndex : 0);
+                .withBeginIndex(this.removedBarsCount > 0 ? retainedStartIndex : 0);
         if (!this.bars.isEmpty()) {
             var removedBarsCount = getRemovedBarsCount();
-            var start = startIndex - removedBarsCount;
+            var start = retainedStartIndex - removedBarsCount;
             var end = Math.min(endIndex - removedBarsCount, this.getEndIndex() + 1);
             return builder.withBars(cut(this.bars, start, end)).build();
         }
@@ -302,6 +303,8 @@ public class BaseBarSeries implements BarSeries {
 
     /**
      * @throws NullPointerException if {@code bar} is {@code null}
+     * @throws ArithmeticException  if appending would advance the absolute index
+     *                              beyond {@link Integer#MAX_VALUE}
      */
     @Override
     public void addBar(final Bar bar, final boolean replace) {
@@ -317,6 +320,9 @@ public class BaseBarSeries implements BarSeries {
                 this.bars.set(this.bars.size() - 1, bar);
                 return;
             }
+            if (this.seriesEndIndex == Integer.MAX_VALUE) {
+                throw new ArithmeticException("Bar series index overflow");
+            }
             final int lastBarIndex = this.bars.size() - 1;
             final Instant seriesEndTime = this.bars.get(lastBarIndex).getEndTime();
             if (!bar.getEndTime().isAfter(seriesEndTime)) {
@@ -331,7 +337,7 @@ public class BaseBarSeries implements BarSeries {
             // The begin index is set to 0 if not already initialized:
             this.seriesBeginIndex = 0;
         }
-        this.seriesEndIndex++;
+        this.seriesEndIndex = Math.incrementExact(this.seriesEndIndex);
         removeExceedingBars();
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -118,13 +118,13 @@ public class BaseBarSeries implements BarSeries {
 
     private static Config defaultConfig(final String name, final List<Bar> bars) {
         List<Bar> copiedBars = new ArrayList<>(Objects.requireNonNull(bars, "bars"));
-        return validatedConfig(name, copiedBars, 0, copiedBars.size() - 1, 0, false,
-                DecimalNumFactory.getInstance(), new TimeBarBuilderFactory());
+        return validatedConfig(name, copiedBars, 0, copiedBars.size() - 1, 0, false, DecimalNumFactory.getInstance(),
+                new TimeBarBuilderFactory());
     }
 
     private static Config validatedConfig(final String name, final List<Bar> bars, final int seriesBeginIndex,
-            final int seriesEndIndex, final int removedBarsCount, final boolean constrained, final NumFactory numFactory,
-            final BarBuilderFactory barBuilderFactory) {
+            final int seriesEndIndex, final int removedBarsCount, final boolean constrained,
+            final NumFactory numFactory, final BarBuilderFactory barBuilderFactory) {
         List<Bar> copiedBars = new ArrayList<>(Objects.requireNonNull(bars, "bars"));
         BarBuilderFactory validatedBarBuilderFactory = Objects.requireNonNull(barBuilderFactory);
         if (copiedBars.isEmpty()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -184,7 +184,7 @@ public class BaseBarSeries implements BarSeries {
         var builder = new BaseBarSeriesBuilder().withName(getName())
                 .withNumFactory(this.numFactory)
                 .withMaxBarCount(this.maximumBarCount)
-                .withBeginIndex(startIndex);
+                .withBeginIndex(this.removedBarsCount > 0 ? startIndex : 0);
         if (!this.bars.isEmpty()) {
             var removedBarsCount = getRemovedBarsCount();
             var start = startIndex - removedBarsCount;

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -251,6 +251,19 @@ public class BaseBarSeries implements BarSeries {
         return List.copyOf(this.bars);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 0.22.9
+     */
+    @Override
+    public void clear() {
+        this.bars.clear();
+        this.seriesBeginIndex = -1;
+        this.seriesEndIndex = -1;
+        this.removedBarsCount = 0;
+    }
+
     @Override
     public int getBeginIndex() {
         return this.seriesBeginIndex;

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeries.java
@@ -95,7 +95,14 @@ public class BaseBarSeries implements BarSeries {
      */
     BaseBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,
             final boolean constrained, final NumFactory numFactory, final BarBuilderFactory barBuilderFactory) {
-        this(validatedConfig(name, bars, seriesBeginIndex, seriesEndIndex, constrained, numFactory, barBuilderFactory));
+        this(name, bars, seriesBeginIndex, seriesEndIndex, 0, constrained, numFactory, barBuilderFactory);
+    }
+
+    BaseBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,
+            final int removedBarsCount, final boolean constrained, final NumFactory numFactory,
+            final BarBuilderFactory barBuilderFactory) {
+        this(validatedConfig(name, bars, seriesBeginIndex, seriesEndIndex, removedBarsCount, constrained, numFactory,
+                barBuilderFactory));
     }
 
     private BaseBarSeries(final Config config) {
@@ -105,32 +112,36 @@ public class BaseBarSeries implements BarSeries {
         this.barBuilderFactory = config.barBuilderFactory();
         this.seriesBeginIndex = config.seriesBeginIndex();
         this.seriesEndIndex = config.seriesEndIndex();
+        this.removedBarsCount = config.removedBarsCount();
         this.constrained = config.constrained();
     }
 
     private static Config defaultConfig(final String name, final List<Bar> bars) {
         List<Bar> copiedBars = new ArrayList<>(Objects.requireNonNull(bars, "bars"));
-        return validatedConfig(name, copiedBars, 0, copiedBars.size() - 1, false, DecimalNumFactory.getInstance(),
-                new TimeBarBuilderFactory());
+        return validatedConfig(name, copiedBars, 0, copiedBars.size() - 1, 0, false,
+                DecimalNumFactory.getInstance(), new TimeBarBuilderFactory());
     }
 
     private static Config validatedConfig(final String name, final List<Bar> bars, final int seriesBeginIndex,
-            final int seriesEndIndex, final boolean constrained, final NumFactory numFactory,
+            final int seriesEndIndex, final int removedBarsCount, final boolean constrained, final NumFactory numFactory,
             final BarBuilderFactory barBuilderFactory) {
         List<Bar> copiedBars = new ArrayList<>(Objects.requireNonNull(bars, "bars"));
         BarBuilderFactory validatedBarBuilderFactory = Objects.requireNonNull(barBuilderFactory);
         if (copiedBars.isEmpty()) {
             // Bar list empty
-            return new Config(name, copiedBars, -1, -1, false, numFactory, validatedBarBuilderFactory);
+            return new Config(name, copiedBars, -1, -1, 0, false, numFactory, validatedBarBuilderFactory);
         }
         // Bar list not empty: checking indexes
         if (seriesEndIndex < seriesBeginIndex - 1) {
             throw new IllegalArgumentException("End index must be >= to begin index - 1");
         }
-        if (seriesEndIndex >= copiedBars.size()) {
-            throw new IllegalArgumentException("End index must be < to the bar list size");
+        if (removedBarsCount < 0 || seriesBeginIndex < removedBarsCount) {
+            throw new IllegalArgumentException("Removed bars count must be between zero and the begin index");
         }
-        return new Config(name, copiedBars, seriesBeginIndex, seriesEndIndex, constrained, numFactory,
+        if (seriesEndIndex >= removedBarsCount + copiedBars.size()) {
+            throw new IllegalArgumentException("End index must be within the offset bar list");
+        }
+        return new Config(name, copiedBars, seriesBeginIndex, seriesEndIndex, removedBarsCount, constrained, numFactory,
                 validatedBarBuilderFactory);
     }
 
@@ -157,8 +168,8 @@ public class BaseBarSeries implements BarSeries {
                 series.removedBarsCount, index);
     }
 
-    private record Config(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, boolean constrained,
-            NumFactory numFactory, BarBuilderFactory barBuilderFactory) {
+    private record Config(String name, List<Bar> bars, int seriesBeginIndex, int seriesEndIndex, int removedBarsCount,
+            boolean constrained, NumFactory numFactory, BarBuilderFactory barBuilderFactory) {
     }
 
     @Override
@@ -172,7 +183,8 @@ public class BaseBarSeries implements BarSeries {
         }
         var builder = new BaseBarSeriesBuilder().withName(getName())
                 .withNumFactory(this.numFactory)
-                .withMaxBarCount(this.maximumBarCount);
+                .withMaxBarCount(this.maximumBarCount)
+                .withBeginIndex(startIndex);
         if (!this.bars.isEmpty()) {
             var removedBarsCount = getRemovedBarsCount();
             var start = startIndex - removedBarsCount;

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -23,6 +23,7 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
     private String name;
     private boolean constrained;
     private int maxBarCount;
+    private int beginIndex;
     private boolean isNumFactoryAssigned = false;
     private NumFactory numFactory = DecimalNumFactory.getInstance();
     private BarBuilderFactory barBuilderFactory = new TimeBarBuilderFactory();
@@ -37,6 +38,7 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         this.name = "unnamed_series";
         this.constrained = false;
         this.maxBarCount = Integer.MAX_VALUE;
+        this.beginIndex = 0;
     }
 
     @Override
@@ -44,8 +46,8 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         int beginIndex = -1;
         int endIndex = -1;
         if (!bars.isEmpty()) {
-            beginIndex = 0;
-            endIndex = bars.size() - 1;
+            beginIndex = this.beginIndex;
+            endIndex = beginIndex + bars.size() - 1;
 
             if (!isNumFactoryAssigned) {
                 // use numFactory derived from bars instead of default numFactory
@@ -66,7 +68,7 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         }
 
         var series = new BaseBarSeries(name == null ? UNNAMED_SERIES_NAME : name, bars, beginIndex, endIndex,
-                constrained, numFactory, barBuilderFactory);
+                beginIndex < 0 ? 0 : beginIndex, constrained, numFactory, barBuilderFactory);
         series.setMaximumBarCount(maxBarCount);
         initValues(); // reinitialize values for next series
         return series;
@@ -120,6 +122,21 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
      */
     public BaseBarSeriesBuilder withBars(List<Bar> bars) {
         this.bars = new ArrayList<>(Objects.requireNonNull(bars, "bars must not be null"));
+        return this;
+    }
+
+    /**
+     * Sets the absolute index assigned to the first supplied bar.
+     *
+     * @param beginIndex non-negative first bar index
+     * @return {@code this}
+     * @since 0.22.9
+     */
+    public BaseBarSeriesBuilder withBeginIndex(int beginIndex) {
+        if (beginIndex < 0) {
+            throw new IllegalArgumentException("beginIndex must be non-negative");
+        }
+        this.beginIndex = beginIndex;
         return this;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/BaseBarSeriesBuilder.java
@@ -41,13 +41,19 @@ public class BaseBarSeriesBuilder implements BarSeriesBuilder {
         this.beginIndex = 0;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ArithmeticException if the configured begin index and bars would
+     *                             exceed {@link Integer#MAX_VALUE}
+     */
     @Override
     public BaseBarSeries build() {
         int beginIndex = -1;
         int endIndex = -1;
         if (!bars.isEmpty()) {
             beginIndex = this.beginIndex;
-            endIndex = beginIndex + bars.size() - 1;
+            endIndex = Math.addExact(beginIndex, bars.size() - 1);
 
             if (!isNumFactoryAssigned) {
                 // use numFactory derived from bars instead of default numFactory

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -142,7 +142,7 @@ public class ConcurrentBarSeries extends BaseBarSeries {
                 final int end = Math.min(endIndex - super.getRemovedBarsCount(), super.getEndIndex() + 1);
                 final var builder = new ConcurrentBarSeriesBuilder().withName(getName())
                         .withBars(cut(bars, start, end))
-                        .withBeginIndex(startIndex)
+                        .withBeginIndex(super.getRemovedBarsCount() > 0 ? startIndex : 0)
                         .withNumFactory(super.numFactory())
                         .withBarBuilderFactory(super.barBuilderFactory());
                 if (!isConstrained()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -93,6 +93,15 @@ public class ConcurrentBarSeries extends BaseBarSeries {
     }
 
     ConcurrentBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,
+            final int removedBarsCount, final boolean constrained, final NumFactory numFactory,
+            final BarBuilderFactory barBuilderFactory) {
+        super(name, bars, seriesBeginIndex, seriesEndIndex, removedBarsCount, constrained, numFactory,
+                barBuilderFactory);
+        initLocks(new ReentrantReadWriteLock());
+        this.tradeBarBuilder = Objects.requireNonNull(super.barBuilder(), "barBuilder cannot be null");
+    }
+
+    ConcurrentBarSeries(final String name, final List<Bar> bars, final int seriesBeginIndex, final int seriesEndIndex,
             final boolean constrained, final NumFactory numFactory, final BarBuilderFactory barBuilderFactory,
             final ReadWriteLock readWriteLock) {
         super(name, bars, seriesBeginIndex, seriesEndIndex, constrained, numFactory, barBuilderFactory);
@@ -133,6 +142,7 @@ public class ConcurrentBarSeries extends BaseBarSeries {
                 final int end = Math.min(endIndex - super.getRemovedBarsCount(), super.getEndIndex() + 1);
                 final var builder = new ConcurrentBarSeriesBuilder().withName(getName())
                         .withBars(cut(bars, start, end))
+                        .withBeginIndex(startIndex)
                         .withNumFactory(super.numFactory())
                         .withBarBuilderFactory(super.barBuilderFactory());
                 if (!isConstrained()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -138,11 +138,12 @@ public class ConcurrentBarSeries extends BaseBarSeries {
             }
             final List<Bar> bars = super.getBarData();
             if (!bars.isEmpty()) {
-                final int start = startIndex - super.getRemovedBarsCount();
+                final int retainedStartIndex = Math.max(startIndex, super.getBeginIndex());
+                final int start = retainedStartIndex - super.getRemovedBarsCount();
                 final int end = Math.min(endIndex - super.getRemovedBarsCount(), super.getEndIndex() + 1);
                 final var builder = new ConcurrentBarSeriesBuilder().withName(getName())
                         .withBars(cut(bars, start, end))
-                        .withBeginIndex(super.getRemovedBarsCount() > 0 ? startIndex : 0)
+                        .withBeginIndex(super.getRemovedBarsCount() > 0 ? retainedStartIndex : 0)
                         .withNumFactory(super.numFactory())
                         .withBarBuilderFactory(super.barBuilderFactory());
                 if (!isConstrained()) {

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeries.java
@@ -242,6 +242,22 @@ public class ConcurrentBarSeries extends BaseBarSeries {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 0.22.9
+     */
+    @Override
+    public void clear() {
+        this.writeLock.lock();
+        try {
+            super.clear();
+            this.tradeBarBuilder = null;
+        } finally {
+            this.writeLock.unlock();
+        }
+    }
+
     @Override
     public int getBeginIndex() {
         this.readLock.lock();

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeriesBuilder.java
@@ -48,6 +48,8 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
      * {@inheritDoc}
      *
      * @since 0.22.2
+     * @throws ArithmeticException if the configured begin index and bars would
+     *                             exceed {@link Integer#MAX_VALUE}
      */
     @Override
     public ConcurrentBarSeries build() {
@@ -55,7 +57,7 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
         int endIndex = -1;
         if (!bars.isEmpty()) {
             beginIndex = this.beginIndex;
-            endIndex = beginIndex + bars.size() - 1;
+            endIndex = Math.addExact(beginIndex, bars.size() - 1);
         }
         // If maxBarCount is configured, the series must be unconstrained to allow
         // removals.

--- a/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeriesBuilder.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/ConcurrentBarSeriesBuilder.java
@@ -23,6 +23,7 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
     private String name;
     private boolean maxBarCountConfigured;
     private int maxBarCount;
+    private int beginIndex;
     private NumFactory numFactory = DecimalNumFactory.getInstance();
     private BarBuilderFactory barBuilderFactory = new TimeBarBuilderFactory(true);
 
@@ -40,6 +41,7 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
         this.name = UNNAMED_SERIES_NAME;
         this.maxBarCountConfigured = false;
         this.maxBarCount = Integer.MAX_VALUE;
+        this.beginIndex = 0;
     }
 
     /**
@@ -52,14 +54,14 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
         int beginIndex = -1;
         int endIndex = -1;
         if (!bars.isEmpty()) {
-            beginIndex = 0;
-            endIndex = bars.size() - 1;
+            beginIndex = this.beginIndex;
+            endIndex = beginIndex + bars.size() - 1;
         }
         // If maxBarCount is configured, the series must be unconstrained to allow
         // removals.
         boolean effectiveConstrained = !maxBarCountConfigured;
         var series = new ConcurrentBarSeries(name == null ? UNNAMED_SERIES_NAME : name, bars, beginIndex, endIndex,
-                effectiveConstrained, numFactory, barBuilderFactory);
+                beginIndex < 0 ? 0 : beginIndex, effectiveConstrained, numFactory, barBuilderFactory);
         if (maxBarCountConfigured) {
             series.setMaximumBarCount(maxBarCount);
         }
@@ -97,6 +99,21 @@ public class ConcurrentBarSeriesBuilder implements BarSeriesBuilder {
      */
     public ConcurrentBarSeriesBuilder withBars(List<Bar> bars) {
         this.bars = new ArrayList<>(bars);
+        return this;
+    }
+
+    /**
+     * Sets the absolute index assigned to the first supplied bar.
+     *
+     * @param beginIndex non-negative first bar index
+     * @return {@code this}
+     * @since 0.22.9
+     */
+    public ConcurrentBarSeriesBuilder withBeginIndex(int beginIndex) {
+        if (beginIndex < 0) {
+            throw new IllegalArgumentException("beginIndex must be non-negative");
+        }
+        this.beginIndex = beginIndex;
         return this;
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractIndicator.java
@@ -95,6 +95,11 @@ public abstract class AbstractIndicator<T> implements Indicator<T> {
         }
 
         @Override
+        public void clear() {
+            throw new UnsupportedOperationException("Indicator bar series views are read-only");
+        }
+
+        @Override
         public int getBeginIndex() {
             return delegate.getBeginIndex();
         }

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -141,6 +142,25 @@ public class BaseBarSeriesBuilderTest extends AbstractIndicatorTest<BarSeries, N
     @Test
     public void testWithBeginIndexRejectsNegativeValues() {
         assertThrows(IllegalArgumentException.class, () -> new BaseBarSeriesBuilder().withBeginIndex(-1));
+    }
+
+    @Test
+    public void testClearRestoredSeriesResetsInitialIndex() {
+        List<Bar> bars = List.of(new TimeBarBuilder(DoubleNumFactory.getInstance()).timePeriod(Duration.ofMinutes(1))
+                .endTime(Instant.parse("2026-01-01T00:01:00Z"))
+                .closePrice(1)
+                .build());
+        BaseBarSeries series = new BaseBarSeriesBuilder().withBars(bars).withBeginIndex(40).withMaxBarCount(10).build();
+
+        series.clear();
+        series.addBar(new TimeBarBuilder(series.numFactory()).timePeriod(Duration.ofMinutes(1))
+                .endTime(Instant.parse("2026-01-01T00:02:00Z"))
+                .closePrice(2)
+                .build());
+
+        assertEquals(0, series.getBeginIndex());
+        assertEquals(0, series.getEndIndex());
+        assertEquals(10, series.getMaximumBarCount());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.math.BigDecimal;
@@ -111,6 +112,35 @@ public class BaseBarSeriesBuilderTest extends AbstractIndicatorTest<BarSeries, N
         assertEquals(doubleNumFactory, series.numFactory());
         assertEquals(doubleNumFactory, bar1.getClosePrice().getNumFactory());
         assertEquals(doubleNumFactory, bar2.getClosePrice().getNumFactory());
+    }
+
+    @Test
+    public void testWithBeginIndexPreservesAbsoluteIndexesAndSubSeriesOffset() {
+        final NumFactory factory = DoubleNumFactory.getInstance();
+        final Duration duration = Duration.ofMinutes(1);
+        final Instant firstEnd = Instant.parse("2026-01-01T00:01:00Z");
+        final var bars = new ArrayList<Bar>();
+        for (int i = 0; i < 4; i++) {
+            bars.add(new TimeBarBuilder(factory).timePeriod(duration)
+                    .endTime(firstEnd.plus(duration.multipliedBy(i)))
+                    .closePrice(100 + i)
+                    .build());
+        }
+
+        BaseBarSeries series = new BaseBarSeriesBuilder().withBars(bars).withBeginIndex(50).build();
+        BarSeries subSeries = series.getSubSeries(51, 54);
+
+        assertEquals(50, series.getBeginIndex());
+        assertEquals(53, series.getEndIndex());
+        assertEquals(50, series.getRemovedBarsCount());
+        assertEquals(51, subSeries.getBeginIndex());
+        assertEquals(53, subSeries.getEndIndex());
+        assertEquals(series.getBar(51), subSeries.getBar(51));
+    }
+
+    @Test
+    public void testWithBeginIndexRejectsNegativeValues() {
+        assertThrows(IllegalArgumentException.class, () -> new BaseBarSeriesBuilder().withBeginIndex(-1));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/BaseBarSeriesBuilderTest.java
@@ -130,6 +130,7 @@ public class BaseBarSeriesBuilderTest extends AbstractIndicatorTest<BarSeries, N
 
         BaseBarSeries series = new BaseBarSeriesBuilder().withBars(bars).withBeginIndex(50).build();
         BarSeries subSeries = series.getSubSeries(51, 54);
+        BarSeries clampedSubSeries = series.getSubSeries(0, 52);
 
         assertEquals(50, series.getBeginIndex());
         assertEquals(53, series.getEndIndex());
@@ -137,6 +138,35 @@ public class BaseBarSeriesBuilderTest extends AbstractIndicatorTest<BarSeries, N
         assertEquals(51, subSeries.getBeginIndex());
         assertEquals(53, subSeries.getEndIndex());
         assertEquals(series.getBar(51), subSeries.getBar(51));
+        assertEquals(50, clampedSubSeries.getBeginIndex());
+        assertEquals(51, clampedSubSeries.getEndIndex());
+        assertEquals(series.getBar(50), clampedSubSeries.getBar(50));
+    }
+
+    @Test
+    public void testWithBeginIndexSupportsIntegerMaximumWithoutWrapping() {
+        final NumFactory factory = DoubleNumFactory.getInstance();
+        final Bar first = new TimeBarBuilder(factory).timePeriod(Duration.ofMinutes(1))
+                .endTime(Instant.parse("2026-01-01T00:01:00Z"))
+                .closePrice(1)
+                .build();
+        final Bar second = new TimeBarBuilder(factory).timePeriod(Duration.ofMinutes(1))
+                .endTime(Instant.parse("2026-01-01T00:02:00Z"))
+                .closePrice(2)
+                .build();
+
+        BaseBarSeries series = new BaseBarSeriesBuilder().withBars(List.of(first))
+                .withBeginIndex(Integer.MAX_VALUE)
+                .build();
+
+        assertEquals(Integer.MAX_VALUE, series.getBeginIndex());
+        assertEquals(Integer.MAX_VALUE, series.getEndIndex());
+        assertThrows(ArithmeticException.class, () -> series.addBar(second));
+        assertEquals(1, series.getBarCount());
+        assertThrows(ArithmeticException.class,
+                () -> new BaseBarSeriesBuilder().withBars(List.of(first, second))
+                        .withBeginIndex(Integer.MAX_VALUE)
+                        .build());
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
@@ -130,8 +130,7 @@ public class ConcurrentBarSeriesBuilderTest extends AbstractIndicatorTest<BarSer
 
     @Test
     public void testWithBeginIndexRejectsNegativeValues() {
-        assertThrows(IllegalArgumentException.class,
-                () -> new ConcurrentBarSeriesBuilder().withBeginIndex(-1));
+        assertThrows(IllegalArgumentException.class, () -> new ConcurrentBarSeriesBuilder().withBeginIndex(-1));
     }
 
     @Test

--- a/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
@@ -134,6 +134,22 @@ public class ConcurrentBarSeriesBuilderTest extends AbstractIndicatorTest<BarSer
     }
 
     @Test
+    public void testClearRestoredSeriesResetsInitialIndex() {
+        ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withBars(createTestBars(1))
+                .withNumFactory(numFactory)
+                .withBeginIndex(40)
+                .withMaxBarCount(10)
+                .build();
+
+        series.clear();
+        series.addBar(createTestBar(1));
+
+        assertEquals(0, series.getBeginIndex());
+        assertEquals(0, series.getEndIndex());
+        assertEquals(10, series.getMaximumBarCount());
+    }
+
+    @Test
     public void testWithBarsEmptyList() {
         ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withName("testWithBarsEmptyListSeries")
                 .withBars(Collections.emptyList())

--- a/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
@@ -108,6 +108,33 @@ public class ConcurrentBarSeriesBuilderTest extends AbstractIndicatorTest<BarSer
     }
 
     @Test
+    public void testWithBeginIndexPreservesAbsoluteIndexesThroughAppendAndPruning() {
+        ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withBars(createTestBars(3))
+                .withNumFactory(numFactory)
+                .withBeginIndex(100)
+                .withMaxBarCount(3)
+                .build();
+
+        assertEquals(100, series.getBeginIndex());
+        assertEquals(102, series.getEndIndex());
+        assertEquals(100, series.getRemovedBarsCount());
+        assertEquals(createTestBars(3).get(0), series.getBar(100));
+
+        series.addBar(createTestBar(3));
+
+        assertEquals(101, series.getBeginIndex());
+        assertEquals(103, series.getEndIndex());
+        assertEquals(101, series.getRemovedBarsCount());
+        assertEquals(createTestBar(3), series.getBar(103));
+    }
+
+    @Test
+    public void testWithBeginIndexRejectsNegativeValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ConcurrentBarSeriesBuilder().withBeginIndex(-1));
+    }
+
+    @Test
     public void testWithBarsEmptyList() {
         ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withName("testWithBarsEmptyListSeries")
                 .withBars(Collections.emptyList())

--- a/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/ConcurrentBarSeriesBuilderTest.java
@@ -129,6 +129,40 @@ public class ConcurrentBarSeriesBuilderTest extends AbstractIndicatorTest<BarSer
     }
 
     @Test
+    public void testWithBeginIndexClampsSubSeriesToRetainedWindow() {
+        ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withBars(createTestBars(3))
+                .withNumFactory(numFactory)
+                .withBeginIndex(50)
+                .build();
+
+        ConcurrentBarSeries subSeries = series.getSubSeries(0, 52);
+
+        assertEquals(50, subSeries.getBeginIndex());
+        assertEquals(51, subSeries.getEndIndex());
+        assertEquals(series.getBar(50), subSeries.getBar(50));
+    }
+
+    @Test
+    public void testWithBeginIndexSupportsIntegerMaximumWithoutWrapping() {
+        Bar first = createTestBar(0);
+        Bar second = createTestBar(1);
+        ConcurrentBarSeries series = new ConcurrentBarSeriesBuilder().withBars(List.of(first))
+                .withNumFactory(numFactory)
+                .withBeginIndex(Integer.MAX_VALUE)
+                .build();
+
+        assertEquals(Integer.MAX_VALUE, series.getBeginIndex());
+        assertEquals(Integer.MAX_VALUE, series.getEndIndex());
+        assertThrows(ArithmeticException.class, () -> series.addBar(second));
+        assertEquals(1, series.getBarCount());
+        assertThrows(ArithmeticException.class,
+                () -> new ConcurrentBarSeriesBuilder().withBars(List.of(first, second))
+                        .withNumFactory(numFactory)
+                        .withBeginIndex(Integer.MAX_VALUE)
+                        .build());
+    }
+
+    @Test
     public void testWithBeginIndexRejectsNegativeValues() {
         assertThrows(IllegalArgumentException.class, () -> new ConcurrentBarSeriesBuilder().withBeginIndex(-1));
     }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- add `withBeginIndex(int)` to base and concurrent bar-series builders
- preserve absolute retained indices through appends, pruning, subseries, and serialization
- support intentional series clearing for fail-safe strategy reinitialization

- [x] I have run `mvn -B clean license:format formatter:format verify install` (or `scripts/run-full-build-quiet.sh`) to test my changes per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring bar series with a configurable starting index, preserving absolute indices during appends, pruning, sub-series creation, and persistence.
  * Added `clear()` support to reset retained bars and indices while preserving series configuration.
  * Added equivalent functionality for concurrent bar series.

* **Bug Fixes**
  * Prevented read-only indicator views from clearing their underlying series.

* **Documentation**
  * Updated the changelog with the new retained-series behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->