### PR TITLE
Release 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- _No changes yet._
+
+## 0.24.1 (2026-08-10)
+
 - **Formatting now uses a smaller format-only Spotless stack (`CF-411`)**: Mycila 5.1.1 continues to own license headers, while Spotless 3.9.0 replaces formatter-maven-plugin and applies the existing Eclipse profile through `spotless:apply` / `spotless:check` in local and hosted quality gates.
 - **Cached indicators stay synchronized with moving and revised series**: `CachedIndicator` now consumes exact `BarSeries` change snapshots to invalidate replaced-history tails, discard removed prefixes, and reconcile cache limits changed after indicator construction. Bounded caches also expand backward in place instead of rebuilding their full storage on every reverse read.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ta4j requires **Java 25+**. Most applications need only `ta4j-core`:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.24.0</version>
+  <version>0.24.1</version>
 </dependency>
 ```
 
@@ -65,7 +65,7 @@ Snapshot builds are published through the Sonatype Central snapshot repository:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-core</artifactId>
-  <version>0.24.1-SNAPSHOT</version>
+  <version>0.24.2-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -79,7 +79,7 @@ Stable examples artifact:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.24.0</version>
+  <version>0.24.1</version>
 </dependency>
 ```
 
@@ -93,7 +93,7 @@ Snapshot examples artifact:
 <dependency>
   <groupId>org.ta4j</groupId>
   <artifactId>ta4j-examples</artifactId>
-  <version>0.24.1-SNAPSHOT</version>
+  <version>0.24.2-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.24.1</version>
+    <version>0.24.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ta4j</groupId>
     <artifactId>ta4j-parent</artifactId>
-    <version>0.24.1-SNAPSHOT</version>
+    <version>0.24.1</version>
     <packaging>pom</packaging>
 
     <name>Ta4j Parent</name>

--- a/release/0.24.1.md
+++ b/release/0.24.1.md
@@ -1,0 +1,4 @@
+## 0.24.1 (2026-08-10)
+
+- **Formatting now uses a smaller format-only Spotless stack (`CF-411`)**: Mycila 5.1.1 continues to own license headers, while Spotless 3.9.0 replaces formatter-maven-plugin and applies the existing Eclipse profile through `spotless:apply` / `spotless:check` in local and hosted quality gates.
+- **Cached indicators stay synchronized with moving and revised series**: `CachedIndicator` now consumes exact `BarSeries` change snapshots to invalidate replaced-history tails, discard removed prefixes, and reconcile cache limits changed after indicator construction. Bounded caches also expand backward in place instead of rebuilding their full storage on every reverse read.

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.24.1-SNAPSHOT</version>
+        <version>0.24.1</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-core/pom.xml
+++ b/ta4j-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.24.1</version>
+        <version>0.24.2-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-core</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.24.1-SNAPSHOT</version>
+        <version>0.24.1</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 

--- a/ta4j-examples/pom.xml
+++ b/ta4j-examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.ta4j</groupId>
         <artifactId>ta4j-parent</artifactId>
-        <version>0.24.1</version>
+        <version>0.24.2-SNAPSHOT</version>
     </parent>
     <artifactId>ta4j-examples</artifactId>
 


### PR DESCRIPTION
Automated release PR for 0.24.1.

Contains:
- Set version to 0.24.1
- Generated release notes: release/0.24.1.md
- Bump to next snapshot: 0.24.2-SNAPSHOT
- Synced removal-ready deprecation issues: 0 plan(s), 0 created, 0 updated, 0 reopened, 0 stale closed

<!-- release-meta
releaseVersion: 0.24.1
nextVersion: 0.24.2-SNAPSHOT
releaseCommit: fd7757c08641fd8cffe062995da858ad9b81ed1f
-->