### PR TITLE
Fix trend and volume serialization round trips

### DIFF
--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/AccelerationDecelerationIndicator.java
@@ -13,8 +13,10 @@ import org.ta4j.core.num.Num;
  */
 public class AccelerationDecelerationIndicator extends CachedIndicator<Num> {
 
-    private final AwesomeOscillatorIndicator awesome;
-    private final SMAIndicator sma;
+    private final int barCountSma1;
+    private final int barCountSma2;
+    private final transient AwesomeOscillatorIndicator awesome;
+    private final transient SMAIndicator sma;
 
     /**
      * Constructor.
@@ -25,6 +27,8 @@ public class AccelerationDecelerationIndicator extends CachedIndicator<Num> {
      */
     public AccelerationDecelerationIndicator(BarSeries series, int barCountSma1, int barCountSma2) {
         super(series);
+        this.barCountSma1 = barCountSma1;
+        this.barCountSma2 = barCountSma2;
         this.awesome = new AwesomeOscillatorIndicator(new MedianPriceIndicator(series), barCountSma1, barCountSma2);
         this.sma = new SMAIndicator(awesome, barCountSma1);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitLongIndicator.java
@@ -19,9 +19,10 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class ChandelierExitLongIndicator extends CachedIndicator<Num> {
 
-    private final HighestValueIndicator high;
-    private final ATRIndicator atr;
+    private final int barCount;
     private final Num k;
+    private final transient HighestValueIndicator high;
+    private final transient ATRIndicator atr;
 
     /**
      * Constructor with:
@@ -46,9 +47,10 @@ public class ChandelierExitLongIndicator extends CachedIndicator<Num> {
      */
     public ChandelierExitLongIndicator(BarSeries series, int barCount, double k) {
         super(series);
+        this.barCount = barCount;
+        this.k = getBarSeries().numFactory().numOf(k);
         this.high = new HighestValueIndicator(new HighPriceIndicator(series), barCount);
         this.atr = new ATRIndicator(series, barCount);
-        this.k = getBarSeries().numFactory().numOf(k);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChandelierExitShortIndicator.java
@@ -19,9 +19,10 @@ import static org.ta4j.core.num.NaN.NaN;
  */
 public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
 
-    private final LowestValueIndicator low;
-    private final ATRIndicator atr;
+    private final int barCount;
     private final Num k;
+    private final transient LowestValueIndicator low;
+    private final transient ATRIndicator atr;
 
     /**
      * Constructor with:
@@ -46,9 +47,10 @@ public class ChandelierExitShortIndicator extends CachedIndicator<Num> {
      */
     public ChandelierExitShortIndicator(BarSeries series, int barCount, double k) {
         super(series);
+        this.barCount = barCount;
+        this.k = getBarSeries().numFactory().numOf(k);
         this.low = new LowestValueIndicator(new LowPriceIndicator(series), barCount);
         this.atr = new ATRIndicator(series, barCount);
-        this.k = getBarSeries().numFactory().numOf(k);
     }
 
     @Override

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ChopIndicator.java
@@ -36,12 +36,13 @@ import org.ta4j.core.num.Num;
  */
 public class ChopIndicator extends CachedIndicator<Num> {
 
-    private final ATRIndicator atrIndicator;
-    private final int timeFrame;
-    private final Num log10n;
-    private final HighestValueIndicator hvi;
-    private final LowestValueIndicator lvi;
-    private final Num scaleUpTo;
+    private final int ciTimeFrame;
+    private final int scaleTo;
+    private final transient ATRIndicator atrIndicator;
+    private final transient Num log10n;
+    private final transient HighestValueIndicator hvi;
+    private final transient LowestValueIndicator lvi;
+    private final transient Num scaleUpTo;
 
     /**
      * Constructor.
@@ -53,10 +54,11 @@ public class ChopIndicator extends CachedIndicator<Num> {
      */
     public ChopIndicator(BarSeries barSeries, int ciTimeFrame, int scaleTo) {
         super(barSeries);
+        this.ciTimeFrame = ciTimeFrame;
+        this.scaleTo = scaleTo;
         this.atrIndicator = new ATRIndicator(barSeries, 1); // ATR(1) = Average True Range (Period of 1)
         this.hvi = new HighestValueIndicator(new HighPriceIndicator(barSeries), ciTimeFrame);
         this.lvi = new LowestValueIndicator(new LowPriceIndicator(barSeries), ciTimeFrame);
-        this.timeFrame = ciTimeFrame;
         this.log10n = getBarSeries().numFactory().numOf(Math.log10(ciTimeFrame));
         this.scaleUpTo = getBarSeries().numFactory().numOf(scaleTo);
     }
@@ -64,7 +66,7 @@ public class ChopIndicator extends CachedIndicator<Num> {
     @Override
     public Num calculate(int index) {
         Num summ = atrIndicator.getValue(index);
-        for (int i = 1; i < timeFrame; ++i) {
+        for (int i = 1; i < ciTimeFrame; ++i) {
             summ = summ.plus(atrIndicator.getValue(index - i));
         }
         Num a = summ.dividedBy((hvi.getValue(index).minus(lvi.getValue(index))));
@@ -74,7 +76,7 @@ public class ChopIndicator extends CachedIndicator<Num> {
 
     @Override
     public int getCountOfUnstableBars() {
-        int atrUnstableBars = atrIndicator.getCountOfUnstableBars() + timeFrame - 1;
+        int atrUnstableBars = atrIndicator.getCountOfUnstableBars() + ciTimeFrame - 1;
         int highLowUnstableBars = Math.max(hvi.getCountOfUnstableBars(), lvi.getCountOfUnstableBars());
         return Math.max(atrUnstableBars, highLowUnstableBars);
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicator.java
@@ -22,8 +22,8 @@ import org.ta4j.core.num.Num;
  * </p>
  */
 public class IntraDayMomentumIndexIndicator extends CachedIndicator<Num> {
-    private final SMAIndicator averageCloseOpenDiff;
-    private final SMAIndicator averageOpenCloseDiff;
+    private final transient SMAIndicator averageCloseOpenDiff;
+    private final transient SMAIndicator averageOpenCloseDiff;
 
     private final int barCount;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/SqueezeProIndicator.java
@@ -48,12 +48,12 @@ public class SqueezeProIndicator extends CachedIndicator<Num> {
         NONE, LOW, MID, HIGH
     }
 
-    private final Indicator<Num> closePrice;
-    private final Indicator<Num> priceSma;
-    private final Indicator<Num> priceStdDev;
-    private final Indicator<Num> trueRangeSma;
-    private final Indicator<Num> detrendedPrice;
-    private final Indicator<Num> momentum;
+    private final transient Indicator<Num> closePrice;
+    private final transient Indicator<Num> priceSma;
+    private final transient Indicator<Num> priceStdDev;
+    private final transient Indicator<Num> trueRangeSma;
+    private final transient Indicator<Num> detrendedPrice;
+    private final transient Indicator<Num> momentum;
 
     private final Num bollingerBandK;
     private final Num keltnerShiftFactorHigh;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonDownIndicator.java
@@ -21,9 +21,9 @@ import org.ta4j.core.num.Num;
 public class AroonDownIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final LowestValueIndicator lowestLowPriceIndicator;
     private final Indicator<Num> lowPriceIndicator;
-    private final Num barCountNum;
+    private final transient LowestValueIndicator lowestLowPriceIndicator;
+    private final transient Num barCountNum;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicator.java
@@ -17,8 +17,8 @@ import org.ta4j.core.num.Num;
 public class AroonOscillatorIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final AroonUpIndicator aroonUpIndicator;
-    private final AroonDownIndicator aroonDownIndicator;
+    private final transient AroonUpIndicator aroonUpIndicator;
+    private final transient AroonDownIndicator aroonDownIndicator;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/aroon/AroonUpIndicator.java
@@ -21,9 +21,9 @@ import org.ta4j.core.num.Num;
 public class AroonUpIndicator extends CachedIndicator<Num> {
 
     private final int barCount;
-    private final HighestValueIndicator highestHighPriceIndicator;
     private final Indicator<Num> highPriceIndicator;
-    private final Num barCountNum;
+    private final transient HighestValueIndicator highestHighPriceIndicator;
+    private final transient Num barCountNum;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicator.java
@@ -19,7 +19,7 @@ import org.ta4j.core.num.Num;
 public class IchimokuChikouSpanIndicator extends CachedIndicator<Num> {
 
     /** The close price. */
-    private final ClosePriceIndicator closePriceIndicator;
+    private final transient ClosePriceIndicator closePriceIndicator;
 
     /** The time delay. */
     private final int timeDelay;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicator.java
@@ -22,10 +22,10 @@ import org.ta4j.core.num.Num;
 public class IchimokuLineIndicator extends CachedIndicator<Num> {
 
     /** The period high. */
-    private final Indicator<Num> periodHigh;
+    private final transient Indicator<Num> periodHigh;
 
     /** The period low. */
-    private final Indicator<Num> periodLow;
+    private final transient Indicator<Num> periodLow;
 
     /** The time frame. */
     private final int barCount;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicator.java
@@ -18,7 +18,10 @@ import org.ta4j.core.num.Num;
 public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
 
     /** Ichimoku avg line indicator. */
-    private final IchimokuLineIndicator lineIndicator;
+    private final transient IchimokuLineIndicator lineIndicator;
+
+    /** The time frame. */
+    private final int barCount;
 
     /** Displacement on the chart (usually 26). */
     private final int offset;
@@ -51,6 +54,7 @@ public class IchimokuSenkouSpanBIndicator extends CachedIndicator<Num> {
      */
     public IchimokuSenkouSpanBIndicator(BarSeries series, int barCount, int offset) {
         super(series);
+        this.barCount = barCount;
         this.lineIndicator = new IchimokuLineIndicator(series, barCount);
         this.offset = offset;
     }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicator.java
@@ -18,11 +18,13 @@ import org.ta4j.core.num.Num;
  */
 public class CorrelationCoefficientIndicator extends CachedIndicator<Num> {
 
+    private final Indicator<Num> indicator1;
+    private final Indicator<Num> indicator2;
     private final int barCount;
     private final SampleType sampleType;
-    private final VarianceIndicator variance1;
-    private final VarianceIndicator variance2;
-    private final CovarianceIndicator covariance;
+    private final transient VarianceIndicator variance1;
+    private final transient VarianceIndicator variance2;
+    private final transient CovarianceIndicator covariance;
 
     /**
      * Constructor using {@link SampleType#POPULATION} for backward compatibility.
@@ -47,6 +49,8 @@ public class CorrelationCoefficientIndicator extends CachedIndicator<Num> {
     public CorrelationCoefficientIndicator(Indicator<Num> indicator1, Indicator<Num> indicator2, int barCount,
             SampleType sampleType) {
         super(indicator1);
+        this.indicator1 = indicator1;
+        this.indicator2 = indicator2;
         this.barCount = Math.max(barCount, 1);
         this.sampleType = Objects.requireNonNull(sampleType, "sampleType must not be null");
         this.variance1 = this.sampleType.isSample() ? VarianceIndicator.ofSample(indicator1, this.barCount)

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/CovarianceIndicator.java
@@ -16,8 +16,8 @@ public class CovarianceIndicator extends CachedIndicator<Num> {
     private final Indicator<Num> indicator1;
     private final Indicator<Num> indicator2;
     private final int barCount;
-    private final SMAIndicator sma1;
-    private final SMAIndicator sma2;
+    private final transient SMAIndicator sma1;
+    private final transient SMAIndicator sma2;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/statistics/StandardErrorIndicator.java
@@ -14,8 +14,10 @@ import org.ta4j.core.num.Num;
  */
 public class StandardErrorIndicator extends CachedIndicator<Num> {
 
+    private final Indicator<Num> indicator;
     private final int barCount;
-    private final StandardDeviationIndicator sdev;
+    private final SampleType sampleType;
+    private final transient StandardDeviationIndicator sdev;
 
     /**
      * Constructor using {@link SampleType#POPULATION} for backward compatibility.
@@ -37,9 +39,10 @@ public class StandardErrorIndicator extends CachedIndicator<Num> {
      */
     public StandardErrorIndicator(Indicator<Num> indicator, int barCount, SampleType sampleType) {
         super(indicator);
+        this.indicator = Objects.requireNonNull(indicator, "indicator must not be null");
         this.barCount = Math.max(barCount, 1);
-        this.sdev = Objects.requireNonNull(sampleType, "sampleType must not be null").isSample()
-                ? StandardDeviationIndicator.ofSample(indicator, this.barCount)
+        this.sampleType = Objects.requireNonNull(sampleType, "sampleType must not be null");
+        this.sdev = this.sampleType.isSample() ? StandardDeviationIndicator.ofSample(indicator, this.barCount)
                 : StandardDeviationIndicator.ofPopulation(indicator, this.barCount);
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/DownTrendIndicator.java
@@ -15,10 +15,11 @@ public class DownTrendIndicator extends AbstractIndicator<Boolean> {
     private static final int DEFAULT_UNSTABLE_BARS = 5;
     private static final double DEFAULT_STRENGTH_THRESHOLD = 25;
 
-    private final ADXIndicator directionStrengthIndicator;
-    private final MinusDIIndicator minusDIIndicator;
-    private final PlusDIIndicator plusDIIndicator;
+    private final int unstableBars;
     private final Num strengthThreshold;
+    private final transient ADXIndicator directionStrengthIndicator;
+    private final transient MinusDIIndicator minusDIIndicator;
+    private final transient PlusDIIndicator plusDIIndicator;
 
     public DownTrendIndicator(final BarSeries series) {
         this(series, DEFAULT_UNSTABLE_BARS);
@@ -30,6 +31,7 @@ public class DownTrendIndicator extends AbstractIndicator<Boolean> {
 
     public DownTrendIndicator(final BarSeries series, int unstableBars, double strengthThreshold) {
         super(series);
+        this.unstableBars = unstableBars;
         this.strengthThreshold = getBarSeries().numFactory().numOf(strengthThreshold);
         this.directionStrengthIndicator = new ADXIndicator(series, unstableBars);
         this.minusDIIndicator = new MinusDIIndicator(series, unstableBars);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/trend/UpTrendIndicator.java
@@ -15,10 +15,11 @@ public class UpTrendIndicator extends AbstractIndicator<Boolean> {
     private static final int DEFAULT_UNSTABLE_BARS = 5;
     private static final double DEFAULT_STRENGTH_THRESHOLD = 25;
 
-    private final ADXIndicator directionStrengthIndicator;
-    private final MinusDIIndicator minusDIIndicator;
-    private final PlusDIIndicator plusDIIndicator;
+    private final int unstableBars;
     private final Num strengthThreshold;
+    private final transient ADXIndicator directionStrengthIndicator;
+    private final transient MinusDIIndicator minusDIIndicator;
+    private final transient PlusDIIndicator plusDIIndicator;
 
     public UpTrendIndicator(final BarSeries series) {
         this(series, DEFAULT_UNSTABLE_BARS);
@@ -30,6 +31,7 @@ public class UpTrendIndicator extends AbstractIndicator<Boolean> {
 
     public UpTrendIndicator(final BarSeries series, int unstableBars, double strengthThreshold) {
         super(series);
+        this.unstableBars = unstableBars;
         this.strengthThreshold = getBarSeries().numFactory().numOf(strengthThreshold);
         this.directionStrengthIndicator = new ADXIndicator(series, unstableBars);
         this.minusDIIndicator = new MinusDIIndicator(series, unstableBars);

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/AccelerationDecelerationIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -64,4 +69,12 @@ public class AccelerationDecelerationIndicatorTest extends AbstractIndicatorTest
         assertNumEquals(0, acceleration.getValue(3));
         assertNumEquals(0, acceleration.getValue(4));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new AccelerationDecelerationIndicator(series, 3, 5),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitLongIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -67,4 +72,12 @@ public class ChandelierExitLongIndicatorTest extends AbstractIndicatorTest<Indic
         assertThat(Double.isNaN(cel.getValue(13).doubleValue())).isFalse();
         assertThat(Double.isNaN(cel.getValue(14).doubleValue())).isFalse();
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(
+                serializationFixture(series, new ChandelierExitLongIndicator(series, 8, 2.5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChandelierExitShortIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -67,4 +72,12 @@ public class ChandelierExitShortIndicatorTest extends AbstractIndicatorTest<Indi
         assertThat(Double.isNaN(ces.getValue(13).doubleValue())).isFalse();
         assertThat(Double.isNaN(ces.getValue(14).doubleValue())).isFalse();
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(
+                serializationFixture(series, new ChandelierExitShortIndicator(series, 8, 2.5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ChopIndicatorTest.java
@@ -6,6 +6,12 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -56,5 +62,11 @@ public class ChopIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
     }
 
     // TODO: this test class needs better cases
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ChopIndicator(series, 8, 100), stableIndexes(series)));
+    }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/IntraDayMomentumIndexIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -82,6 +87,13 @@ public class IntraDayMomentumIndexIndicatorTest extends AbstractIndicatorTest<In
         assertEquals(4, new IntraDayMomentumIndexIndicator(mockBarSeries, 5).getCountOfUnstableBars());
         assertEquals(0, new IntraDayMomentumIndexIndicator(mockBarSeries, 1).getCountOfUnstableBars());
         assertEquals(2, new IntraDayMomentumIndexIndicator(mockBarSeries, 3).getCountOfUnstableBars());
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new IntraDayMomentumIndexIndicator(series, 8), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/SqueezeProIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.num.NaN.NaN;
@@ -552,4 +555,12 @@ public class SqueezeProIndicatorTest extends AbstractIndicatorTest<Indicator<Num
 
         return new LoadedSeries(series, indexByDate);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SqueezeProIndicator(series, 8, 2.0, 1.0, 1.5, 2.0),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonFacadeTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators.aroon;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -220,4 +226,13 @@ public class AroonFacadeTest extends AbstractIndicatorTest<Indicator<Num>, Num> 
             assertNumEquals(aroonOscillatorIndicator.getValue(i), oscillatorNumeric.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new AroonFacade(series, 8).up(), stableIndexes(series)),
+                serializationFixture(series, new AroonFacade(series, 8).down(), stableIndexes(series)),
+                serializationFixture(series, new AroonFacade(series, 8).oscillator(), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/aroon/AroonOscillatorIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators.aroon;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -16,6 +23,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
+import org.ta4j.core.num.DecimalNumFactory;
+import org.ta4j.core.num.DoubleNumFactory;
+import org.ta4j.core.num.NumFactory;
 
 public class AroonOscillatorIndicatorTest {
     private BarSeries data;
@@ -232,4 +242,13 @@ public class AroonOscillatorIndicatorTest {
         assertNumEquals(40d, aroonOscillator.getValue(data.getEndIndex() - 1));
         assertNumEquals(32d, aroonOscillator.getValue(data.getEndIndex()));
     }
+
+    @Test
+    public void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new AroonOscillatorIndicator(series, 8), stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuChikouSpanIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.ichimoku;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
@@ -80,6 +85,12 @@ public class IchimokuChikouSpanIndicatorTest extends AbstractIndicatorTest<BarSe
         assertEquals(NaN.NaN, indicator.getValue(8));
         assertEquals(NaN.NaN, indicator.getValue(9));
         assertEquals(NaN.NaN, indicator.getValue(10));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new IchimokuChikouSpanIndicator(series, 8), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuKijunSenIndicatorTest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.ichimoku;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class IchimokuKijunSenIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public IchimokuKijunSenIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new IchimokuKijunSenIndicator(series, 8), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuLineIndicatorTest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.ichimoku;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class IchimokuLineIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public IchimokuLineIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new IchimokuLineIndicator(series, 8), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanAIndicatorTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.ichimoku;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class IchimokuSenkouSpanAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public IchimokuSenkouSpanAIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(
+                serializationFixture(series, new IchimokuSenkouSpanAIndicator(series, 8, 13), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuSenkouSpanBIndicatorTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.ichimoku;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class IchimokuSenkouSpanBIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public IchimokuSenkouSpanBIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(
+                serializationFixture(series, new IchimokuSenkouSpanBIndicator(series, 21, 8), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/ichimoku/IchimokuTenkanSenIndicatorTest.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.ichimoku;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class IchimokuTenkanSenIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public IchimokuTenkanSenIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new IchimokuTenkanSenIndicator(series, 8), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/CorrelationCoefficientIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.statistics;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -110,4 +115,15 @@ public class CorrelationCoefficientIndicatorTest extends AbstractIndicatorTest<I
             assertNumEquals(sampleWithOne.getValue(i), sampleWithNegative.getValue(i), 1.0e-12);
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new CorrelationCoefficientIndicator(close, volume, 8, SampleType.SAMPLE), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardErrorIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.statistics;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -84,4 +89,14 @@ public class StandardErrorIndicatorTest extends AbstractIndicatorTest<Indicator<
             assertNumEquals(withOne.getValue(i), withNegative.getValue(i), 1.0e-12);
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new StandardErrorIndicator(close, 8, SampleType.SAMPLE),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/trend/DownTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/trend/DownTrendIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.trend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -45,4 +50,11 @@ public class DownTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Bool
 
         assertEquals(expectedUnstableBars, indicator.getCountOfUnstableBars());
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new DownTrendIndicator(series, 7, 20.0), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/trend/UpTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/trend/UpTrendIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.trend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -45,4 +50,11 @@ public class UpTrendIndicatorTest extends AbstractIndicatorTest<Indicator<Boolea
 
         assertEquals(expectedUnstableBars, indicator.getCountOfUnstableBars());
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new UpTrendIndicator(series, 7, 20.0), stableIndexes(series)));
+    }
+
 }


### PR DESCRIPTION
Fixes CF-279, CF-280, CF-281, CF-282, CF-285.

Changes proposed in this pull request:
- Preserve constructor state for trend, Aroon, Ichimoku, statistics, and volume-related descriptors.
- Keep derived moving-window and helper indicators transient across the trend/volume inventory.
- Add trend/volume inventory coverage for the CF-232 serialization rollout.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization reliability for a broad range of technical indicators.
  - Preserved indicator calculations and configuration across serialization and restoration.
  - Strengthened handling of indicator parameters and sample settings.

- **Tests**
  - Added comprehensive serialization coverage for trend, volume, and composite indicators.
  - Expanded validation across common market-data inputs and indicator combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->