### PR TITLE
Split remaining serialization unit tests

### DIFF
--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/ADXIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class ADXIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(22, actualIndicator.getCountOfUnstableBars());
         assertEquals(7.3884, actualIndicator.getValue(actualIndicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new ADXIndicator(series, 7, 5), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/DXIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/DXIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -32,4 +37,11 @@ public class DXIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         Indicator<Num> thirteenBars = getIndicator(series, 13);
         assertEquals(14, thirteenBars.getCountOfUnstableBars());
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new DXIndicator(series, 7), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/MinusDIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class MinusDIIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> 
         assertEquals(14, indicator.getCountOfUnstableBars());
         assertEquals(20.9020, indicator.getValue(indicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new MinusDIIndicator(series, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/adx/PlusDIIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.adx;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -43,6 +48,12 @@ public class PlusDIIndicatorTest extends AbstractIndicatorTest<BarSeries, Num> {
         assertEquals(14, actualIndicator.getCountOfUnstableBars());
         assertEquals(22.1399, actualIndicator.getValue(actualIndicator.getBarSeries().getEndIndex()).doubleValue(),
                 TestUtils.GENERAL_OFFSET);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new PlusDIIndicator(series, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/ATMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/ATMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.*;
 
@@ -49,6 +54,14 @@ public class ATMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         assertThat(atma.getCountOfUnstableBars()).isEqualTo(4);
         assertThat(Num.isNaNOrNull(atma.getValue(3))).isTrue();
         assertNumEquals(3, atma.getValue(4));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new ATMAIndicator(close, 7), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/HMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/HMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -47,6 +52,14 @@ public class HMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num>
         assertNumEquals(75.5363, hma.getValue(18));
         assertNumEquals(75.1713, hma.getValue(19));
         assertNumEquals(75.3597, hma.getValue(20));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new HMAIndicator(close, 9), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VWMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/VWMAIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.averages;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.junit.Assert.assertEquals;
 import static org.ta4j.core.TestUtils.*;
 
@@ -137,6 +142,15 @@ public class VWMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         VWMAIndicator vwma = new VWMAIndicator(price, volume, 5, EMAIndicator::new);
 
         assertEquals(7, vwma.getCountOfUnstableBars());
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new VWMAIndicator(close, volume, 6), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/bollinger/BollingerBandFacadeTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators.bollinger;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -76,4 +82,18 @@ public class BollingerBandFacadeTest extends AbstractIndicatorTest<Indicator<Num
             assertNumEquals(widthBB.getValue(i), widthBBNumeric.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).middle(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).upper(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).lower(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).bandwidth(), stableIndexes(series)),
+                serializationFixture(series, new BollingerBandFacade(close, 9, 2.0).percentB(), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelFacadeTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -62,6 +67,16 @@ public class DonchianChannelFacadeTest extends AbstractIndicatorTest<Indicator<N
             assertNumEquals(donchianChannelFacade.middle().getValue(i), donchianChannelMiddle.getValue(i));
             assertNumEquals(donchianChannelFacade.upper().getValue(i), donchianChannelUpper.getValue(i));
         }
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+
+        return List.of(
+                serializationFixture(series, new DonchianChannelFacade(series, 8).upper(), stableIndexes(series)),
+                serializationFixture(series, new DonchianChannelFacade(series, 8).lower(), stableIndexes(series)),
+                serializationFixture(series, new DonchianChannelFacade(series, 8).middle(), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelLowerIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
@@ -87,4 +92,12 @@ public class DonchianChannelLowerIndicatorTest extends AbstractIndicatorTest<Bar
         assertEquals(numOf(95), subject.getValue(7));
         assertEquals(numOf(95), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelLowerIndicator(series, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelMiddleIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
@@ -76,4 +81,12 @@ public class DonchianChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ba
         assertEquals(upper.getValue(8), upperCopy.getValue(8));
         assertEquals(expected.getValue(8), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelMiddleIndicator(series, 9), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/donchian/DonchianChannelUpperIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.donchian;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
@@ -72,4 +77,12 @@ public class DonchianChannelUpperIndicatorTest extends AbstractIndicatorTest<Bar
         assertEquals(numOf(110), subject.getValue(7));
         assertEquals(numOf(105), subject.getValue(8));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List
+                .of(serializationFixture(series, new DonchianChannelUpperIndicator(series, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottSwingIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/elliott/ElliottSwingIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators.elliott;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.assertIndicatorRoundTrips;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.elliott.ElliottDegree;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -286,4 +293,14 @@ class ElliottSwingIndicatorTest {
             return series;
         }
     }
+
+    @Test
+    void serializationRoundTrips() {
+        for (NumFactory numFactory : List.of(DoubleNumFactory.getInstance(), DecimalNumFactory.getInstance())) {
+            BarSeries series = serializationSeries(numFactory);
+            assertIndicatorRoundTrips(series, new ElliottSwingIndicator(series, 3, ElliottDegree.MINOR),
+                    stableIndexes(series));
+        }
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelFacadeTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -88,4 +93,18 @@ public class KeltnerChannelFacadeTest extends AbstractIndicatorTest<Indicator<Nu
             assertNumEquals(km.getValue(i), middleNumeric.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+
+        return List.of(
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).middle(),
+                        stableIndexes(series)),
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).upper(),
+                        stableIndexes(series)),
+                serializationFixture(series, new KeltnerChannelFacade(series, 7, 5, 1.5).lower(),
+                        stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelLowerIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,4 +114,15 @@ public class KeltnerChannelLowerIndicatorTest extends AbstractIndicatorTest<Indi
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KeltnerChannelLowerIndicator(new KeltnerChannelMiddleIndicator(close, 7), 1.5, 6),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelMiddleIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -275,4 +280,14 @@ public class KeltnerChannelMiddleIndicatorTest extends AbstractIndicatorTest<Ind
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new KeltnerChannelMiddleIndicator(close, 7), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/keltner/KeltnerChannelUpperIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.keltner;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
@@ -110,4 +115,15 @@ public class KeltnerChannelUpperIndicatorTest extends AbstractIndicatorTest<Indi
             assertThat(restored.getValue(i)).isEqualTo(indicator.getValue(i));
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KeltnerChannelUpperIndicator(new KeltnerChannelMiddleIndicator(close, 7), 1.5, 6),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/statistics/StandardDeviationIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.statistics;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Before;
@@ -67,4 +72,14 @@ public class StandardDeviationIndicatorTest extends AbstractIndicatorTest<Indica
         assertNumEquals(Math.sqrt(4.66666666666667), sdv.getValue(9));
         assertNumEquals(Math.sqrt(14), sdv.getValue(10));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+
+        return List.of(serializationFixture(series, new StandardDeviationIndicator(close, 8, SampleType.SAMPLE),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
@@ -336,26 +340,6 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildLongerSeries();
-        // Use default parameters to ensure round-trip reconstruction works
-        // since the framework reconstructs using the default constructor
-        SuperTrendIndicator original = new SuperTrendIndicator(series);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -421,4 +405,11 @@ public class SuperTrendIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         series.barBuilder().openPrice(95).closePrice(90).highPrice(96).lowPrice(89).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendIndicator(series, 8, 2.0), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendLowerBandIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
@@ -179,25 +183,6 @@ public class SuperTrendLowerBandIndicatorTest extends AbstractIndicatorTest<BarS
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildSeries();
-        ATRIndicator atrIndicator = new ATRIndicator(series, 3);
-        SuperTrendLowerBandIndicator original = new SuperTrendLowerBandIndicator(series, atrIndicator, 2.5);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendLowerBandIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -242,4 +227,11 @@ public class SuperTrendLowerBandIndicatorTest extends AbstractIndicatorTest<BarS
         series.barBuilder().openPrice(90).closePrice(85).highPrice(91).lowPrice(84).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendLowerBandIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/supertrend/SuperTrendUpperBandIndicatorTest.java
@@ -3,12 +3,16 @@
  */
 package org.ta4j.core.indicators.supertrend;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.indicators.ATRIndicator;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
@@ -142,25 +146,6 @@ public class SuperTrendUpperBandIndicatorTest extends AbstractIndicatorTest<BarS
         }
     }
 
-    @Test
-    public void serializationRoundTrip() {
-        BarSeries series = buildSeries();
-        ATRIndicator atrIndicator = new ATRIndicator(series, 3);
-        SuperTrendUpperBandIndicator original = new SuperTrendUpperBandIndicator(series, atrIndicator, 2.5);
-
-        String json = original.toJson();
-        @SuppressWarnings("unchecked")
-        Indicator<Num> restored = (Indicator<Num>) Indicator.fromJson(series, json);
-
-        assertThat(restored).isInstanceOf(SuperTrendUpperBandIndicator.class);
-        assertThat(restored.toDescriptor()).isEqualTo(original.toDescriptor());
-
-        // Verify values match
-        for (int i = series.getBeginIndex(); i <= series.getEndIndex(); i++) {
-            assertThat(restored.getValue(i)).isEqualTo(original.getValue(i));
-        }
-    }
-
     private BarSeries buildSeries() {
         BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).build();
         series.barBuilder().openPrice(10).closePrice(11).highPrice(12).lowPrice(10).add();
@@ -205,4 +190,11 @@ public class SuperTrendUpperBandIndicatorTest extends AbstractIndicatorTest<BarS
         series.barBuilder().openPrice(110).closePrice(115).highPrice(116).lowPrice(109).add();
         return series;
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series, new SuperTrendUpperBandIndicator(series), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AnchoredVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/AnchoredVWAPIndicatorTest.java
@@ -3,6 +3,12 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -200,4 +206,15 @@ public class AnchoredVWAPIndicatorTest extends AbstractIndicatorTest<Indicator<N
             return unstableBars;
         }
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List
+                .of(serializationFixture(series, new AnchoredVWAPIndicator(close, volume, 5), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/EaseOfMovementIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/EaseOfMovementIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -187,4 +192,16 @@ public class EaseOfMovementIndicatorTest extends AbstractIndicatorTest<BarSeries
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        HighPriceIndicator high = new HighPriceIndicator(series);
+        LowPriceIndicator low = new LowPriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new EaseOfMovementIndicator(high, low, volume, 8, 100_000_000),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ForceIndexIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/ForceIndexIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -170,4 +175,14 @@ public class ForceIndexIndicatorTest extends AbstractIndicatorTest<BarSeries, Nu
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new ForceIndexIndicator(close, volume, 8), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/KlingerVolumeOscillatorIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/KlingerVolumeOscillatorIndicatorTest.java
@@ -3,6 +3,11 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.ta4j.core.TestUtils.assertNumEquals;
@@ -218,4 +223,17 @@ public class KlingerVolumeOscillatorIndicatorTest extends AbstractIndicatorTest<
         }
         assertThat(actual).isEqualByComparingTo(expected);
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        HighPriceIndicator high = new HighPriceIndicator(series);
+        LowPriceIndicator low = new LowPriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new KlingerVolumeOscillatorIndicator(high, low, close, volume, 5, 9, 1), stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/MVWAPIndicatorTest.java
@@ -3,6 +3,13 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -76,4 +83,15 @@ public class MVWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Nu
         assertNumEquals(45.1386, mvwap.getValue(17));
         assertNumEquals(44.9487, mvwap.getValue(18));
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new MVWAPIndicator(new VWAPIndicator(close, volume, 8), 5),
+                stableIndexes(series)));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPBandIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPBandIndicatorTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPBandIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPBandIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPBandIndicator(new VWAPIndicator(close, volume, 8),
+                        new VWAPStandardDeviationIndicator(new VWAPIndicator(close, volume, 8)), 1.5,
+                        VWAPBandIndicator.BandType.UPPER),
+                stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPDeviationIndicatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPDeviationIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPDeviationIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPDeviationIndicator(close, new VWAPIndicator(close, volume, 8)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPIndicatorTest.java
@@ -3,6 +3,9 @@
  */
 package org.ta4j.core.indicators.volume;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.ta4j.core.TestUtils.assertNumEquals;
 
@@ -128,6 +131,15 @@ public class VWAPIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num
         assertThat(indicator.getCountOfUnstableBars()).isEqualTo(4);
         assertThat(indicator.getValue(3).isNaN()).isTrue();
         assertNumEquals(13, indicator.getValue(4));
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series, new VWAPIndicator(close, volume, 8), stableIndexes(series)));
     }
 
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPStandardDeviationIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPStandardDeviationIndicatorTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPStandardDeviationIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPStandardDeviationIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+
+        return List.of(serializationFixture(series,
+                new VWAPStandardDeviationIndicator(new VWAPIndicator(close, volume, 8)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPZScoreIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/volume/VWAPZScoreIndicatorTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+package org.ta4j.core.indicators.volume;
+
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Indicator;
+import org.ta4j.core.indicators.AbstractIndicatorTest;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.VolumeIndicator;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.num.NumFactory;
+
+public class VWAPZScoreIndicatorTest extends AbstractIndicatorTest<Indicator<Num>, Num> {
+
+    public VWAPZScoreIndicatorTest(NumFactory numFactory) {
+        super(numFactory);
+    }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        ClosePriceIndicator close = new ClosePriceIndicator(series);
+        VolumeIndicator volume = new VolumeIndicator(series);
+        VWAPIndicator vwap = new VWAPIndicator(close, volume, 8);
+
+        return List.of(serializationFixture(series, new VWAPZScoreIndicator(new VWAPDeviationIndicator(close, vwap),
+                new VWAPStandardDeviationIndicator(vwap)), stableIndexes(series)));
+    }
+}

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/wyckoff/WyckoffPhaseIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/wyckoff/WyckoffPhaseIndicatorTest.java
@@ -3,13 +3,17 @@
  */
 package org.ta4j.core.indicators.wyckoff;
 
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.serializationSeries;
+import static org.ta4j.core.indicators.IndicatorSerializationRoundTripTestSupport.stableIndexes;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.ta4j.core.BarSeries;
-import org.ta4j.core.Indicator;
 import org.ta4j.core.indicators.AbstractIndicatorTest;
 import org.ta4j.core.mocks.MockBarSeriesBuilder;
 import org.ta4j.core.num.Num;
@@ -158,33 +162,6 @@ public class WyckoffPhaseIndicatorTest extends AbstractIndicatorTest<BarSeries, 
     }
 
     /**
-     * Verifies that round trip serialize and deserialize.
-     */
-    @Test
-    public void shouldRoundTripSerializeAndDeserialize() {
-        var indicator = WyckoffPhaseIndicator.builder(accumulationSeries)
-                .withSwingConfiguration(1, 1, 0)
-                .withVolumeWindows(1, 2)
-                .withTolerances(numOf(0.02), numOf(0.05))
-                .withVolumeThresholds(numOf(1.4), numOf(0.6))
-                .build();
-
-        int index = accumulationSeries.getBeginIndex() + 3;
-        WyckoffPhase expected = indicator.getValue(index);
-
-        String json = indicator.toJson();
-        Indicator<?> restored = Indicator.fromJson(accumulationSeries, json);
-
-        assertThat(restored).isInstanceOf(WyckoffPhaseIndicator.class);
-        var restoredIndicator = (WyckoffPhaseIndicator) restored;
-        assertThat(restoredIndicator.toDescriptor()).isEqualTo(indicator.toDescriptor());
-        assertThat(restoredIndicator.getValue(index)).isEqualTo(expected);
-        assertThat(restoredIndicator.getLastPhaseTransitionIndex(index))
-                .isEqualTo(indicator.getLastPhaseTransitionIndex(index));
-        assertThat(restoredIndicator.getCountOfUnstableBars()).isEqualTo(indicator.getCountOfUnstableBars());
-    }
-
-    /**
      * Verifies that reject invalid builder configuration.
      */
     @Test
@@ -234,4 +211,13 @@ public class WyckoffPhaseIndicatorTest extends AbstractIndicatorTest<BarSeries, 
     private void addBar(BarSeries series, double open, double high, double low, double close, double volume) {
         series.barBuilder().openPrice(open).highPrice(high).lowPrice(low).closePrice(close).volume(volume).add();
     }
+
+    @Override
+    protected List<IndicatorSerializationFixture<?>> serializationFixtures() {
+        BarSeries series = serializationSeries(numFactory);
+        return List.of(serializationFixture(series,
+                new WyckoffPhaseIndicator(series, 3, 2, 1, 5, 12, numOf(0.02), numOf(0.05), numOf(1.6), numOf(0.7)),
+                stableIndexes(series)));
+    }
+
 }


### PR DESCRIPTION
Fixes CF-232, CF-278, CF-279, CF-280, CF-281, CF-282, CF-285, CF-286.

Changes proposed in this pull request:
- Move remaining serialization/deserialization assertions into owning indicator and facade test classes.
- Add concrete VWAP-derived test classes for the final per-class serialization split.
- Codify the 1:1 unit-test ownership rule in test-scoped AGENTS guidance.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded serialization round-trip coverage across trend, momentum, volatility, channel, statistics, supertrend, and volume indicators (including ADX/DX and DI variants).
  * Added/extended fixture-based serialization checks for Bollinger, Donchian, Keltner, and multiple SuperTrend components.
  * Improved serialization confidence for averages and VWAP-derived indicators (VWAP, MVWAP, VWAP bands/deviation/standard deviation/z-score) and for Elliott Swing and Wyckoff Phase, replacing bespoke JSON checks with the shared fixture approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->