### PR TITLE
Fix serialization core audit round trips

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ATRIndicator.java
@@ -17,7 +17,8 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class ATRIndicator extends AbstractIndicator<Num> {
 
-    private final int trueRangeUnstableBars;
+    private final TRIndicator tr;
+    private final transient int trueRangeUnstableBars;
     private final transient MMAIndicator averageTrueRangeIndicator;
     private final int barCount;
 
@@ -43,6 +44,7 @@ public class ATRIndicator extends AbstractIndicator<Num> {
 
     private ATRIndicator(Config config) {
         super(config.trueRangeIndicator().getBarSeries());
+        this.tr = config.trueRangeIndicator();
         this.trueRangeUnstableBars = config.trueRangeUnstableBars();
         this.barCount = config.barCount();
         this.averageTrueRangeIndicator = new MMAIndicator(config.trueRangeIndicator(), config.barCount());

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractFractalConfirmationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractFractalConfirmationIndicator.java
@@ -24,7 +24,7 @@ abstract class AbstractFractalConfirmationIndicator extends CachedIndicator<Bool
     private final Indicator<Num> indicator;
     private final int precedingBars;
     private final int followingBars;
-    private final int unstableBars;
+    private final transient int unstableBars;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractRecentFractalSwingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractRecentFractalSwingIndicator.java
@@ -17,7 +17,7 @@ import org.ta4j.core.num.Num;
  */
 abstract class AbstractRecentFractalSwingIndicator extends AbstractRecentSwingIndicator {
 
-    private final Indicator<Num> indicator;
+    private final transient Indicator<Num> indicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractRecentSwingIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AbstractRecentSwingIndicator.java
@@ -29,8 +29,8 @@ import static org.ta4j.core.num.NaN.NaN;
 public abstract class AbstractRecentSwingIndicator extends CachedIndicator<Num> implements RecentSwingIndicator {
 
     private final Indicator<Num> priceIndicator;
-    private final SwingPointTracker swingPoints;
-    private final int unstableBars;
+    private final transient SwingPointTracker swingPoints;
+    private final transient int unstableBars;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/GatorOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/GatorOscillatorIndicator.java
@@ -38,7 +38,7 @@ public class GatorOscillatorIndicator extends CachedIndicator<Num> {
     private final transient Indicator<Num> jawMinusTeeth;
     private final transient Indicator<Num> teethMinusLips;
     private final boolean upperHistogram;
-    private final int unstableBars;
+    private final transient int unstableBars;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ParabolicSarIndicator.java
@@ -26,31 +26,31 @@ import org.ta4j.core.num.Num;
  */
 public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
 
-    private final LowPriceIndicator lowPriceIndicator;
-    private final LowestValueIndicator lowestValueIndicator;
-    private final HighPriceIndicator highPriceIndicator;
-    private final HighestValueIndicator highestValueIndicator;
+    private final transient LowPriceIndicator lowPriceIndicator;
+    private final transient LowestValueIndicator lowestValueIndicator;
+    private final transient HighPriceIndicator highPriceIndicator;
+    private final transient HighestValueIndicator highestValueIndicator;
 
     private final Num maxAcceleration;
     private final Num accelerationStart;
     private final Num accelerationIncrement;
 
-    private final Map<Integer, Boolean> isUpTrendMap = new HashMap<>();
-    private final Map<Integer, Num> lastExtreme = new HashMap<>();
-    private final Map<Integer, Num> lastAf = new HashMap<>();
+    private final transient Map<Integer, Boolean> isUpTrendMap = new HashMap<>();
+    private final transient Map<Integer, Num> lastExtreme = new HashMap<>();
+    private final transient Map<Integer, Num> lastAf = new HashMap<>();
 
     /**
      * If series have removed bars, first actual bar won't have 0 index.
      */
-    private int seriesStartIndex = getBarSeries().getBeginIndex();
+    private transient int seriesStartIndex = getBarSeries().getBeginIndex();
 
     /**
      * Constructor with:
      *
      * <ul>
-     * <li>{@code aF} = 0.02
-     * <li>{@code maxA} = 0.2
-     * <li>{@code increment} = 0.02
+     * <li>{@code accelerationStart} = 0.02
+     * <li>{@code maxAcceleration} = 0.2
+     * <li>{@code accelerationIncrement} = 0.02
      * </ul>
      *
      * @param series the bar series for this indicator
@@ -62,31 +62,32 @@ public class ParabolicSarIndicator extends RecursiveCachedIndicator<Num> {
     /**
      * Constructor with {@code increment} = 0.02.
      *
-     * @param series the bar series for this indicator
-     * @param aF     acceleration factor
-     * @param maxA   maximum acceleration
+     * @param series            the bar series for this indicator
+     * @param accelerationStart acceleration factor
+     * @param maxAcceleration   maximum acceleration
      */
-    public ParabolicSarIndicator(BarSeries series, Num aF, Num maxA) {
-        this(series, aF, maxA, series.numFactory().numOf(0.02));
+    public ParabolicSarIndicator(BarSeries series, Num accelerationStart, Num maxAcceleration) {
+        this(series, accelerationStart, maxAcceleration, series.numFactory().numOf(0.02));
     }
 
     /**
      * Constructor.
      *
-     * @param series    the bar series for this indicator
-     * @param aF        acceleration factor (usually 0.02)
-     * @param maxA      maximum acceleration (usually 0.2)
-     * @param increment the increment step (usually 0.02)
+     * @param series                the bar series for this indicator
+     * @param accelerationStart     acceleration factor (usually 0.02)
+     * @param maxAcceleration       maximum acceleration (usually 0.2)
+     * @param accelerationIncrement the increment step (usually 0.02)
      */
-    public ParabolicSarIndicator(BarSeries series, Num aF, Num maxA, Num increment) {
+    public ParabolicSarIndicator(BarSeries series, Num accelerationStart, Num maxAcceleration,
+            Num accelerationIncrement) {
         super(series);
         this.lowPriceIndicator = new LowPriceIndicator(series);
         this.lowestValueIndicator = new LowestValueIndicator(lowPriceIndicator, 2);
         this.highPriceIndicator = new HighPriceIndicator(series);
         this.highestValueIndicator = new HighestValueIndicator(highPriceIndicator, 2);
-        this.maxAcceleration = maxA;
-        this.accelerationStart = aF;
-        this.accelerationIncrement = increment;
+        this.maxAcceleration = maxAcceleration;
+        this.accelerationStart = accelerationStart;
+        this.accelerationIncrement = accelerationIncrement;
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RSIIndicator.java
@@ -23,7 +23,7 @@ public class RSIIndicator extends CachedIndicator<Num> {
     private final transient MMAIndicator averageGainIndicator;
     private final transient MMAIndicator averageLossIndicator;
     private final int barCount;
-    private final int unstableBars;
+    private final transient int unstableBars;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticIndicator.java
@@ -35,8 +35,8 @@ import static org.ta4j.core.num.NaN.NaN;
 public class StochasticIndicator extends CachedIndicator<Num> {
 
     private final Indicator<Num> indicator;
-    private final HighestValueIndicator highest;
-    private final LowestValueIndicator lowest;
+    private final transient HighestValueIndicator highest;
+    private final transient LowestValueIndicator lowest;
     private final int lookback;
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/UltimateOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/UltimateOscillatorIndicator.java
@@ -68,11 +68,11 @@ public class UltimateOscillatorIndicator extends CachedIndicator<Num> {
     private final transient RunningTotalIndicator middleTrueRangeSumIndicator;
     private final transient RunningTotalIndicator longTrueRangeSumIndicator;
 
-    private final Num shortWeight;
-    private final Num middleWeight;
-    private final Num longWeight;
-    private final Num totalWeight;
-    private final Num hundred;
+    private final transient Num shortWeight;
+    private final transient Num middleWeight;
+    private final transient Num longWeight;
+    private final transient Num totalWeight;
+    private final transient Num hundred;
 
     /**
      * Constructor using the canonical (7, 14, 28) periods.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/AbstractEMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/AbstractEMAIndicator.java
@@ -22,7 +22,7 @@ public abstract class AbstractEMAIndicator extends RecursiveCachedIndicator<Num>
 
     private final Indicator<Num> indicator;
     private final int barCount;
-    private final Num multiplier;
+    private final transient Num multiplier;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DarkCloudCoverIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DarkCloudCoverIndicator.java
@@ -40,8 +40,8 @@ import org.ta4j.core.num.Num;
  */
 public class DarkCloudCoverIndicator extends CachedIndicator<Boolean> {
 
-    private final UpTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient UpTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num bigBodyThresholdPercentage;
     private final Num gapThresholdPercentage;
     private final Num penetrationThresholdPercentage;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/PiercingLineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/PiercingLineIndicator.java
@@ -41,8 +41,8 @@ import org.ta4j.core.num.Num;
  */
 public class PiercingLineIndicator extends CachedIndicator<Boolean> {
 
-    private final DownTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient DownTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num bigBodyThresholdPercentage;
     private final Num gapThresholdPercentage;
     private final Num penetrationThresholdPercentage;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottScenarioIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/elliott/ElliottScenarioIndicator.java
@@ -33,7 +33,7 @@ public class ElliottScenarioIndicator extends CachedIndicator<ElliottScenarioSet
     private final ElliottSwingIndicator swingIndicator;
     private final ElliottChannelIndicator channelIndicator;
     private final ElliottScenarioGenerator generator;
-    private final ElliottDegree degree;
+    private final transient ElliottDegree degree;
 
     /**
      * Creates a scenario indicator with default settings.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/forecast/OnlineChangePointForecastStateIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/forecast/OnlineChangePointForecastStateIndicator.java
@@ -78,7 +78,7 @@ public final class OnlineChangePointForecastStateIndicator extends AbstractIndic
     private final double priorMeanPrecision;
     private final double priorShape;
     private final double priorScale;
-    private final int unstableBarCount;
+    private final transient int unstableBarCount;
     private transient volatile PosteriorModel posteriorModel;
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicator.java
@@ -88,8 +88,8 @@ import org.ta4j.core.num.Num;
  */
 public class SuperTrendIndicator extends RecursiveCachedIndicator<Num> {
 
-    private final SuperTrendUpperBandIndicator superTrendUpperBandIndicator;
-    private final SuperTrendLowerBandIndicator superTrendLowerBandIndicator;
+    private final transient SuperTrendUpperBandIndicator superTrendUpperBandIndicator;
+    private final transient SuperTrendLowerBandIndicator superTrendLowerBandIndicator;
     private final int barCount;
     private final double multiplier;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicator.java
@@ -50,7 +50,7 @@ public class SuperTrendLowerBandIndicator extends RecursiveCachedIndicator<Num> 
 
     private final ATRIndicator atrIndicator;
     private final Num multiplier;
-    private final MedianPriceIndicator medianPriceIndicator;
+    private final transient MedianPriceIndicator medianPriceIndicator;
 
     /**
      * Constructor with {@code multiplier} = 3.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicator.java
@@ -50,7 +50,7 @@ public class SuperTrendUpperBandIndicator extends RecursiveCachedIndicator<Num> 
 
     private final ATRIndicator atrIndicator;
     private final Num multiplier;
-    private final MedianPriceIndicator medianPriceIndicator;
+    private final transient MedianPriceIndicator medianPriceIndicator;
 
     /**
      * Constructor with {@code multiplier} = 3.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/TrendLineResistanceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/TrendLineResistanceIndicator.java
@@ -226,6 +226,37 @@ public class TrendLineResistanceIndicator extends AbstractTrendLineIndicator {
     }
 
     /**
+     * Deserialization-friendly constructor that accepts explicit scoring weights,
+     * tolerance parameters, and search caps as strings/primitives.
+     *
+     * @param swingHighIndicator         the swing-high indicator to use
+     * @param barCount                   number of bars to look back when selecting
+     *                                   swing points
+     * @param touchCountWeight           weight for swing point touch count
+     * @param touchesExtremeWeight       weight for extreme point inclusion
+     * @param outsideCountWeight         weight for minimizing outside swings
+     * @param averageDeviationWeight     weight for minimizing average deviation
+     * @param anchorRecencyWeight        weight for anchor point recency
+     * @param toleranceMode              tolerance mode as string (PERCENTAGE,
+     *                                   ABSOLUTE, or TICK_SIZE)
+     * @param toleranceValue             tolerance value
+     * @param toleranceMinimum           minimum absolute tolerance
+     * @param maxSwingPointsForTrendline maximum number of swing points to consider
+     * @param maxCandidatePairs          maximum number of candidate pairs to
+     *                                   evaluate
+     * @since 0.23.1
+     */
+    public TrendLineResistanceIndicator(RecentSwingIndicator swingHighIndicator, int barCount, double touchCountWeight,
+            double touchesExtremeWeight, double outsideCountWeight, double averageDeviationWeight,
+            double anchorRecencyWeight, String toleranceMode, double toleranceValue, double toleranceMinimum,
+            int maxSwingPointsForTrendline, int maxCandidatePairs) {
+        super(swingHighIndicator, barCount, TrendLineSide.RESISTANCE, touchCountWeight, touchesExtremeWeight,
+                outsideCountWeight, averageDeviationWeight, anchorRecencyWeight,
+                ToleranceSettings.from(toleranceMode, toleranceValue, toleranceMinimum), maxSwingPointsForTrendline,
+                maxCandidatePairs);
+    }
+
+    /**
      * Builds a resistance trend line from a swing-high indicator implementation.
      *
      * @param recentSwingHighIndicator the swing-high indicator to use

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/TrendLineSupportIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/supportresistance/TrendLineSupportIndicator.java
@@ -248,6 +248,37 @@ public class TrendLineSupportIndicator extends AbstractTrendLineIndicator {
     }
 
     /**
+     * Deserialization-friendly constructor that accepts explicit scoring weights,
+     * tolerance parameters, and search caps as strings/primitives.
+     *
+     * @param swingLowIndicator          the swing-low indicator to use
+     * @param barCount                   number of bars to look back when selecting
+     *                                   swing points
+     * @param touchCountWeight           weight for swing point touch count
+     * @param touchesExtremeWeight       weight for extreme point inclusion
+     * @param outsideCountWeight         weight for minimizing outside swings
+     * @param averageDeviationWeight     weight for minimizing average deviation
+     * @param anchorRecencyWeight        weight for anchor point recency
+     * @param toleranceMode              tolerance mode as string (PERCENTAGE,
+     *                                   ABSOLUTE, or TICK_SIZE)
+     * @param toleranceValue             tolerance value
+     * @param toleranceMinimum           minimum absolute tolerance
+     * @param maxSwingPointsForTrendline maximum number of swing points to consider
+     * @param maxCandidatePairs          maximum number of candidate pairs to
+     *                                   evaluate
+     * @since 0.23.1
+     */
+    public TrendLineSupportIndicator(RecentSwingIndicator swingLowIndicator, int barCount, double touchCountWeight,
+            double touchesExtremeWeight, double outsideCountWeight, double averageDeviationWeight,
+            double anchorRecencyWeight, String toleranceMode, double toleranceValue, double toleranceMinimum,
+            int maxSwingPointsForTrendline, int maxCandidatePairs) {
+        super(swingLowIndicator, barCount, TrendLineSide.SUPPORT, touchCountWeight, touchesExtremeWeight,
+                outsideCountWeight, averageDeviationWeight, anchorRecencyWeight,
+                ToleranceSettings.from(toleranceMode, toleranceValue, toleranceMinimum), maxSwingPointsForTrendline,
+                maxCandidatePairs);
+    }
+
+    /**
      * Builds a support trend line by analysing the low price of each bar using a
      * symmetric look-back and look-forward window.
      *

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/AccumulationDistributionIndicator.java
@@ -13,7 +13,7 @@ import org.ta4j.core.num.Num;
  */
 public class AccumulationDistributionIndicator extends RecursiveCachedIndicator<Num> {
 
-    private final CloseLocationValueIndicator clvIndicator;
+    private final transient CloseLocationValueIndicator clvIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/ChaikinOscillatorIndicator.java
@@ -17,9 +17,11 @@ import org.ta4j.core.num.Num;
  */
 public class ChaikinOscillatorIndicator extends CachedIndicator<Num> {
 
-    private final AccumulationDistributionIndicator accumulationDistributionIndicator;
-    private final EMAIndicator emaShort;
-    private final EMAIndicator emaLong;
+    private final int shortBarCount;
+    private final int longBarCount;
+    private final transient AccumulationDistributionIndicator accumulationDistributionIndicator;
+    private final transient EMAIndicator emaShort;
+    private final transient EMAIndicator emaLong;
 
     /**
      * Constructor.
@@ -30,6 +32,8 @@ public class ChaikinOscillatorIndicator extends CachedIndicator<Num> {
      */
     public ChaikinOscillatorIndicator(BarSeries series, int shortBarCount, int longBarCount) {
         super(series);
+        this.shortBarCount = shortBarCount;
+        this.longBarCount = longBarCount;
         this.accumulationDistributionIndicator = new AccumulationDistributionIndicator(series);
         this.emaShort = new EMAIndicator(accumulationDistributionIndicator, shortBarCount);
         this.emaLong = new EMAIndicator(accumulationDistributionIndicator, longBarCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/volume/MVWAPIndicator.java
@@ -18,7 +18,9 @@ import org.ta4j.core.num.Num;
  */
 public class MVWAPIndicator extends CachedIndicator<Num> {
 
-    private final Indicator<Num> sma;
+    private final Indicator<Num> vwap;
+    private final int barCount;
+    private final transient Indicator<Num> sma;
 
     /**
      * Constructor.
@@ -28,6 +30,8 @@ public class MVWAPIndicator extends CachedIndicator<Num> {
      */
     public MVWAPIndicator(VWAPIndicator vwap, int barCount) {
         super(vwap);
+        this.vwap = vwap;
+        this.barCount = barCount;
         this.sma = new SMAIndicator(vwap, barCount);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/RecentZigZagSwingHighIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/RecentZigZagSwingHighIndicator.java
@@ -48,7 +48,7 @@ import org.ta4j.core.num.Num;
 public class RecentZigZagSwingHighIndicator extends AbstractRecentSwingIndicator {
 
     private final ZigZagStateIndicator stateIndicator;
-    private final Indicator<Num> price;
+    private final transient Indicator<Num> price;
 
     /**
      * Constructs an indicator using the state's high-price source.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/RecentZigZagSwingLowIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/zigzag/RecentZigZagSwingLowIndicator.java
@@ -48,7 +48,7 @@ import org.ta4j.core.num.Num;
 public class RecentZigZagSwingLowIndicator extends AbstractRecentSwingIndicator {
 
     private final ZigZagStateIndicator stateIndicator;
-    private final Indicator<Num> price;
+    private final transient Indicator<Num> price;
 
     /**
      * Constructs an indicator using the state's low-price source.

--- a/ta4j-core/src/main/java/org/ta4j/core/serialization/IndicatorSerialization.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/serialization/IndicatorSerialization.java
@@ -338,9 +338,6 @@ public final class IndicatorSerialization {
             InvocationPlan candidate = plan.get();
             if (bestPlan == null || isBetterMatch(candidate, bestPlan, components.size())) {
                 bestPlan = candidate;
-                if (candidate.consumedComponents() == components.size()) {
-                    break;
-                }
             }
         }
         if (bestPlan != null) {
@@ -369,6 +366,7 @@ public final class IndicatorSerialization {
         Type[] genericParameterTypes = constructor.getGenericParameterTypes();
         Object[] args = new Object[parameterTypes.length];
         int componentIndex = 0;
+        int componentSpecificity = 0;
         boolean bulkConsumed = false;
         boolean constructorUsesIndicators = false;
         LinkedHashMap<String, Object> parameterPool = parameters == null ? new LinkedHashMap<>()
@@ -389,6 +387,7 @@ public final class IndicatorSerialization {
                 if (!parameterType.isInstance(component)) {
                     return Optional.empty();
                 }
+                componentSpecificity += indicatorParameterSpecificity(parameterType);
                 args[i] = component;
             } else if (parameterType.isArray() && Indicator.class.isAssignableFrom(parameterType.getComponentType())) {
                 constructorUsesIndicators = true;
@@ -401,6 +400,7 @@ public final class IndicatorSerialization {
                     if (!parameterType.getComponentType().isInstance(component)) {
                         return Optional.empty();
                     }
+                    componentSpecificity += indicatorParameterSpecificity(parameterType.getComponentType());
                 }
                 args[i] = remaining;
                 componentIndex = components.size();
@@ -419,6 +419,7 @@ public final class IndicatorSerialization {
                         if (!listElementType.isInstance(component)) {
                             return Optional.empty();
                         }
+                        componentSpecificity += indicatorParameterSpecificity(listElementType);
                     }
                     args[i] = remaining;
                     componentIndex = components.size();
@@ -459,14 +460,30 @@ public final class IndicatorSerialization {
             args[request.index()] = converted;
         }
 
-        // Validate that all components were consumed
-        // Note: components is guaranteed non-null due to early return check above
         boolean hasComponents = !components.isEmpty();
+        if (componentIndex != components.size()) {
+            return Optional.empty();
+        }
+        if (hasUnconsumedConstructorParameters(parameterPool)) {
+            return Optional.empty();
+        }
         if (!constructorUsesIndicators && hasComponents && hasIndicatorConstructor) {
             return Optional.empty();
         }
 
-        return Optional.of(new InvocationPlan(constructor, args, componentIndex, constructorUsesIndicators));
+        return Optional.of(
+                new InvocationPlan(constructor, args, componentIndex, constructorUsesIndicators, componentSpecificity));
+    }
+
+    private static int indicatorParameterSpecificity(Class<?> parameterType) {
+        return parameterType == Indicator.class ? 0 : 1;
+    }
+
+    private static boolean hasUnconsumedConstructorParameters(Map<String, Object> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return false;
+        }
+        return parameters.keySet().stream().anyMatch(parameter -> !parameter.startsWith("__enumType_"));
     }
 
     private static boolean constructorConsumesIndicators(Constructor<?> constructor) {
@@ -508,6 +525,9 @@ public final class IndicatorSerialization {
         }
         if (candidate.usesIndicators() && !current.usesIndicators()) {
             return true;
+        }
+        if (candidate.componentSpecificity() != current.componentSpecificity()) {
+            return candidate.componentSpecificity() > current.componentSpecificity();
         }
         return false;
     }
@@ -1018,6 +1038,6 @@ public final class IndicatorSerialization {
     }
 
     private record InvocationPlan(Constructor<?> constructor, Object[] arguments, int consumedComponents,
-            boolean usesIndicators) {
+            boolean usesIndicators, int componentSpecificity) {
     }
 }

--- a/ta4j-core/src/test/java/AGENTS.md
+++ b/ta4j-core/src/test/java/AGENTS.md
@@ -10,6 +10,8 @@ These are cross-cutting test rules for ta4j-core. Deeper package guides can add 
 
 ## Test design conventions
 
+- Default unit-test ownership is 1:1: `MyType` belongs in `MyTypeTest`. Do not add roll-up, inventory, or broad
+  suite-style unit test classes for new coverage; place focused tests in the owning production class's test file.
 - Use `assertThrows` for exception assertions (avoid `@Test(expected = ...)` and manual try/catch assertions).
 - Avoid reflection-based access to private APIs; test through public behavior or refactor for dependency injection.
 - Prefer dependency injection when production code is hard to test.

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AGENTS.md
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AGENTS.md
@@ -5,6 +5,8 @@ Follow `ta4j-core/src/test/java/AGENTS.md` for global policy; this file adds ind
 ## Structure
 
 - Mirror production naming (`MyIndicator` -> `MyIndicatorTest`).
+- Keep serialization/deserialization coverage in the owning indicator or facade test class. Do not add indicator
+  roll-up inventory test classes for new serialization coverage.
 - Prefer extending `AbstractIndicatorTest<BarSeries, Num>` so scenarios run for both `DoubleNum` and `DecimalNum`.
 
 ## Data and assertions

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/IndicatorSerializationRoundTripTestSupport.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/IndicatorSerializationRoundTripTestSupport.java
@@ -12,15 +12,42 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
+import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
 import org.ta4j.core.serialization.ComponentDescriptor;
 import org.ta4j.core.serialization.ComponentSerialization;
 import org.ta4j.core.serialization.IndicatorSerialization;
 
-final class IndicatorSerializationRoundTripTestSupport {
+public final class IndicatorSerializationRoundTripTestSupport {
 
     private IndicatorSerializationRoundTripTestSupport() {
+    }
+
+    public static BarSeries serializationSeries(NumFactory numFactory) {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
+        for (int i = 0; i < 160; i++) {
+            double base = 100 + i * 0.5 + Math.sin(i / 3.0) * 2.0;
+            double open = base + Math.cos(i / 5.0);
+            double close = base + Math.sin(i / 7.0);
+            double high = Math.max(open, close) + 1.5 + (i % 4) * 0.1;
+            double low = Math.min(open, close) - 1.5 - (i % 3) * 0.1;
+            double volume = 1_000 + i * 17 + (i % 5) * 23;
+            series.barBuilder().openPrice(open).closePrice(close).highPrice(high).lowPrice(low).volume(volume).add();
+        }
+        return series;
+    }
+
+    public static int[] stableIndexes(BarSeries series) {
+        int endIndex = series.getEndIndex();
+        return new int[] { endIndex - 3, endIndex - 1, endIndex };
+    }
+
+    public static <T> void assertIndicatorRoundTrips(BarSeries series, Indicator<T> indicator, int... indexes) {
+        assertIndicatorRoundTrips(
+                new AbstractIndicatorTest.IndicatorSerializationFixture<>(series, indicator, indexes));
     }
 
     static void assertIndicatorRoundTrips(AbstractIndicatorTest.IndicatorSerializationFixture<?> fixture) {

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ParabolicSarIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.BarSeries;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -354,6 +359,13 @@ public class ParabolicSarIndicatorTest extends AbstractIndicatorTest<Indicator<N
         assertNumEquals(values.get(8), parabolicSarIndicator.getValue(8));
         assertNumEquals(values.get(7), parabolicSarIndicator.getValue(7));
         assertNumEquals(values.get(6), parabolicSarIndicator.getValue(6));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series,
+                new ParabolicSarIndicator(series, numOf(0.02), numOf(0.2), numOf(0.02)), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendLineResistanceIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendLineResistanceIndicatorTest.java
@@ -125,7 +125,7 @@ public class TrendLineResistanceIndicatorTest extends AbstractIndicatorTest<Indi
         assertThat(descriptor.getComponents()).hasSize(1);
         final ComponentDescriptor swingDescriptor = descriptor.getComponents().getFirst();
         assertThat(swingDescriptor.getType()).isEqualTo("RecentFractalSwingHighIndicator");
-        assertThat(swingDescriptor.getParameters()).containsKey("unstableBars");
+        assertThat(swingDescriptor.getParameters()).doesNotContainKey("unstableBars");
         assertThat(swingDescriptor.getComponents())
                 .anySatisfy(component -> assertThat(component.getType()).isEqualTo("HighPriceIndicator"));
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendLineSupportIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendLineSupportIndicatorTest.java
@@ -111,7 +111,7 @@ public class TrendLineSupportIndicatorTest extends AbstractIndicatorTest<Indicat
         assertThat(descriptor.getComponents()).hasSize(1);
         final ComponentDescriptor swingDescriptor = descriptor.getComponents().getFirst();
         assertThat(swingDescriptor.getType()).isEqualTo("RecentFractalSwingLowIndicator");
-        assertThat(swingDescriptor.getParameters()).containsKey("unstableBars");
+        assertThat(swingDescriptor.getParameters()).doesNotContainKey("unstableBars");
         assertThat(swingDescriptor.getComponents())
                 .anySatisfy(component -> assertThat(component.getType()).isEqualTo("LowPriceIndicator"));
 

--- a/ta4j-core/src/test/java/org/ta4j/core/serialization/IndicatorSerializationTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/serialization/IndicatorSerializationTest.java
@@ -4,6 +4,7 @@
 package org.ta4j.core.serialization;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -202,6 +203,28 @@ public class IndicatorSerializationTest {
 
         assertThat(reconstructed).isInstanceOf(IndicatorConstructorSelectionTestIndicator.class);
         assertThat(reconstructed.toDescriptor()).isEqualTo(original.toDescriptor());
+    }
+
+    @Test
+    public void deserializeRejectsDescriptorsWithUnconsumedComponentsOrParameters() {
+        BarSeries series = new MockBarSeriesBuilder().withData(1, 2, 3, 4, 5).build();
+        ComponentDescriptor extraComponentDescriptor = ComponentDescriptor.builder()
+                .withType("ClosePriceIndicator")
+                .addComponent(ComponentDescriptor.builder().withType("ClosePriceIndicator").build())
+                .build();
+
+        IndicatorSerializationException componentException = assertThrows(IndicatorSerializationException.class,
+                () -> IndicatorSerialization.fromDescriptor(series, extraComponentDescriptor));
+        assertThat(componentException).hasMessageContaining("no suitable constructor");
+
+        ComponentDescriptor extraParameterDescriptor = ComponentDescriptor.builder()
+                .withType("ClosePriceIndicator")
+                .withParameters(Map.of("unusedBarCount", 3))
+                .build();
+
+        IndicatorSerializationException parameterException = assertThrows(IndicatorSerializationException.class,
+                () -> IndicatorSerialization.fromDescriptor(series, extraParameterDescriptor));
+        assertThat(parameterException).hasMessageContaining("no suitable constructor");
     }
 
     @Test


### PR DESCRIPTION
Fixes CF-232, CF-286.

Changes proposed in this pull request:
- Enforce strict indicator descriptor reconstruction so child components and constructor parameters must be consumed.
- Move prerequisite constructor-state fixes for existing round-trip coverage into the base of the stack.
- Keep derived helper/cache state transient for full-suite serialization compatibility.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added serialization support for MVWAP indicators, including descriptor and JSON export.
  * Added constructor options for trendline support and resistance indicators, including tolerance settings and search limits.

* **Bug Fixes**
  * Improved indicator deserialization to select compatible configurations more reliably.
  * Invalid or incomplete serialized indicator definitions are now rejected with clearer errors.
  * Improved consistency when saving and restoring indicator configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->