### PR TITLE
Fix oscillator serialization round trips

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AwesomeOscillatorIndicator.java
@@ -18,8 +18,11 @@ import org.ta4j.core.num.Num;
  */
 public class AwesomeOscillatorIndicator extends CachedIndicator<Num> {
 
-    private final SMAIndicator sma5;
-    private final SMAIndicator sma34;
+    private final Indicator<Num> indicator;
+    private final int barCountSma1;
+    private final int barCountSma2;
+    private final transient SMAIndicator sma5;
+    private final transient SMAIndicator sma34;
 
     /**
      * Constructor.
@@ -30,6 +33,9 @@ public class AwesomeOscillatorIndicator extends CachedIndicator<Num> {
      */
     public AwesomeOscillatorIndicator(Indicator<Num> indicator, int barCountSma1, int barCountSma2) {
         super(indicator);
+        this.indicator = indicator;
+        this.barCountSma1 = barCountSma1;
+        this.barCountSma2 = barCountSma2;
         this.sma5 = new SMAIndicator(indicator, barCountSma1);
         this.sma34 = new SMAIndicator(indicator, barCountSma2);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CMOIndicator.java
@@ -20,8 +20,9 @@ import org.ta4j.core.num.Num;
  */
 public class CMOIndicator extends CachedIndicator<Num> {
 
-    private final GainIndicator gainIndicator;
-    private final LossIndicator lossIndicator;
+    private final Indicator<Num> indicator;
+    private final transient GainIndicator gainIndicator;
+    private final transient LossIndicator lossIndicator;
     private final int barCount;
 
     /**
@@ -32,6 +33,7 @@ public class CMOIndicator extends CachedIndicator<Num> {
      */
     public CMOIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator);
+        this.indicator = indicator;
         this.gainIndicator = new GainIndicator(indicator);
         this.lossIndicator = new LossIndicator(indicator);
         this.barCount = barCount;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CompressionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CompressionIndicator.java
@@ -30,10 +30,13 @@ public class CompressionIndicator extends CachedIndicator<Num> {
 
     private static final Number DEFAULT_BOLLINGER_K = 2;
 
-    private final Indicator<Num> atrCompressionIndicator;
-    private final Indicator<Num> bollingerCompressionIndicator;
-    private final Indicator<Num> donchianCompressionIndicator;
-    private final Indicator<Num> compositeIndicator;
+    private final Indicator<Num> atrPercentIndicator;
+    private final Indicator<Num> bollingerWidthIndicator;
+    private final Indicator<Num> donchianWidthIndicator;
+    private final transient Indicator<Num> atrCompressionIndicator;
+    private final transient Indicator<Num> bollingerCompressionIndicator;
+    private final transient Indicator<Num> donchianCompressionIndicator;
+    private final transient Indicator<Num> compositeIndicator;
     private final int barCount;
     private final int percentileBarCount;
 
@@ -82,6 +85,9 @@ public class CompressionIndicator extends CachedIndicator<Num> {
         super(config.series());
         this.barCount = config.barCount();
         this.percentileBarCount = config.percentileBarCount();
+        this.atrPercentIndicator = config.atrPercentIndicator();
+        this.bollingerWidthIndicator = config.bollingerWidthIndicator();
+        this.donchianWidthIndicator = config.donchianWidthIndicator();
         this.atrCompressionIndicator = config.atrCompressionIndicator();
         this.bollingerCompressionIndicator = config.bollingerCompressionIndicator();
         this.donchianCompressionIndicator = config.donchianCompressionIndicator();
@@ -110,7 +116,8 @@ public class CompressionIndicator extends CachedIndicator<Num> {
                 .of(new SumIndicator(atrCompressionIndicator, bollingerCompressionIndicator,
                         donchianCompressionIndicator))
                 .dividedBy(3);
-        return new Config(series, atrCompressionIndicator, bollingerCompressionIndicator, donchianCompressionIndicator,
+        return new Config(series, atrPercentIndicator, bollingerWidthIndicator, donchianWidthIndicator,
+                atrCompressionIndicator, bollingerCompressionIndicator, donchianCompressionIndicator,
                 compositeIndicator, barCount, percentileBarCount);
     }
 
@@ -192,7 +199,8 @@ public class CompressionIndicator extends CachedIndicator<Num> {
         return NumericIndicator.of(new PercentRankIndicator(indicator, percentileBarCount)).multipliedBy(-1).plus(100);
     }
 
-    private record Config(BarSeries series, Indicator<Num> atrCompressionIndicator,
+    private record Config(BarSeries series, Indicator<Num> atrPercentIndicator, Indicator<Num> bollingerWidthIndicator,
+            Indicator<Num> donchianWidthIndicator, Indicator<Num> atrCompressionIndicator,
             Indicator<Num> bollingerCompressionIndicator, Indicator<Num> donchianCompressionIndicator,
             Indicator<Num> compositeIndicator, int barCount, int percentileBarCount) {
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ConnorsRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ConnorsRSIIndicator.java
@@ -25,9 +25,13 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class ConnorsRSIIndicator extends CachedIndicator<Num> {
 
-    private final RSIIndicator priceRsi;
-    private final RSIIndicator streakRsi;
-    private final PercentRankIndicator percentRankIndicator;
+    private final Indicator<Num> indicator;
+    private final int rsiPeriod;
+    private final int streakRsiPeriod;
+    private final int percentRankPeriod;
+    private final transient RSIIndicator priceRsi;
+    private final transient RSIIndicator streakRsi;
+    private final transient PercentRankIndicator percentRankIndicator;
 
     /**
      * Constructor using the original Connors RSI defaults ({@code rsiPeriod}=3,
@@ -56,6 +60,10 @@ public class ConnorsRSIIndicator extends CachedIndicator<Num> {
 
     private ConnorsRSIIndicator(Config config) {
         super(config.indicator());
+        this.indicator = config.indicator();
+        this.rsiPeriod = config.rsiPeriod();
+        this.streakRsiPeriod = config.streakRsiPeriod();
+        this.percentRankPeriod = config.percentRankPeriod();
         this.priceRsi = config.priceRsi();
         this.streakRsi = config.streakRsi();
         this.percentRankIndicator = config.percentRankIndicator();
@@ -71,7 +79,8 @@ public class ConnorsRSIIndicator extends CachedIndicator<Num> {
         RSIIndicator priceRsi = new RSIIndicator(indicator, rsiPeriod);
         RSIIndicator streakRsi = new RSIIndicator(new StreakIndicator(indicator), streakRsiPeriod);
         PercentRankIndicator percentRankIndicator = new PercentRankIndicator(priceChangeIndicator, percentRankPeriod);
-        return new Config(indicator, priceRsi, streakRsi, percentRankIndicator);
+        return new Config(indicator, rsiPeriod, streakRsiPeriod, percentRankPeriod, priceRsi, streakRsi,
+                percentRankIndicator);
     }
 
     @Override
@@ -97,7 +106,7 @@ public class ConnorsRSIIndicator extends CachedIndicator<Num> {
                 percentRankIndicator.getCountOfUnstableBars());
     }
 
-    private record Config(Indicator<Num> indicator, RSIIndicator priceRsi, RSIIndicator streakRsi,
-            PercentRankIndicator percentRankIndicator) {
+    private record Config(Indicator<Num> indicator, int rsiPeriod, int streakRsiPeriod, int percentRankPeriod,
+            RSIIndicator priceRsi, RSIIndicator streakRsi, PercentRankIndicator percentRankIndicator) {
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/CoppockCurveIndicator.java
@@ -17,7 +17,11 @@ import org.ta4j.core.num.Num;
  */
 public class CoppockCurveIndicator extends CachedIndicator<Num> {
 
-    private final WMAIndicator wma;
+    private final Indicator<Num> indicator;
+    private final int longRoCBarCount;
+    private final int shortRoCBarCount;
+    private final int wmaBarCount;
+    private final transient WMAIndicator wma;
 
     /**
      * Constructor with:
@@ -44,6 +48,10 @@ public class CoppockCurveIndicator extends CachedIndicator<Num> {
      */
     public CoppockCurveIndicator(Indicator<Num> indicator, int longRoCBarCount, int shortRoCBarCount, int wmaBarCount) {
         super(indicator);
+        this.indicator = indicator;
+        this.longRoCBarCount = longRoCBarCount;
+        this.shortRoCBarCount = shortRoCBarCount;
+        this.wmaBarCount = wmaBarCount;
         SumIndicator sum = new SumIndicator(new ROCIndicator(indicator, longRoCBarCount),
                 new ROCIndicator(indicator, shortRoCBarCount));
         this.wma = new WMAIndicator(sum, wmaBarCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/FisherIndicator.java
@@ -34,11 +34,18 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
     private static final double VALUE_MIN = -0.999;
 
     private final Indicator<Num> ref;
-    private final Indicator<Num> intermediateValue;
-    private final Num densityFactor;
-    private final Num gamma;
-    private final Num delta;
-    private final Num one;
+    private final int barCount;
+    private final double alpha;
+    private final double beta;
+    private final double gamma;
+    private final double delta;
+    private final double densityFactor;
+    private final boolean isPriceIndicator;
+    private final transient Indicator<Num> intermediateValue;
+    private final transient Num densityFactorNum;
+    private final transient Num gammaNum;
+    private final transient Num deltaNum;
+    private final transient Num one;
 
     /**
      * Constructor.
@@ -113,25 +120,32 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
      *
      * @param ref              the indicator
      * @param barCount         the time frame (usually 10)
-     * @param alphaD           the alpha (usually 0.33 or 0.5)
-     * @param betaD            the beta (usually 0.67 or 0.5)
-     * @param gammaD           the gamma (usually 0.25 or 0.5)
-     * @param deltaD           the delta (usually 0.5)
-     * @param densityFactorD   the density factor (usually 1.0)
+     * @param alpha            the alpha (usually 0.33 or 0.5)
+     * @param beta             the beta (usually 0.67 or 0.5)
+     * @param gamma            the gamma (usually 0.25 or 0.5)
+     * @param delta            the delta (usually 0.5)
+     * @param densityFactor    the density factor (usually 1.0)
      * @param isPriceIndicator use true, if "ref" is a price indicator
      */
-    public FisherIndicator(Indicator<Num> ref, int barCount, final double alphaD, final double betaD,
-            final double gammaD, final double deltaD, double densityFactorD, boolean isPriceIndicator) {
+    public FisherIndicator(Indicator<Num> ref, int barCount, final double alpha, final double beta, final double gamma,
+            final double delta, double densityFactor, boolean isPriceIndicator) {
         super(ref);
         this.ref = ref;
+        this.barCount = barCount;
+        this.alpha = alpha;
+        this.beta = beta;
+        this.gamma = gamma;
+        this.delta = delta;
+        this.densityFactor = densityFactor;
+        this.isPriceIndicator = isPriceIndicator;
         final var numFactory = getBarSeries().numFactory();
-        this.gamma = numFactory.numOf(gammaD);
-        this.delta = numFactory.numOf(deltaD);
-        this.densityFactor = numFactory.numOf(densityFactorD);
+        this.gammaNum = numFactory.numOf(gamma);
+        this.deltaNum = numFactory.numOf(delta);
+        this.densityFactorNum = numFactory.numOf(densityFactor);
         this.one = numFactory.one();
 
-        Num alpha = numFactory.numOf(alphaD);
-        Num beta = numFactory.numOf(betaD);
+        Num alphaNum = numFactory.numOf(alpha);
+        Num betaNum = numFactory.numOf(beta);
         final Indicator<Num> periodHigh = new HighestValueIndicator(
                 isPriceIndicator ? new HighPriceIndicator(ref.getBarSeries()) : ref, barCount);
         final Indicator<Num> periodLow = new LowestValueIndicator(
@@ -151,9 +165,9 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
                 Num minL = periodLow.getValue(index);
                 Num maxH = periodHigh.getValue(index);
                 Num term1 = currentRef.minus(minL).dividedBy(maxH.minus(minL)).minus(numFactory.numOf(ZERO_DOT_FIVE));
-                Num term2 = alpha.multipliedBy(numFactory.numOf(2)).multipliedBy(term1);
-                Num term3 = term2.plus(beta.multipliedBy(getValue(index - 1)));
-                return term3.dividedBy(FisherIndicator.this.densityFactor);
+                Num term2 = alphaNum.multipliedBy(numFactory.numOf(2)).multipliedBy(term1);
+                Num term3 = term2.plus(betaNum.multipliedBy(getValue(index - 1)));
+                return term3.dividedBy(FisherIndicator.this.densityFactorNum);
             }
 
             @Override
@@ -181,7 +195,7 @@ public class FisherIndicator extends RecursiveCachedIndicator<Num> {
         // Fisher = gamma * Log((1 + Value) / (1 - Value)) + delta * priorFisher
         Num term1 = numFactory.numOf((Math.log(one.plus(value).dividedBy(one.minus(value)).doubleValue())));
         Num term2 = getValue(index - 1);
-        return gamma.multipliedBy(term1).plus(delta.multipliedBy(term2));
+        return gammaNum.multipliedBy(term1).plus(deltaNum.multipliedBy(term2));
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KRIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KRIIndicator.java
@@ -17,7 +17,8 @@ import org.ta4j.core.num.Num;
  *      "https://www.tradingview.com/script/xzRPAboO-Indicator-Kairi-Relative-Index-KRI/">TradingView</a>
  */
 public class KRIIndicator extends AbstractIndicator<Num> {
-    private final Indicator<Num> kriIndicator;
+    private final Indicator<Num> indicator;
+    private final transient Indicator<Num> kriIndicator;
     private final int barCount;
 
     public KRIIndicator(BarSeries series, int barCount) {
@@ -26,6 +27,7 @@ public class KRIIndicator extends AbstractIndicator<Num> {
 
     public KRIIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator.getBarSeries());
+        this.indicator = indicator;
 
         final var smaIndicator = new SMAIndicator(indicator, barCount);
         final var difference = BinaryOperationIndicator.difference(indicator, smaIndicator);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/KSTIndicator.java
@@ -26,14 +26,23 @@ import org.ta4j.core.num.Num;
  */
 public class KSTIndicator extends CachedIndicator<Num> {
 
-    private final SMAIndicator RCMA1;
-    private final SMAIndicator RCMA2;
-    private final SMAIndicator RCMA3;
-    private final SMAIndicator RCMA4;
-    private final Num RCMA1_Multiplier = getBarSeries().numFactory().one();
-    private final Num RCMA2_Multiplier = getBarSeries().numFactory().numOf(2);
-    private final Num RCMA3_Multiplier = getBarSeries().numFactory().numOf(3);
-    private final Num RCMA4_Multiplier = getBarSeries().numFactory().numOf(4);
+    private final Indicator<Num> indicator;
+    private final int rcma1SMABarCount;
+    private final int rcma1ROCBarCount;
+    private final int rcma2SMABarCount;
+    private final int rcma2ROCBarCount;
+    private final int rcma3SMABarCount;
+    private final int rcma3ROCBarCount;
+    private final int rcma4SMABarCount;
+    private final int rcma4ROCBarCount;
+    private final transient SMAIndicator RCMA1;
+    private final transient SMAIndicator RCMA2;
+    private final transient SMAIndicator RCMA3;
+    private final transient SMAIndicator RCMA4;
+    private final transient Num RCMA1_Multiplier = getBarSeries().numFactory().one();
+    private final transient Num RCMA2_Multiplier = getBarSeries().numFactory().numOf(2);
+    private final transient Num RCMA3_Multiplier = getBarSeries().numFactory().numOf(3);
+    private final transient Num RCMA4_Multiplier = getBarSeries().numFactory().numOf(4);
 
     /**
      * Constructor with:
@@ -48,11 +57,7 @@ public class KSTIndicator extends CachedIndicator<Num> {
      * @param indicator the {@link Indicator}
      */
     public KSTIndicator(Indicator<Num> indicator) {
-        super(indicator);
-        this.RCMA1 = new SMAIndicator(new ROCIndicator(indicator, 10), 10);
-        this.RCMA2 = new SMAIndicator(new ROCIndicator(indicator, 15), 10);
-        this.RCMA3 = new SMAIndicator(new ROCIndicator(indicator, 20), 10);
-        this.RCMA4 = new SMAIndicator(new ROCIndicator(indicator, 30), 15);
+        this(indicator, 10, 10, 10, 15, 10, 20, 15, 30);
     }
 
     /**
@@ -72,6 +77,15 @@ public class KSTIndicator extends CachedIndicator<Num> {
             int rcma2ROCBarCount, int rcma3SMABarCount, int rcma3ROCBarCount, int rcma4SMABarCount,
             int rcma4ROCBarCount) {
         super(indicator);
+        this.indicator = indicator;
+        this.rcma1SMABarCount = rcma1SMABarCount;
+        this.rcma1ROCBarCount = rcma1ROCBarCount;
+        this.rcma2SMABarCount = rcma2SMABarCount;
+        this.rcma2ROCBarCount = rcma2ROCBarCount;
+        this.rcma3SMABarCount = rcma3SMABarCount;
+        this.rcma3ROCBarCount = rcma3ROCBarCount;
+        this.rcma4SMABarCount = rcma4SMABarCount;
+        this.rcma4ROCBarCount = rcma4ROCBarCount;
         this.RCMA1 = new SMAIndicator(new ROCIndicator(indicator, rcma1ROCBarCount), rcma1SMABarCount);
         this.RCMA2 = new SMAIndicator(new ROCIndicator(indicator, rcma2ROCBarCount), rcma2SMABarCount);
         this.RCMA3 = new SMAIndicator(new ROCIndicator(indicator, rcma3ROCBarCount), rcma3SMABarCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/RAVIIndicator.java
@@ -15,8 +15,11 @@ import org.ta4j.core.num.Num;
  */
 public class RAVIIndicator extends CachedIndicator<Num> {
 
-    private final SMAIndicator shortSma;
-    private final SMAIndicator longSma;
+    private final Indicator<Num> price;
+    private final int shortSmaBarCount;
+    private final int longSmaBarCount;
+    private final transient SMAIndicator shortSma;
+    private final transient SMAIndicator longSma;
 
     /**
      * Constructor.
@@ -27,6 +30,9 @@ public class RAVIIndicator extends CachedIndicator<Num> {
      */
     public RAVIIndicator(Indicator<Num> price, int shortSmaBarCount, int longSmaBarCount) {
         super(price);
+        this.price = price;
+        this.shortSmaBarCount = shortSmaBarCount;
+        this.longSmaBarCount = longSmaBarCount;
         this.shortSma = new SMAIndicator(price, shortSmaBarCount);
         this.longSma = new SMAIndicator(price, longSmaBarCount);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SchaffTrendCycleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SchaffTrendCycleIndicator.java
@@ -23,10 +23,12 @@ import org.ta4j.core.num.Num;
  */
 public class SchaffTrendCycleIndicator extends CachedIndicator<Num> {
 
-    private final EMAIndicator stcSmoothed;
+    private final Indicator<Num> indicator;
+    private final int fastPeriod;
     private final int slowPeriod;
     private final int cycleLength;
     private final int smoothingPeriod;
+    private final transient EMAIndicator stcSmoothed;
 
     /**
      * Constructor with common parameterization ({@code fast}=23, {@code slow}=50,
@@ -57,6 +59,8 @@ public class SchaffTrendCycleIndicator extends CachedIndicator<Num> {
 
     private SchaffTrendCycleIndicator(Config config) {
         super(config.indicator());
+        this.indicator = config.indicator();
+        this.fastPeriod = config.fastPeriod();
         this.slowPeriod = config.slowPeriod();
         this.cycleLength = config.cycleLength();
         this.smoothingPeriod = config.smoothingPeriod();
@@ -77,7 +81,7 @@ public class SchaffTrendCycleIndicator extends CachedIndicator<Num> {
         EMAIndicator macdStochasticSmoothed = new EMAIndicator(macdStochastic, smoothingPeriod);
         StochasticIndicator cycleStochastic = new StochasticIndicator(macdStochasticSmoothed, cycleLength);
         EMAIndicator stcSmoothed = new EMAIndicator(cycleStochastic, smoothingPeriod);
-        return new Config(indicator, stcSmoothed, slowPeriod, cycleLength, smoothingPeriod);
+        return new Config(indicator, fastPeriod, stcSmoothed, slowPeriod, cycleLength, smoothingPeriod);
     }
 
     @Override
@@ -97,7 +101,7 @@ public class SchaffTrendCycleIndicator extends CachedIndicator<Num> {
         return slowPeriod + cycleLength + smoothingPeriod + cycleLength + smoothingPeriod;
     }
 
-    private record Config(Indicator<Num> indicator, EMAIndicator stcSmoothed, int slowPeriod, int cycleLength,
-            int smoothingPeriod) {
+    private record Config(Indicator<Num> indicator, int fastPeriod, EMAIndicator stcSmoothed, int slowPeriod,
+            int cycleLength, int smoothingPeriod) {
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StochasticRSIIndicator.java
@@ -19,8 +19,9 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class StochasticRSIIndicator extends CachedIndicator<Num> {
 
+    private final Indicator<Num> indicator;
     private final int barCount;
-    private final StochasticIndicator stochasticIndicator;
+    private final transient StochasticIndicator stochasticIndicator;
 
     /**
      * Constructor.
@@ -54,6 +55,7 @@ public class StochasticRSIIndicator extends CachedIndicator<Num> {
      */
     public StochasticRSIIndicator(RSIIndicator rsiIndicator, int barCount) {
         super(rsiIndicator);
+        this.indicator = rsiIndicator;
         this.barCount = barCount;
         this.stochasticIndicator = new StochasticIndicator(rsiIndicator, barCount);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/StretchZScoreIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/StretchZScoreIndicator.java
@@ -38,9 +38,9 @@ public class StretchZScoreIndicator extends CachedIndicator<Num> {
 
     private final Indicator<Num> sourceIndicator;
     private final Indicator<Num> referenceIndicator;
-    private final Indicator<Num> deviationIndicator;
-    private final StandardDeviationIndicator standardDeviationIndicator;
-    private final ZScoreIndicator zScoreIndicator;
+    private final transient Indicator<Num> deviationIndicator;
+    private final transient StandardDeviationIndicator standardDeviationIndicator;
+    private final transient ZScoreIndicator zScoreIndicator;
     private final int barCount;
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/TrendConclusionIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/TrendConclusionIndicator.java
@@ -37,11 +37,12 @@ import org.ta4j.core.num.Num;
  */
 public class TrendConclusionIndicator extends CachedIndicator<Num> {
 
-    private final Indicator<Num> adxFadeComponent;
-    private final Indicator<Num> histogramMeanReversionComponent;
-    private final Indicator<Num> priceRecenterComponent;
+    private final Indicator<Num> adxFadeIndicator;
+    private final Indicator<Num> histogramMeanReversionIndicator;
+    private final Indicator<Num> priceRecenterIndicator;
     private final Indicator<Num> compressionComponent;
-    private final Indicator<Num> compositeIndicator;
+    private final transient Indicator<Num> adxFadeComponent;
+    private final transient Indicator<Num> compositeIndicator;
     private final int normalizationBarCount;
 
     /**
@@ -87,9 +88,10 @@ public class TrendConclusionIndicator extends CachedIndicator<Num> {
     private TrendConclusionIndicator(Config config) {
         super(config.series());
         this.normalizationBarCount = config.normalizationBarCount();
+        this.adxFadeIndicator = config.adxFadeIndicator();
+        this.histogramMeanReversionIndicator = config.histogramMeanReversionIndicator();
+        this.priceRecenterIndicator = config.priceRecenterIndicator();
         this.adxFadeComponent = config.adxFadeComponent();
-        this.histogramMeanReversionComponent = config.histogramMeanReversionComponent();
-        this.priceRecenterComponent = config.priceRecenterComponent();
         this.compressionComponent = config.compressionComponent();
         this.compositeIndicator = config.compositeIndicator();
     }
@@ -115,8 +117,8 @@ public class TrendConclusionIndicator extends CachedIndicator<Num> {
         Indicator<Num> adxFadeComponent = oneSidedPercentRank(adxFadeIndicator, normalizationBarCount);
         Indicator<Num> compositeIndicator = NumericIndicator.of(new SumIndicator(adxFadeComponent,
                 histogramMeanReversionIndicator, priceRecenterIndicator, compressionIndicator)).dividedBy(4);
-        return new Config(series, adxFadeComponent, histogramMeanReversionIndicator, priceRecenterIndicator,
-                compressionIndicator, compositeIndicator, normalizationBarCount);
+        return new Config(series, adxFadeIndicator, histogramMeanReversionIndicator, priceRecenterIndicator,
+                adxFadeComponent, compressionIndicator, compositeIndicator, normalizationBarCount);
     }
 
     /**
@@ -152,7 +154,7 @@ public class TrendConclusionIndicator extends CachedIndicator<Num> {
      * @since 0.22.7
      */
     public Indicator<Num> getHistogramMeanReversionComponent() {
-        return histogramMeanReversionComponent;
+        return histogramMeanReversionIndicator;
     }
 
     /**
@@ -160,7 +162,7 @@ public class TrendConclusionIndicator extends CachedIndicator<Num> {
      * @since 0.22.7
      */
     public Indicator<Num> getPriceRecenterComponent() {
-        return priceRecenterComponent;
+        return priceRecenterIndicator;
     }
 
     /**
@@ -212,8 +214,9 @@ public class TrendConclusionIndicator extends CachedIndicator<Num> {
                 .plus(100);
     }
 
-    private record Config(BarSeries series, Indicator<Num> adxFadeComponent,
-            Indicator<Num> histogramMeanReversionComponent, Indicator<Num> priceRecenterComponent,
-            Indicator<Num> compressionComponent, Indicator<Num> compositeIndicator, int normalizationBarCount) {
+    private record Config(BarSeries series, Indicator<Num> adxFadeIndicator,
+            Indicator<Num> histogramMeanReversionIndicator, Indicator<Num> priceRecenterIndicator,
+            Indicator<Num> adxFadeComponent, Indicator<Num> compressionComponent, Indicator<Num> compositeIndicator,
+            int normalizationBarCount) {
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/TrendScoreIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/TrendScoreIndicator.java
@@ -39,11 +39,14 @@ import org.ta4j.core.num.Num;
  */
 public class TrendScoreIndicator extends CachedIndicator<Num> {
 
-    private final Indicator<Num> emaAlignmentComponent;
-    private final Indicator<Num> macdHistogramComponent;
-    private final Indicator<Num> adxStrengthComponent;
-    private final Indicator<Num> adxChangeComponent;
-    private final Indicator<Num> compositeIndicator;
+    private final Indicator<Num> emaAlignmentIndicator;
+    private final Indicator<Num> macdHistogramIndicator;
+    private final Indicator<Num> adxIndicator;
+    private final transient Indicator<Num> emaAlignmentComponent;
+    private final transient Indicator<Num> macdHistogramComponent;
+    private final transient Indicator<Num> adxStrengthComponent;
+    private final transient Indicator<Num> adxChangeComponent;
+    private final transient Indicator<Num> compositeIndicator;
     private final int normalizationBarCount;
 
     /**
@@ -80,6 +83,9 @@ public class TrendScoreIndicator extends CachedIndicator<Num> {
     private TrendScoreIndicator(Config config) {
         super(config.series());
         this.normalizationBarCount = config.normalizationBarCount();
+        this.emaAlignmentIndicator = config.emaAlignmentIndicator();
+        this.macdHistogramIndicator = config.macdHistogramIndicator();
+        this.adxIndicator = config.adxIndicator();
         this.emaAlignmentComponent = config.emaAlignmentComponent();
         this.macdHistogramComponent = config.macdHistogramComponent();
         this.adxStrengthComponent = config.adxStrengthComponent();
@@ -112,8 +118,9 @@ public class TrendScoreIndicator extends CachedIndicator<Num> {
                 centeredPercentRank(new DifferenceIndicator(adxIndicator), normalizationBarCount), directionBias);
         Indicator<Num> compositeIndicator = NumericIndicator.of(new SumIndicator(emaAlignmentComponent,
                 macdHistogramComponent, adxStrengthComponent, adxChangeComponent)).dividedBy(4).multipliedBy(100);
-        return new Config(series, emaAlignmentComponent, macdHistogramComponent, adxStrengthComponent,
-                adxChangeComponent, compositeIndicator, normalizationBarCount);
+        return new Config(series, emaAlignmentIndicator, macdHistogramIndicator, adxIndicator, emaAlignmentComponent,
+                macdHistogramComponent, adxStrengthComponent, adxChangeComponent, compositeIndicator,
+                normalizationBarCount);
     }
 
     /**
@@ -215,7 +222,8 @@ public class TrendScoreIndicator extends CachedIndicator<Num> {
         };
     }
 
-    private record Config(BarSeries series, Indicator<Num> emaAlignmentComponent, Indicator<Num> macdHistogramComponent,
+    private record Config(BarSeries series, Indicator<Num> emaAlignmentIndicator, Indicator<Num> macdHistogramIndicator,
+            Indicator<Num> adxIndicator, Indicator<Num> emaAlignmentComponent, Indicator<Num> macdHistogramComponent,
             Indicator<Num> adxStrengthComponent, Indicator<Num> adxChangeComponent, Indicator<Num> compositeIndicator,
             int normalizationBarCount) {
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/ADXIndicator.java
@@ -21,8 +21,8 @@ public class ADXIndicator extends CachedIndicator<Num> {
 
     private final int diBarCount;
     private final int adxBarCount;
-    private final DXIndicator dxIndicator;
-    private final MMAIndicator averageDXIndicator;
+    private final transient DXIndicator dxIndicator;
+    private final transient MMAIndicator averageDXIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/DXIndicator.java
@@ -16,8 +16,8 @@ import org.ta4j.core.num.Num;
 public class DXIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final PlusDIIndicator plusDIIndicator;
-    private final MinusDIIndicator minusDIIndicator;
+    private final transient PlusDIIndicator plusDIIndicator;
+    private final transient MinusDIIndicator minusDIIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/MinusDIIndicator.java
@@ -24,9 +24,9 @@ import org.ta4j.core.num.Num;
 public class MinusDIIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final ATRIndicator atrIndicator;
-    private final MinusDMIndicator minusDMIndicator;
-    private final MMAIndicator avgMinusDMIndicator;
+    private final transient ATRIndicator atrIndicator;
+    private final transient MinusDMIndicator minusDMIndicator;
+    private final transient MMAIndicator avgMinusDMIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/adx/PlusDIIndicator.java
@@ -24,9 +24,9 @@ import org.ta4j.core.num.Num;
 public class PlusDIIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final ATRIndicator atrIndicator;
-    private final PlusDMIndicator plusDMIndicator;
-    private final MMAIndicator avgPlusDMIndicator;
+    private final transient ATRIndicator atrIndicator;
+    private final transient PlusDMIndicator plusDMIndicator;
+    private final transient MMAIndicator avgPlusDMIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/ATMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/ATMAIndicator.java
@@ -22,10 +22,11 @@ import static org.ta4j.core.num.NaN.NaN;
 public class ATMAIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final int slow;
-    private final int fast;
-    private final SMAIndicator sma;
-    private final SMAIndicator smaSma;
+    private final Indicator<Num> indicator;
+    private final transient int slow;
+    private final transient int fast;
+    private final transient SMAIndicator sma;
+    private final transient SMAIndicator smaSma;
 
     /**
      * Constructor.
@@ -37,6 +38,7 @@ public class ATMAIndicator extends CachedIndicator<Num> {
     public ATMAIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator.getBarSeries());
         this.barCount = barCount;
+        this.indicator = indicator;
         this.fast = Math.ceilDiv(barCount, 2);
         this.slow = (barCount / 2) + 1;
         this.sma = new SMAIndicator(indicator, slow);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/HMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/HMAIndicator.java
@@ -18,8 +18,9 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class HMAIndicator extends CachedIndicator<Num> {
 
+    private final Indicator<Num> indicator;
     private final int barCount;
-    private final WMAIndicator sqrtWma;
+    private final transient WMAIndicator sqrtWma;
 
     /**
      * Constructor.
@@ -29,6 +30,7 @@ public class HMAIndicator extends CachedIndicator<Num> {
      */
     public HMAIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator);
+        this.indicator = indicator;
         this.barCount = barCount;
 
         final var halfWma = new WMAIndicator(indicator, barCount / 2);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/KiJunV2Indicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/KiJunV2Indicator.java
@@ -28,9 +28,11 @@ import static org.ta4j.core.num.NaN.NaN;
 public class KiJunV2Indicator extends CachedIndicator<Num> {
 
     private final int barCount; // Lookback period
-    private final NumFactory numFactory;
-    private final HighestValueIndicator highestValue;
-    private final LowestValueIndicator lowestValue;
+    private final Indicator<Num> highPrice;
+    private final Indicator<Num> lowPrice;
+    private final transient NumFactory numFactory;
+    private final transient HighestValueIndicator highestValue;
+    private final transient LowestValueIndicator lowestValue;
 
     /**
      * Constructor.
@@ -42,9 +44,11 @@ public class KiJunV2Indicator extends CachedIndicator<Num> {
     public KiJunV2Indicator(Indicator<Num> highPrice, Indicator<Num> lowPrice, int barCount) {
         super(highPrice.getBarSeries());
         this.barCount = barCount;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
         this.numFactory = highPrice.getBarSeries().numFactory();
-        this.highestValue = new HighestValueIndicator(new HighPriceIndicator(highPrice.getBarSeries()), barCount);
-        this.lowestValue = new LowestValueIndicator(new LowPriceIndicator(lowPrice.getBarSeries()), barCount);
+        this.highestValue = new HighestValueIndicator(highPrice, barCount);
+        this.lowestValue = new LowestValueIndicator(lowPrice, barCount);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/TMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/TMAIndicator.java
@@ -23,9 +23,10 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class TMAIndicator extends CachedIndicator<Num> {
 
+    private final Indicator<Num> indicator;
     private final int barCount;
-    private final SMAIndicator sma;
-    private final SMAIndicator smaSma;
+    private final transient SMAIndicator sma;
+    private final transient SMAIndicator smaSma;
 
     /**
      * Constructor.
@@ -35,6 +36,7 @@ public class TMAIndicator extends CachedIndicator<Num> {
      */
     public TMAIndicator(Indicator<Num> indicator, int barCount) {
         super(indicator.getBarSeries());
+        this.indicator = indicator;
         this.barCount = barCount;
         this.sma = new SMAIndicator(indicator, barCount);
         this.smaSma = new SMAIndicator(sma, barCount);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/VIDYAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/VIDYAIndicator.java
@@ -24,7 +24,7 @@ public class VIDYAIndicator extends CachedIndicator<Num> {
     private final Indicator<Num> indicator; // Input price (e.g., close price)
     private final int cmoPeriod; // Lookback period for cmoPeriod
     private final int vidyaPeriod; // Lookback period for VIDYA
-    private final CMOIndicator cmoIndicator;
+    private final transient CMOIndicator cmoIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/VWMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/VWMAIndicator.java
@@ -33,7 +33,7 @@ public class VWMAIndicator extends CachedIndicator<Num> {
     private final int barCount;
     private final Indicator<Num> priceIndicator;
     private final Indicator<Num> volumeIndicator;
-    private final Indicator<Num> volumeWeightedIndicator;
+    private final transient Indicator<Num> volumeWeightedIndicator;
 
     /**
      * Constructor.
@@ -43,6 +43,19 @@ public class VWMAIndicator extends CachedIndicator<Num> {
      */
     public VWMAIndicator(Indicator<Num> priceIndicator, int barCount) {
         this(defaultConfig(priceIndicator, barCount));
+    }
+
+    /**
+     * Constructor using the default SMA averaging strategy with explicit price and
+     * volume inputs.
+     *
+     * @param priceIndicator  price based indicator
+     * @param volumeIndicator volume based indicator
+     * @param barCount        the time frame
+     * @since 0.23.1
+     */
+    public VWMAIndicator(Indicator<Num> priceIndicator, Indicator<Num> volumeIndicator, int barCount) {
+        this(validatedConfig(priceIndicator, volumeIndicator, barCount, SMAIndicator::new));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicator.java
@@ -15,8 +15,8 @@ import org.ta4j.core.num.Num;
 public class DonchianChannelLowerIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final LowPriceIndicator lowPrice;
-    private final LowestValueIndicator lowestPrice;
+    private final transient LowPriceIndicator lowPrice;
+    private final transient LowestValueIndicator lowestPrice;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicator.java
@@ -13,8 +13,8 @@ import org.ta4j.core.num.Num;
 public class DonchianChannelMiddleIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final DonchianChannelLowerIndicator lower;
-    private final DonchianChannelUpperIndicator upper;
+    private final transient DonchianChannelLowerIndicator lower;
+    private final transient DonchianChannelUpperIndicator upper;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicator.java
@@ -15,8 +15,8 @@ import org.ta4j.core.num.Num;
 public class DonchianChannelUpperIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final HighPriceIndicator highPrice;
-    private final HighestValueIndicator highestPrice;
+    private final transient HighPriceIndicator highPrice;
+    private final transient HighestValueIndicator highestPrice;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicator.java
@@ -18,7 +18,10 @@ import org.ta4j.core.num.Num;
  */
 public class StandardDeviationIndicator extends CachedIndicator<Num> {
 
-    private final VarianceIndicator variance;
+    private final Indicator<Num> indicator;
+    private final int barCount;
+    private final SampleType sampleType;
+    private final transient VarianceIndicator variance;
 
     /**
      * Constructor using {@link SampleType#POPULATION} for backward compatibility.
@@ -40,8 +43,10 @@ public class StandardDeviationIndicator extends CachedIndicator<Num> {
      */
     public StandardDeviationIndicator(Indicator<Num> indicator, int barCount, SampleType sampleType) {
         super(indicator);
-        this.variance = Objects.requireNonNull(sampleType, "sampleType must not be null").isSample()
-                ? VarianceIndicator.ofSample(indicator, barCount)
+        this.indicator = indicator;
+        this.barCount = barCount;
+        this.sampleType = Objects.requireNonNull(sampleType, "sampleType must not be null");
+        this.variance = this.sampleType.isSample() ? VarianceIndicator.ofSample(indicator, barCount)
                 : VarianceIndicator.ofPopulation(indicator, barCount);
     }
 

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AwesomeOscillatorIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -62,6 +67,15 @@ public class AwesomeOscillatorIndicatorTest extends AbstractIndicatorTest<Indica
         assertNumEquals(0, awesome.getValue(2));
         assertNumEquals(0, awesome.getValue(3));
         assertNumEquals(0, awesome.getValue(4));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        MedianPriceIndicator median = new MedianPriceIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new AwesomeOscillatorIndicator(median, 2, 5), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CMOIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -47,4 +52,13 @@ public class CMOIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertNumEquals(24.1983, cmo.getValue(14));
         assertNumEquals(47.644, cmo.getValue(15));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new CMOIndicator(close, 5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CompressionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CompressionIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -11,6 +18,9 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.NumFactory;
 
 public class CompressionIndicatorTest {
 
@@ -45,4 +55,13 @@ public class CompressionIndicatorTest {
             }
         };
     }
+
+    @Test
+    public void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new CompressionIndicator(series, 5, 8), stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ConnorsRSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ConnorsRSIIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
@@ -155,4 +161,13 @@ public class ConnorsRSIIndicatorTest extends AbstractIndicatorTest<Indicator<Num
         Num ratio = numFactory.numOf(lessThanCount).dividedBy(numFactory.numOf(valid));
         return ratio.multipliedBy(numFactory.numOf(100));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new ConnorsRSIIndicator(close, 3, 2, 4), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/CoppockCurveIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
@@ -41,4 +47,13 @@ public class CoppockCurveIndicatorTest extends AbstractIndicatorTest<Indicator<N
         assertNumEquals(7.4532, cc.getValue(38));
         assertNumEquals(8.79, cc.getValue(39));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new CoppockCurveIndicator(close, 5, 3, 4), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/FisherIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.indicators.helpers.MedianPriceIndicator;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import java.time.Instant;
@@ -182,4 +188,14 @@ public class FisherIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, N
         assertNumEquals(0.5026313552592737, fisher.getValue(14));
         assertNumEquals(0.06492516204615063, fisher.getValue(15));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        MedianPriceIndicator median = new MedianPriceIndicator(series);
+
+        return List.of(serializationFixture(series, new FisherIndicator(median, 8, 0.33, 0.67, 0.5, 0.5, 1.0, true),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KRIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KRIIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -45,4 +51,13 @@ public class KRIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertNumEquals(-3.04213, kriIndicator.getValue(19));
         assertNumEquals(-3.04841, kriIndicator.getValue(20));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new KRIIndicator(close, 5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/KSTIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -43,6 +48,15 @@ public class KSTIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertNumEquals(38.783888, kstIndicator.getValue(47));
         assertNumEquals(37.543147, kstIndicator.getValue(48));
         assertNumEquals(36.253502, kstIndicator.getValue(49));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(
+                serializationFixture(series, new KSTIndicator(close, 2, 3, 3, 4, 4, 5, 5, 6), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/RAVIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -52,4 +57,13 @@ public class RAVIIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         assertNumEquals(2.6167, ravi.getValue(13));
         assertNumEquals(4.0799, ravi.getValue(14));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new RAVIIndicator(close, 3, 7), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SchaffTrendCycleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SchaffTrendCycleIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -94,4 +100,14 @@ public class SchaffTrendCycleIndicatorTest extends AbstractIndicatorTest<Indicat
             assertThat(Num.isNaNOrNull(indicator.getValue(i))).isTrue();
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(
+                serializationFixture(series, new SchaffTrendCycleIndicator(close, 3, 6, 4, 2), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticOscillatorDIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static junit.framework.TestCase.assertEquals;
 
 import org.junit.Before;
@@ -66,4 +71,13 @@ public class StochasticOscillatorDIndicatorTest extends AbstractIndicatorTest<In
         assertEquals(sma.getValue(2), sos.getValue(2));
         assertEquals(sma.getValue(13), sos.getValue(13));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series,
+                new StochasticOscillatorDIndicator(new StochasticOscillatorKIndicator(series, 5)),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/StochasticRSIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
@@ -105,4 +110,13 @@ public class StochasticRSIIndicatorTest extends AbstractIndicatorTest<Indicator<
 
         assertEquals(barCount + barCount - 1, subject.getCountOfUnstableBars());
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new StochasticRSIIndicator(close, 5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendConclusionIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendConclusionIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -11,6 +18,9 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.NumFactory;
 
 public class TrendConclusionIndicatorTest {
 
@@ -46,4 +56,14 @@ public class TrendConclusionIndicatorTest {
             }
         };
     }
+
+    @Test
+    public void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new TrendConclusionIndicator(series, 8, 4, 9, 3, 5, 6, 8),
+                    stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendScoreIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TrendScoreIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -11,6 +18,9 @@ import org.ta4j.core.BarSeries;
 import org.ta4j.core.Indicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.NumFactory;
 
 public class TrendScoreIndicatorTest {
 
@@ -53,4 +63,13 @@ public class TrendScoreIndicatorTest {
             }
         };
     }
+
+    @Test
+    public void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new TrendScoreIndicator(series, 4, 9, 3, 5, 8), stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/TrueStrengthIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/TrueStrengthIndexIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -260,6 +265,15 @@ public class TrueStrengthIndexIndicatorTest extends AbstractIndicatorTest<Indica
                 assertThat(actual).isEqualTo(expected);
             }
         }
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new TrueStrengthIndexIndicator(close, 4, 3), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/KiJunV2IndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/KiJunV2IndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.*;
 
 import org.junit.Test;
@@ -44,6 +49,15 @@ public class KiJunV2IndicatorTest extends AbstractIndicatorTest<Indicator<Num>, 
 
             assertNumEquals(expected.doubleValue(), value);
         }
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        HighPriceIndicator high = new HighPriceIndicator(series);
+        LowPriceIndicator low = new LowPriceIndicator(series);
+
+        return List.of(serializationFixture(series, new KiJunV2Indicator(high, low, 9), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/TMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/TMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.*;
 import static org.ta4j.core.TestUtils.*;
 
@@ -70,4 +75,13 @@ public class TMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertEquals("TMA at index 8", 70, tma.getValue(8).doubleValue(), 0.001);
         assertEquals("TMA at index 9", 80, tma.getValue(9).doubleValue(), 0.001);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new TMAIndicator(close, 6), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VIDYAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VIDYAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.*;
 
 import org.junit.Test;
@@ -36,6 +41,14 @@ public class VIDYAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Nu
 
             assertNumEquals(expected.doubleValue(), value);
         }
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new VIDYAIndicator(close, 5, 6), stableIndexes(series)));
     }
 
 }


### PR DESCRIPTION
Fixes CF-277, CF-278.

Changes proposed in this pull request:
- Persist constructor inputs for oscillator, composite, average, ADX, Donchian, and standard-deviation descriptors.
- Keep rebuilt helper indicators transient so JSON stays constructor-focused.
- Add shared inventory test support and oscillator/composite inventory coverage.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a convenient VWMA constructor for price, volume, and period inputs using the default smoothing method.

- **Improvements**
  - Improved indicator serialization and restoration by preserving configuration and source inputs across a broad range of technical indicators.
  - Maintained existing calculation behavior while improving reliability when indicators are serialized and reused.

- **Tests**
  - Added comprehensive serialization coverage for oscillator, trend, moving-average, and price-volume indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->