### PR TITLE
Release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- _No changes yet._
+
+## 0.23.0 (2026-07-13)
+
 ### Added
 - **Causal swing detection for sharp, rounded, and consensus-confirmed turns**: Added `SwingDetectors.slopeChange(window)` with balanced persistence and half-ATR filtering plus `SwingDetectors.consensus(...)` for tolerant quorum agreement, while ZigZag detection now locates pivots from intrabar highs/lows, confirms reversals from closes with pivot-anchored thresholds, derives matching high/low swing sources directly from state, and resolves fractal plateaus to one deterministic midpoint.
 - **CF-289: Forecast predictions for forward price estimates**: Added a ta4j-core forecast indicator layer with `Forecast` summaries, a `ReturnIndicator` semantic contract, constructor-first EWMA and Monte Carlo price forecasts, explicit return projections for advanced tuning, `forecast.state`, `forecast.projection`, and `forecast.adapters` subpackages for framework contracts and conversion bridges, non-throwing forecast quantile lookup with `hasQuantile(...)`, and projection methods for quantiles, medians, means, and standard deviations as regular `Indicator<Num>` values.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add Ta4j from Maven Central:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.22.8</version>
+  <version>0.23.0</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ Prefer living on the edge? Use the snapshot repository and version:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.22.9-SNAPSHOT</version>
+  <version>0.23.1-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ Sample applications are also published so you can copy/paste entire flows:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.22.8</version>
+  <version>0.23.0</version>
 </dependency>
 ```
 
@@ -115,7 +115,7 @@ Like living on the edge? Use the snapshot version of ta4j-examples for the lates
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.22.9-SNAPSHOT</version>
+  <version>0.23.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.23.0</version>
+    <version>0.23.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.22.9-SNAPSHOT</version>
+    <version>0.23.0</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/release/0.23.0.md
+++ b/release/0.23.0.md
@@ -1,0 +1,29 @@
+## 0.23.0 (2026-07-13)
+
+### Added
+- **Causal swing detection for sharp, rounded, and consensus-confirmed turns**: Added `SwingDetectors.slopeChange(window)` with balanced persistence and half-ATR filtering plus `SwingDetectors.consensus(...)` for tolerant quorum agreement, while ZigZag detection now locates pivots from intrabar highs/lows, confirms reversals from closes with pivot-anchored thresholds, derives matching high/low swing sources directly from state, and resolves fractal plateaus to one deterministic midpoint.
+- **CF-289: Forecast predictions for forward price estimates**: Added a ta4j-core forecast indicator layer with `Forecast` summaries, a `ReturnIndicator` semantic contract, constructor-first EWMA and Monte Carlo price forecasts, explicit return projections for advanced tuning, `forecast.state`, `forecast.projection`, and `forecast.adapters` subpackages for framework contracts and conversion bridges, non-throwing forecast quantile lookup with `hasQuantile(...)`, and projection methods for quantiles, medians, means, and standard deviations as regular `Indicator<Num>` values.
+- **EW snapshots can publish five-outlook live macro reports**: The manual `EW Snapshot Analysis` workflow now runs `ElliottWavePresetDemo` for configurable daily instruments and exchanges, writes dynamic run summaries plus embedded-chart HTML, and uploads charts, scenario-outlook JSON, cached provider responses, and the full demo log for public monitoring.
+- **Dynamic backtest sizing**: You can now pass a `PositionSizer` into `BarSeriesManager`, `BacktestExecutor`, top-K strategy ranking, and walk-forward execution to size each entry from the signal bar while exits automatically close the currently open amount. Starter factories cover fixed units, realized-balance max sizing with entry-fee awareness, and Kelly sizing with optional fractional or levered coefficients (CF-90).
+- **Pluggable execution-target estimation for dynamic sizing**: Added `TradeExecutionModel#estimateEntryTarget(...)` so custom execution models can provide sizing-aware fill timing and pricing. Dynamic sizing now defaults to conservative next-open estimation for models that do not override this API, and falls back safely when no target is resolvable to keep runs defined.
+
+### Changed
+- **Retained bar series can resume at their absolute index**: `BaseBarSeriesBuilder` and
+  `ConcurrentBarSeriesBuilder` now accept `withBeginIndex(int)`, allowing persisted windows to
+  append, prune, create subseries, and serialize without rebasing their surviving bars to zero;
+  `BarSeries.clear()` resets a restored series for intentional reinitialization while preserving
+  its configuration.
+- **Finite `Num` validation is reusable across indicators**: Added `Num.isFinite(...)` for indicator-safe checks that reject null, NaN, and primitive-backed infinities without misclassifying finite high-precision `DecimalNum` values whose `doubleValue()` overflows; internal indicator code now uses this shared contract directly, and `IndicatorUtils.isInvalid(...)` is deprecated as a compatibility shim.
+- **Elliott anchor calibration is harness-only**: Long BTC anchor calibration now lives behind `ElliottWaveAnchorCalibrationHarness` as a dedicated CLI/job entrypoint, while the remaining harness unit tests exercise registry, windowing, report, and artifact contracts with synthetic inputs. Active docs warn that full anchor calibration can run for 8+ hours.
+- **Daily live Elliott preset runs now use the generic macro snapshot path**: `ElliottWavePresetDemo` routes any daily live instrument through the macro-cycle preset so non-BTC symbols receive the same base case plus four alternate outlooks with instrument-aware filenames and scenario-outlook JSON.
+- **EW snapshot outputs are easier to consume from automation**: `ElliottWavePresetDemo` now has help/status-code handling for invalid CLI usage, and live macro scenario JSON includes portable chart and report file names for artifact viewers that do not preserve absolute paths.
+- **Quiet Maven verify stays focused on failures**: `ta4j-core` test logging now keeps intentional `TimeBarBuilder` missing-bar warnings and invalid `ReturnRepresentation` parse warnings out of `mvn verify -q` output while preserving explicit log-capture assertions for those expected paths.
+- **Cached indicator stress coverage is less scheduler-sensitive**: `CachedIndicatorTest` now waits for a bounded minimum-read signal before ending the concurrent mutation phase, so the full-build gate continues to exercise cache invalidation under contention without failing because reader threads were scheduled late.
+
+### Fixed
+- **Day-of-week rule descriptors are deterministic**: `DayOfWeekRule` now canonicalizes its configured enum set so descriptor and JSON serialization round trips cannot fail or change output when hash iteration order varies between runs.
+- **Source position labels remain accurate in isolated chart renders**: Trading-record
+  chart callers can now provide a 1-based source position start, so position bands
+  and buy/sell annotations retain their original ordinal when a focused chart
+  contains only a later source position (CF-299).
+- **CF-207/208/209/210/211/236 SpotBugs closure**: Cleared the historical SpotBugs baseline across constructor safety, cache concurrency, representation ownership, examples IO/reporting, serialization, indicator/rule/backtest accessors, and Elliott analysis paths; Maven `verify`, standalone SpotBugs scans, and GitHub CI now run SpotBugs without an exclude filter and fail on new findings.

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.9-SNAPSHOT</version>
+        <version>0.23.0</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.22.9-SNAPSHOT</version>
+        <version>0.23.0</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 


### PR DESCRIPTION
Automated release PR for 0.23.0.

Contains:
- Set version to 0.23.0
- Generated release notes: release/0.23.0.md
- Bump to next snapshot: 0.23.1-SNAPSHOT
- Synced removal-ready deprecation issues: 0 plan(s), 0 created, 0 updated, 0 reopened, 0 stale closed

<!-- release-meta
releaseVersion: 0.23.0
nextVersion: 0.23.1-SNAPSHOT
releaseCommit: 896d7138a9d1818fe6725b89b433ba7860b8f654
-->