### PR TITLE
Stabilize quiet-build heartbeat fixture

### DIFF
--- a/scripts/tests/test_run_full_build_quiet.sh
+++ b/scripts/tests/test_run_full_build_quiet.sh
@@ -449,7 +449,7 @@ EOF
   chmod +x "$TMP/bin/mvn"
 
   local output
-  output="$(QUIET_BUILD_TIMEOUT_SECONDS=5 QUIET_BUILD_STALL_SECONDS=5 QUIET_BUILD_HEARTBEAT_SECONDS=1 run_quiet_build scripts/run-full-build-quiet.sh)"
+  output="$(QUIET_BUILD_TIMEOUT_SECONDS=30 QUIET_BUILD_STALL_SECONDS=30 QUIET_BUILD_HEARTBEAT_SECONDS=1 run_quiet_build scripts/run-full-build-quiet.sh)"
   local log_file
   log_file="$(latest_log_from_output "$output")"
 


### PR DESCRIPTION
Follow-up to #1506.

Changes proposed in this pull request:
- give the quiet-build heartbeat success fixture enough timeout headroom under parallel preflight load
- preserve the one-second stalled-build negative-control timeout unchanged
- prevent the canonical local build gate from failing intermittently before Maven starts

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format formatter:format verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] This exclusively test-only stabilization does not require an unreleased `CHANGELOG.md` entry under repository policy.
