### PR TITLE
Fix candlestick serialization round trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Quiet quality gates complete faster without losing checks**: Repository script fixtures now run in parallel under the quiet build preflight, metadata validation fixtures fake Maven effective-model lookups instead of launching Maven repeatedly, and structural backtest-result tests avoid duplicate numeric-factory parameterization while execution-sensitive coverage remains cross-factory. The shell quiet build now keeps successful fixture chatter and Maven INFO banners out of stdout, passing through only WARN/ERROR-level log lines before a compact elapsed-time, test, coverage, and log-path footer.
 
 ### Fixed
+- **Indicator serialization round-trips now preserve constructor state across the CF-232 / CF-277-CF-286 inventory**: Oscillator, composite, channel, trend, volume, VWAP, Ichimoku, SuperTrend, ADX, and candlestick indicators now serialize durable constructor inputs instead of rebuilt helper graphs, while stricter descriptor reconstruction rejects unconsumed child components or parameters.
 - **Quiet build works under system Bash with no extra Maven args**: The default
   `scripts/run-full-build-quiet.sh` path now preserves the hosted non-demo test
   tag without expanding an empty pass-through argument array under macOS

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/AbstractMarubozuIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/AbstractMarubozuIndicator.java
@@ -30,16 +30,19 @@ abstract class AbstractMarubozuIndicator extends CachedIndicator<Boolean> {
     static final double DEFAULT_UPPER_SHADOW_TO_BODY_RATIO = 0.05d;
     static final double DEFAULT_LOWER_SHADOW_TO_BODY_RATIO = 0.05d;
 
-    private final RealBodyIndicator realBodyIndicator;
-    private final Indicator<Num> bodyHeightIndicator;
-    private final SMAIndicator averageBodyHeightIndicator;
-    private final UpperShadowIndicator upperShadowIndicator;
-    private final LowerShadowIndicator lowerShadowIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
+    private final transient Indicator<Num> bodyHeightIndicator;
+    private final transient SMAIndicator averageBodyHeightIndicator;
+    private final transient UpperShadowIndicator upperShadowIndicator;
+    private final transient LowerShadowIndicator lowerShadowIndicator;
     private final int bodyAveragePeriod;
-    private final Num bodyToAverageBodyRatioThreshold;
-    private final Num upperShadowToBodyRatioThreshold;
-    private final Num lowerShadowToBodyRatioThreshold;
-    private final Num zero;
+    private final double bodyToAverageBodyRatio;
+    private final double upperShadowToBodyRatio;
+    private final double lowerShadowToBodyRatio;
+    private final transient Num bodyToAverageBodyRatioThreshold;
+    private final transient Num upperShadowToBodyRatioThreshold;
+    private final transient Num lowerShadowToBodyRatioThreshold;
+    private final transient Num zero;
 
     AbstractMarubozuIndicator(final BarSeries series) {
         this(validatedConfig(series, DEFAULT_BODY_AVERAGE_PERIOD, DEFAULT_BODY_TO_AVERAGE_BODY_RATIO,
@@ -55,6 +58,9 @@ abstract class AbstractMarubozuIndicator extends CachedIndicator<Boolean> {
     private AbstractMarubozuIndicator(final Config config) {
         super(config.series());
         this.bodyAveragePeriod = config.bodyAveragePeriod();
+        this.bodyToAverageBodyRatio = config.bodyToAverageBodyRatio();
+        this.upperShadowToBodyRatio = config.upperShadowToBodyRatio();
+        this.lowerShadowToBodyRatio = config.lowerShadowToBodyRatio();
         this.realBodyIndicator = config.realBodyIndicator();
         this.bodyHeightIndicator = config.bodyHeightIndicator();
         this.averageBodyHeightIndicator = config.averageBodyHeightIndicator();
@@ -94,7 +100,8 @@ abstract class AbstractMarubozuIndicator extends CachedIndicator<Boolean> {
         Num lowerShadowToBodyRatioThreshold = numFactory.numOf(lowerShadowToBodyRatio);
         Num zero = numFactory.zero();
         return new Config(validatedSeries, realBodyIndicator, bodyHeightIndicator, averageBodyHeightIndicator,
-                upperShadowIndicator, lowerShadowIndicator, bodyAveragePeriod, bodyToAverageBodyRatioThreshold,
+                upperShadowIndicator, lowerShadowIndicator, bodyAveragePeriod, bodyToAverageBodyRatio,
+                upperShadowToBodyRatio, lowerShadowToBodyRatio, bodyToAverageBodyRatioThreshold,
                 upperShadowToBodyRatioThreshold, lowerShadowToBodyRatioThreshold, zero);
     }
 
@@ -147,7 +154,8 @@ abstract class AbstractMarubozuIndicator extends CachedIndicator<Boolean> {
 
     private record Config(BarSeries series, RealBodyIndicator realBodyIndicator, Indicator<Num> bodyHeightIndicator,
             SMAIndicator averageBodyHeightIndicator, UpperShadowIndicator upperShadowIndicator,
-            LowerShadowIndicator lowerShadowIndicator, int bodyAveragePeriod, Num bodyToAverageBodyRatioThreshold,
+            LowerShadowIndicator lowerShadowIndicator, int bodyAveragePeriod, double bodyToAverageBodyRatio,
+            double upperShadowToBodyRatio, double lowerShadowToBodyRatio, Num bodyToAverageBodyRatioThreshold,
             Num upperShadowToBodyRatioThreshold, Num lowerShadowToBodyRatioThreshold, Num zero) {
     }
 }

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishKickerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BearishKickerIndicator.java
@@ -18,8 +18,8 @@ import org.ta4j.core.num.Num;
  */
 public class BearishKickerIndicator extends CachedIndicator<Boolean> {
 
-    private final UpTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient UpTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num bigBodyThresholdPercentage;
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishKickerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/BullishKickerIndicator.java
@@ -18,8 +18,8 @@ import org.ta4j.core.num.Num;
  */
 public class BullishKickerIndicator extends CachedIndicator<Boolean> {
 
-    private final DownTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient DownTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num bigBodyThresholdPercentage;
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/DojiIndicator.java
@@ -24,13 +24,19 @@ import org.ta4j.core.num.Num;
 public class DojiIndicator extends CachedIndicator<Boolean> {
 
     /** Body height. */
-    private final Indicator<Num> bodyHeightInd;
+    private final transient Indicator<Num> bodyHeightInd;
 
     /** Average body height. */
-    private final SMAIndicator averageBodyHeightInd;
+    private final transient SMAIndicator averageBodyHeightInd;
+
+    /** The number of bars used to calculate the average body height. */
+    private final int barCount;
+
+    /** The raw factor used when checking if a candle is Doji. */
+    private final double bodyFactor;
 
     /** The factor used when checking if a candle is Doji. */
-    private final Num factor;
+    private final transient Num factor;
 
     /**
      * Constructor.
@@ -42,6 +48,8 @@ public class DojiIndicator extends CachedIndicator<Boolean> {
      */
     public DojiIndicator(BarSeries series, int barCount, double bodyFactor) {
         super(series);
+        this.barCount = barCount;
+        this.bodyFactor = bodyFactor;
         this.bodyHeightInd = UnaryOperationIndicator.abs(new RealBodyIndicator(series));
         this.averageBodyHeightInd = new SMAIndicator(bodyHeightInd, barCount);
         this.factor = getBarSeries().numFactory().numOf(bodyFactor);

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/EveningStarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/EveningStarIndicator.java
@@ -18,8 +18,8 @@ import org.ta4j.core.num.Num;
  */
 public class EveningStarIndicator extends CachedIndicator<Boolean> {
 
-    private final UpTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient UpTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num smallBodyThresholdPercentage;
     private final Num bigBodyThresholdPercentage;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HammerIndicator.java
@@ -18,8 +18,8 @@ public class HammerIndicator extends CachedIndicator<Boolean> {
     private static final double DEFAULT_BODY_LENGTH_TO_BOTTOM_WICK_COEFFICIENT = 2d;
     private static final double DEFAULT_BODY_LENGTH_TO_UPPER_WICK_COEFFICIENT = 1d;
 
-    private final RealBodyIndicator realBodyIndicator;
-    private final DownTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
+    private final transient DownTrendIndicator trendIndicator;
     private final double bodyToBottomWickRatio;
     private final double bodyToUpperWickRatio;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/HangingManIndicator.java
@@ -18,8 +18,8 @@ public class HangingManIndicator extends CachedIndicator<Boolean> {
     private static final double DEFAULT_BODY_LENGTH_TO_BOTTOM_WICK_COEFFICIENT = 2d;
     private static final double DEFAULT_BODY_LENGTH_TO_UPPER_WICK_COEFFICIENT = 1d;
 
-    private final RealBodyIndicator realBodyIndicator;
-    private final UpTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
+    private final transient UpTrendIndicator trendIndicator;
     private final double bodyToBottomWickRatio;
     private final double bodyToUpperWickRatio;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/InvertedHammerIndicator.java
@@ -15,8 +15,8 @@ public class InvertedHammerIndicator extends CachedIndicator<Boolean> {
     private static final double DEFAULT_BODY_LENGTH_TO_BOTTOM_WICK_COEFFICIENT = 1d;
     private static final double DEFAULT_BODY_LENGTH_TO_UPPER_WICK_COEFFICIENT = 2d;
 
-    private final RealBodyIndicator realBodyIndicator;
-    private final DownTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
+    private final transient DownTrendIndicator trendIndicator;
     private final double bodyToBottomWickRatio;
     private final double bodyToUpperWickRatio;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/MorningStarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/MorningStarIndicator.java
@@ -18,8 +18,8 @@ import org.ta4j.core.num.Num;
  */
 public class MorningStarIndicator extends CachedIndicator<Boolean> {
 
-    private final DownTrendIndicator trendIndicator;
-    private final RealBodyIndicator realBodyIndicator;
+    private final transient DownTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
     private final Num smallBodyThresholdPercentage;
     private final Num bigBodyThresholdPercentage;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ShootingStarIndicator.java
@@ -18,8 +18,8 @@ public class ShootingStarIndicator extends CachedIndicator<Boolean> {
     private static final double DEFAULT_BODY_LENGTH_TO_BOTTOM_WICK_COEFFICIENT = 1d;
     private static final double DEFAULT_BODY_LENGTH_TO_UPPER_WICK_COEFFICIENT = 2d;
 
-    private final RealBodyIndicator realBodyIndicator;
-    private final UpTrendIndicator trendIndicator;
+    private final transient RealBodyIndicator realBodyIndicator;
+    private final transient UpTrendIndicator trendIndicator;
     private final double bodyToBottomWickRatio;
     private final double bodyToUpperWickRatio;
 

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicator.java
@@ -18,13 +18,22 @@ import org.ta4j.core.num.Num;
 public class ThreeBlackCrowsIndicator extends CachedIndicator<Boolean> {
 
     /** Lower shadow. */
-    private final LowerShadowIndicator lowerShadowInd;
+    private final transient LowerShadowIndicator lowerShadowInd;
 
     /** Average lower shadow. */
-    private final SMAIndicator averageLowerShadowInd;
+    private final transient SMAIndicator averageLowerShadowInd;
 
-    /** Factor used when checking if a candle has a very short lower shadow. */
-    private final Num factor;
+    /** Number of bars used to calculate the average lower shadow. */
+    private final int barCount;
+
+    /** Raw factor used to reconstruct the indicator. */
+    private final double factor;
+
+    /**
+     * Factor threshold used when checking if a candle has a very short lower
+     * shadow.
+     */
+    private final transient Num factorThreshold;
 
     /**
      * Constructor.
@@ -36,9 +45,11 @@ public class ThreeBlackCrowsIndicator extends CachedIndicator<Boolean> {
      */
     public ThreeBlackCrowsIndicator(BarSeries series, int barCount, double factor) {
         super(series);
+        this.barCount = barCount;
+        this.factor = factor;
         this.lowerShadowInd = new LowerShadowIndicator(series);
         this.averageLowerShadowInd = new SMAIndicator(lowerShadowInd, barCount);
-        this.factor = getBarSeries().numFactory().numOf(factor);
+        this.factorThreshold = getBarSeries().numFactory().numOf(factor);
     }
 
     @Override
@@ -66,7 +77,7 @@ public class ThreeBlackCrowsIndicator extends CachedIndicator<Boolean> {
         // We use the white candle index to remove to bias of the previous crows
         Num averageLowerShadow = averageLowerShadowInd.getValue(whiteCandleIndex);
 
-        return currentLowerShadow.isLessThan(averageLowerShadow.multipliedBy(factor));
+        return currentLowerShadow.isLessThan(averageLowerShadow.multipliedBy(factorThreshold));
     }
 
     /**

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeInsideDownIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeInsideDownIndicator.java
@@ -17,8 +17,8 @@ import org.ta4j.core.indicators.trend.UpTrendIndicator;
  */
 public class ThreeInsideDownIndicator extends CachedIndicator<Boolean> {
 
-    private final UpTrendIndicator trendIndicator;
-    private final BearishHaramiIndicator harami;
+    private final transient UpTrendIndicator trendIndicator;
+    private final transient BearishHaramiIndicator harami;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeInsideUpIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeInsideUpIndicator.java
@@ -17,8 +17,8 @@ import org.ta4j.core.indicators.trend.DownTrendIndicator;
  */
 public class ThreeInsideUpIndicator extends CachedIndicator<Boolean> {
 
-    private final DownTrendIndicator trendIndicator;
-    private final BullishHaramiIndicator harami;
+    private final transient DownTrendIndicator trendIndicator;
+    private final transient BullishHaramiIndicator harami;
 
     /**
      * Constructor.

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicator.java
@@ -18,10 +18,13 @@ import org.ta4j.core.num.Num;
 public class ThreeWhiteSoldiersIndicator extends CachedIndicator<Boolean> {
 
     /** Upper shadow. */
-    private final UpperShadowIndicator upperShadowInd;
+    private final transient UpperShadowIndicator upperShadowInd;
 
     /** Average upper shadow. */
-    private final SMAIndicator averageUpperShadowInd;
+    private final transient SMAIndicator averageUpperShadowInd;
+
+    /** Number of bars used to calculate the average upper shadow. */
+    private final int barCount;
 
     /** Factor used when checking if a candle has a very short upper shadow. */
     private final Num factor;
@@ -36,6 +39,7 @@ public class ThreeWhiteSoldiersIndicator extends CachedIndicator<Boolean> {
      */
     public ThreeWhiteSoldiersIndicator(BarSeries series, int barCount, Num factor) {
         super(series);
+        this.barCount = barCount;
         this.upperShadowInd = new UpperShadowIndicator(series);
         this.averageUpperShadowInd = new SMAIndicator(upperShadowInd, barCount);
         this.factor = factor;

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class ADXIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(22, actualIndicator.getCountOfUnstableBars());
         assertEquals(7.3884, actualIndicator.getValue(actualIndicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ADXIndicator(series, 7, 5), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/DXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/DXIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -32,4 +37,11 @@ public class DXIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         Indicator<Num> thirteenBars = getIndicator(series, 13);
         assertEquals(14, thirteenBars.getCountOfUnstableBars());
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new DXIndicator(series, 7), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class MinusDIIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> 
         assertEquals(14, indicator.getCountOfUnstableBars());
         assertEquals(20.9020, indicator.getValue(indicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new MinusDIIndicator(series, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class PlusDIIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(14, actualIndicator.getCountOfUnstableBars());
         assertEquals(22.1399, actualIndicator.getValue(actualIndicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new PlusDIIndicator(series, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/ATMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/ATMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.*;
 
@@ -49,6 +54,14 @@ public class ATMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         assertThat(atma.getCountOfUnstableBars()).isEqualTo(4);
         assertThat(Num.isNaNOrNull(atma.getValue(3))).isTrue();
         assertNumEquals(3, atma.getValue(4));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new ATMAIndicator(close, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/HMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/HMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -47,6 +52,14 @@ public class HMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertNumEquals(75.5363, hma.getValue(18));
         assertNumEquals(75.1713, hma.getValue(19));
         assertNumEquals(75.3597, hma.getValue(20));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new HMAIndicator(close, 9), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VWMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VWMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.*;
 
@@ -137,6 +142,15 @@ public class VWMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         VWMAIndicator vwma = new VWMAIndicator(price, volume, 5, EMAIndicator::new);
 
         assertEquals(7, vwma.getCountOfUnstableBars());
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new VWMAIndicator(close, volume, 6), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators.bollinger;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -76,4 +82,18 @@ public class BollingerBandFacadeTest extends AbstractIndicatorTest<Indicator<Num
             assertNumEquals(widthBB.getValue(i), widthBBNumeric.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).middle(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).upper(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).lower(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).bandwidth(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).percentB(), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishEngulfingIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,4 +47,11 @@ public class BearishEngulfingIndicatorTest extends AbstractIndicatorTest<Indicat
         assertFalse(bep.getValue(3));
         assertFalse(bep.getValue(4));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BearishEngulfingIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishHaramiIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,4 +47,11 @@ public class BearishHaramiIndicatorTest extends AbstractIndicatorTest<Indicator<
         assertFalse(bhp.getValue(3));
         assertFalse(bhp.getValue(4));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BearishHaramiIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishKickerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishKickerIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -146,6 +149,12 @@ public class BearishKickerIndicatorTest extends AbstractIndicatorTest<Indicator<
 
         var bearishKicker = new BearishKickerIndicator(series);
         assertTrue(bearishKicker.getValue(18));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BearishKickerIndicator(series), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishMarubozuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BearishMarubozuIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -61,4 +66,11 @@ public class BearishMarubozuIndicatorTest extends AbstractIndicatorTest<Indicato
         series.barBuilder().openPrice(openPrice).closePrice(closePrice).highPrice(highPrice).lowPrice(lowPrice).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BearishMarubozuIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishEngulfingIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,4 +47,11 @@ public class BullishEngulfingIndicatorTest extends AbstractIndicatorTest<Indicat
         assertFalse(bep.getValue(3));
         assertFalse(bep.getValue(4));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BullishEngulfingIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishHaramiIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,4 +47,11 @@ public class BullishHaramiIndicatorTest extends AbstractIndicatorTest<Indicator<
         assertFalse(bhp.getValue(3));
         assertFalse(bhp.getValue(4));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BullishHaramiIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishKickerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishKickerIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -146,6 +149,12 @@ public class BullishKickerIndicatorTest extends AbstractIndicatorTest<Indicator<
 
         var bullishKicker = new BullishKickerIndicator(series);
         assertTrue(bullishKicker.getValue(18));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BullishKickerIndicator(series), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishMarubozuIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/BullishMarubozuIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -62,4 +67,11 @@ public class BullishMarubozuIndicatorTest extends AbstractIndicatorTest<Indicato
         series.barBuilder().openPrice(openPrice).closePrice(closePrice).highPrice(highPrice).lowPrice(lowPrice).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new BullishMarubozuIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DarkCloudCoverIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DarkCloudCoverIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -175,4 +178,11 @@ public class DarkCloudCoverIndicatorTest extends AbstractIndicatorTest<Indicator
         }
         return bars;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new DarkCloudCoverIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/DojiIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -55,4 +60,11 @@ public class DojiIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean>,
         assertFalse(doji.getValue(4));
         assertFalse(doji.getValue(5));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new DojiIndicator(series, 8, 0.1), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/EveningStarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/EveningStarIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -169,6 +172,12 @@ public class EveningStarIndicatorTest extends AbstractIndicatorTest<Indicator<Bo
 
         var es = new EveningStarIndicator(series);
         assertTrue(es.getValue(19));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new EveningStarIndicator(series), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HammerIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -81,4 +84,11 @@ public class HammerIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean
         final var hammer = new HammerIndicator(this.uptrendSeries);
         assertFalse(hammer.getValue(26));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new HammerIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/HangingManIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -81,4 +84,11 @@ public class HangingManIndicatorTest extends AbstractIndicatorTest<Indicator<Boo
         final var hangingManIndicator = new HangingManIndicator(this.downtrendSeries);
         assertFalse(hangingManIndicator.getValue(26));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new HangingManIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/InvertedHammerIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -81,4 +84,11 @@ public class InvertedHammerIndicatorTest extends AbstractIndicatorTest<Indicator
         final var invertedHammer = new InvertedHammerIndicator(this.uptrendSeries);
         assertFalse(invertedHammer.getValue(26));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new InvertedHammerIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/MorningStarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/MorningStarIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -169,6 +172,12 @@ public class MorningStarIndicatorTest extends AbstractIndicatorTest<Indicator<Bo
 
         var ms = new MorningStarIndicator(series);
         assertTrue(ms.getValue(19));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new MorningStarIndicator(series), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/PiercingLineIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/PiercingLineIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -175,4 +178,11 @@ public class PiercingLineIndicatorTest extends AbstractIndicatorTest<Indicator<B
         }
         return bars;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new PiercingLineIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ShootingStarIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -81,4 +84,11 @@ public class ShootingStarIndicatorTest extends AbstractIndicatorTest<Indicator<B
         final var shootingStar = new ShootingStarIndicator(this.downtrendSeries);
         assertFalse(shootingStar.getValue(26));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ShootingStarIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeBlackCrowsIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -48,4 +53,12 @@ public class ThreeBlackCrowsIndicatorTest extends AbstractIndicatorTest<Indicato
         assertFalse(tbc.getValue(6));
         assertFalse(tbc.getValue(7));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new ThreeBlackCrowsIndicator(series, 5, 1.0), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeInsideDownIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeInsideDownIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -122,4 +125,11 @@ public class ThreeInsideDownIndicatorTest extends AbstractIndicatorTest<Indicato
         var tid = new ThreeInsideDownIndicator(series);
         assertTrue(tid.getValue(19));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ThreeInsideDownIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeInsideUpIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeInsideUpIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -122,4 +125,11 @@ public class ThreeInsideUpIndicatorTest extends AbstractIndicatorTest<Indicator<
         var tiu = new ThreeInsideUpIndicator(series);
         assertTrue(tiu.getValue(19));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ThreeInsideUpIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/candles/ThreeWhiteSoldiersIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.candles;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -48,4 +53,12 @@ public class ThreeWhiteSoldiersIndicatorTest extends AbstractIndicatorTest<Indic
         assertFalse(tws.getValue(6));
         assertFalse(tws.getValue(7));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ThreeWhiteSoldiersIndicator(series, 5, numOf(1.0)),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelFacadeTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -62,6 +67,16 @@ public class DonchianChannelFacadeTest extends AbstractIndicatorTest<Indicator<N
             assertNumEquals(donchianChannelFacade.middle().getValue(i), donchianChannelMiddle.getValue(i));
             assertNumEquals(donchianChannelFacade.upper().getValue(i), donchianChannelUpper.getValue(i));
         }
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+
+        return List.of(
+                serializationFixture(series, new DonchianChannelFacade(series, 8).upper(), stableIndexes(series)),
+                serializationFixture(series, new DonchianChannelFacade(series, 8).lower(), stableIndexes(series)),
+                serializationFixture(series, new DonchianChannelFacade(series, 8).middle(), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
@@ -87,4 +92,12 @@ public class DonchianChannelLowerIndicatorTest extends AbstractIndicatorTest<Bar
         assertEquals(numOf(95), subject.getValue(7));
         assertEquals(numOf(95), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelLowerIndicator(series, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
@@ -76,4 +81,12 @@ public class DonchianChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ba
         assertEquals(upper.getValue(8), upperCopy.getValue(8));
         assertEquals(expected.getValue(8), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelMiddleIndicator(series, 9), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
@@ -72,4 +77,12 @@ public class DonchianChannelUpperIndicatorTest extends AbstractIndicatorTest<Bar
         assertEquals(numOf(110), subject.getValue(7));
         assertEquals(numOf(105), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelUpperIndicator(series, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottSwingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottSwingIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators.elliott;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.elliott.ElliottDegree;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -286,4 +293,14 @@ class ElliottSwingIndicatorTest {
             return series;
         }
     }
+
+    @Test
+    void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new ElliottSwingIndicator(series, 3, ElliottDegree.MINOR),
+                    stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -88,4 +93,18 @@ public class KeltnerChannelFacadeTest extends AbstractIndicatorTest<Indicator<Nu
             assertNumEquals(km.getValue(i), middleNumeric.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+
+        return List.of(
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).middle(),
+                        stableIndexes(series)),
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).upper(),
+                        stableIndexes(series)),
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).lower(),
+                        stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,4 +114,15 @@ public class KeltnerChannelLowerIndicatorTest extends AbstractIndicatorTest<Indi
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KeltnerChannelLowerIndicator(new KeltnerChannelMiddleIndicator(close, 7), 1.5, 6),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -275,4 +280,14 @@ public class KeltnerChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ind
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new KeltnerChannelMiddleIndicator(close, 7), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -110,4 +115,15 @@ public class KeltnerChannelUpperIndicatorTest extends AbstractIndicatorTest<Indi
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KeltnerChannelUpperIndicator(new KeltnerChannelMiddleIndicator(close, 7), 1.5, 6),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.statistics;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -67,4 +72,14 @@ public class StandardDeviationIndicatorTest extends AbstractIndicatorTest<Indica
         assertNumEquals(Math.sqrt(4.66666666666667), sdv.getValue(9));
         assertNumEquals(Math.sqrt(14), sdv.getValue(10));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new StandardDeviationIndicator(close, 8, SampleType.SAMPLE),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
@@ -336,26 +340,6 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildLongerSeries();
-        // Use default parameters to ensure round-trip reconstruction works
-        // since the framework reconstructs using the default constructor
-        SuperTrendIndicator original = new SuperTrendIndicator(series);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -421,4 +405,11 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         series.barBuilder().openPrice(95).closePrice(90).highPrice(96).lowPrice(89).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendIndicator(series, 8, 2.0), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
@@ -179,25 +183,6 @@ public class SuperTrendLowerBandIndicatorTest extends AbstractIndicatorTest<BarS
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildSeries();
-        ATRIndicator atrIndicator = new ATRIndicator(series, 3);
-        SuperTrendLowerBandIndicator original = new SuperTrendLowerBandIndicator(series, atrIndicator, 2.5);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendLowerBandIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -242,4 +227,11 @@ public class SuperTrendLowerBandIndicatorTest extends AbstractIndicatorTest<BarS
         series.barBuilder().openPrice(90).closePrice(85).highPrice(91).lowPrice(84).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendLowerBandIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
@@ -142,25 +146,6 @@ public class SuperTrendUpperBandIndicatorTest extends AbstractIndicatorTest<BarS
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildSeries();
-        ATRIndicator atrIndicator = new ATRIndicator(series, 3);
-        SuperTrendUpperBandIndicator original = new SuperTrendUpperBandIndicator(series, atrIndicator, 2.5);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendUpperBandIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -205,4 +190,11 @@ public class SuperTrendUpperBandIndicatorTest extends AbstractIndicatorTest<BarS
         series.barBuilder().openPrice(110).closePrice(115).highPrice(116).lowPrice(109).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendUpperBandIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AnchoredVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AnchoredVWAPIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -200,4 +206,15 @@ public class AnchoredVWAPIndicatorTest extends AbstractIndicatorTest<Indicator<N
             return unstableBars;
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new AnchoredVWAPIndicator(close, volume, 5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/EaseOfMovementIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/EaseOfMovementIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -187,4 +192,16 @@ public class EaseOfMovementIndicatorTest extends AbstractIndicatorTest<BarSeries
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        HighPriceIndicator high = new HighPriceIndicator(series);
+        LowPriceIndicator low = new LowPriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new EaseOfMovementIndicator(high, low, volume, 8, 100_000_000),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ForceIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ForceIndexIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -170,4 +175,14 @@ public class ForceIndexIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new ForceIndexIndicator(close, volume, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/KlingerVolumeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/KlingerVolumeOscillatorIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -218,4 +223,17 @@ public class KlingerVolumeOscillatorIndicatorTest extends AbstractIndicatorTest<
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        HighPriceIndicator high = new HighPriceIndicator(series);
+        LowPriceIndicator low = new LowPriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KlingerVolumeOscillatorIndicator(high, low, close, volume, 5, 9, 1), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -76,4 +83,15 @@ public class MVWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Nu
         assertNumEquals(45.1386, mvwap.getValue(17));
         assertNumEquals(44.9487, mvwap.getValue(18));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new MVWAPIndicator(new VWAPIndicator(close, volume, 8), 5),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPBandIndicatorTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPBandIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPBandIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPBandIndicator(new VWAPIndicator(close, volume, 8),
+                        new VWAPStandardDeviationIndicator(new VWAPIndicator(close, volume, 8)), 1.5,
+                        VWAPBandIndicator.BandType.UPPER),
+                stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPDeviationIndicatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPDeviationIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPDeviationIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPDeviationIndicator(close, new VWAPIndicator(close, volume, 8)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -128,6 +131,15 @@ public class VWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         assertThat(indicator.getCountOfUnstableBars()).isEqualTo(4);
         assertThat(indicator.getValue(3).isNaN()).isTrue();
         assertNumEquals(13, indicator.getValue(4));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new VWAPIndicator(close, volume, 8), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPStandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPStandardDeviationIndicatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPStandardDeviationIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPStandardDeviationIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPStandardDeviationIndicator(new VWAPIndicator(close, volume, 8)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPZScoreIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPZScoreIndicatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPZScoreIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPZScoreIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+        VWAPIndicator vwap = new VWAPIndicator(close, volume, 8);
+
+        return List.of(serializationFixture(series, new VWAPZScoreIndicator(new VWAPDeviationIndicator(close, vwap),
+                new VWAPStandardDeviationIndicator(vwap)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/wyckoff/WyckoffPhaseIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/wyckoff/WyckoffPhaseIndicatorTest.java
@@ -3,13 +3,17 @@
  */
 package org.ta4j.core.indicators.wyckoff;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
@@ -158,33 +162,6 @@ public class WyckoffPhaseIndicatorTest extends AbstractIndicatorTest<BarSeries, 
     }
 
     /**
-     * Verifies that round trip serialize and deserialize.
-     */
-    @Test
-    public void shouldRoundTripSerializeAndDeserialize() {
-        var indicator = WyckoffPhaseIndicator.builder(accumulationSeries)
-                .withSwingConfiguration(1, 1, 0)
-                .withVolumeWindows(1, 2)
-                .withTolerances(numOf(0.02), numOf(0.05))
-                .withVolumeThresholds(numOf(1.4), numOf(0.6))
-                .build();
-
-        int index = accumulationSeries.getBeginIndex() + 3;
-        WyckoffPhase expected = indicator.getValue(index);
-
-        String json = indicator.toJson();
-        Indicator<?> restored = Indicator.fromJson(accumulationSeries, json);
-
-        assertThat(restored).isInstanceOf(WyckoffPhaseIndicator.class);
-        var restoredIndicator = (WyckoffPhaseIndicator) restored;
-        assertThat(restoredIndicator.toDescriptor()).isEqualTo(indicator.toDescriptor());
-        assertThat(restoredIndicator.getValue(index)).isEqualTo(expected);
-        assertThat(restoredIndicator.getLastPhaseTransitionIndex(index))
-                .isEqualTo(indicator.getLastPhaseTransitionIndex(index));
-        assertThat(restoredIndicator.getCountOfUnstableBars()).isEqualTo(indicator.getCountOfUnstableBars());
-    }
-
-    /**
      * Verifies that reject invalid builder configuration.
      */
     @Test
@@ -234,4 +211,13 @@ public class WyckoffPhaseIndicatorTest extends AbstractIndicatorTest<BarSeries, 
     private void addBar(BarSeries series, double open, double high, double low, double close, double volume) {
         series.barBuilder().openPrice(open).highPrice(high).lowPrice(low).closePrice(close).volume(volume).add();
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series,
+                new WyckoffPhaseIndicator(series, 3, 2, 1, 5, 12, numOf(0.02), numOf(0.05), numOf(1.6), numOf(0.7)),
+                stableIndexes(series)));
+    }
+
 }


### PR DESCRIPTION
Fixes CF-283, CF-284, CF-285, CF-286.

Changes proposed in this pull request:
- Preserve constructor state for candlestick pattern descriptors across the final inventory slice.
- Add candlestick inventory coverage for the remaining CF-232 child issues.
- Add the CF-232 / CF-277-CF-286 changelog entry.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indicator serialization and deserialization so constructor settings are preserved across oscillator, composite, channel, trend, volume, VWAP, Ichimoku, SuperTrend, ADX, and candlestick indicators.
  * Improved descriptor validation to reject incomplete or over-specified indicator reconstructions.
  * Improved serialization reliability for candlestick indicators, including custom thresholds and lookback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->