### PR TITLE
Feed the AI release scheduler the last release and its date

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -112,6 +112,20 @@ jobs:
           echo "audit:last_tag=$last_reachable_tag default_branch=$default_branch first_parent_tag=$last_first_parent_tag prefer_no_v_tags=true"
           echo "audit:latest_tag=$latest_tag latest_tag_reachable=$latest_tag_reachable"
 
+      - name: Resolve last release date
+        id: last_release
+        env:
+          LAST_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}
+        run: |
+          set -euo pipefail
+          if [ "${LAST_TAG:-none}" = "none" ]; then
+            release_date="none"
+          else
+            release_date="$(git log -1 --format=%cs "${LAST_TAG}" 2>/dev/null || echo none)"
+          fi
+          echo "date=$release_date" >> $GITHUB_OUTPUT
+          echo "audit:last_release_date=$release_date tag=${LAST_TAG:-none}"
+
       - name: Capture event and normalize dry run flag
         id: run_meta
         env:
@@ -532,6 +546,9 @@ jobs:
               --model "${{ steps.model_config.outputs.model_id }}" \
               --dossier release-dossier.md \
               --semver-rules .github/workflows/semver-rules-override.txt \
+              --last-release-url "https://github.com/${{ github.repository }}/releases" \
+              --last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}" \
+              --last-release-date "${{ steps.last_release.outputs.date }}" \
               --max-request-bytes "$max_request_bytes" \
               --metadata-output release-ai-request-metadata.json \
               --output request.json
@@ -919,6 +936,7 @@ jobs:
           POM_VERSION: ${{ steps.pom_version.outputs.version }}
           POM_BASE: ${{ steps.pom_version.outputs.base }}
           LAST_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}
+          LAST_RELEASE_DATE: ${{ steps.last_release.outputs.date }}
         run: |
           if [ "${SCHEDULER_DUE:-true}" != "true" ]; then
             mutation_plan="no release mutation; scheduled run is outside the biweekly release window"
@@ -975,6 +993,7 @@ jobs:
           echo "decision:computed_version=${VERSION:-}"
           echo "decision:pom_version=${POM_VERSION:-} pom_base=${POM_BASE:-}"
           echo "decision:last_reachable_default_branch_tag=${LAST_TAG:-}"
+          echo "decision:last_release_date=${LAST_RELEASE_DATE:-unknown}"
           echo "decision:last_first_parent_tag=${{ steps.lasttag.outputs.last_first_parent_tag }}"
           {
             echo "## Release Scheduler Decision"
@@ -997,6 +1016,7 @@ jobs:
             echo "- confidence: ${CONFIDENCE:-unknown}"
             echo "- computed version: ${VERSION:-none}"
             echo "- last reachable tag: ${LAST_TAG:-unknown}"
+            echo "- last release date: ${LAST_RELEASE_DATE:-unknown}"
             echo "- reason: ${REASON:-none}"
             echo "- mutation plan: ${mutation_plan}"
             echo "- rerun guidance: ${rerun_guidance}"

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -492,6 +492,9 @@ jobs:
         env:
           AI_MODE: ${{ steps.ai_mode.outputs.mode }}
           RELEASE_AI_MAX_REQUEST_BYTES: ${{ vars.RELEASE_AI_MAX_REQUEST_BYTES }}
+          LAST_RELEASE_URL: ${{ steps.last_release.outputs.url }}
+          LAST_RELEASE_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}
+          LAST_RELEASE_DATE: ${{ steps.last_release.outputs.date }}
         run: |
           set -euo pipefail
           echo "::group::Build AI request"
@@ -550,9 +553,9 @@ jobs:
               --model "${{ steps.model_config.outputs.model_id }}" \
               --dossier release-dossier.md \
               --semver-rules .github/workflows/semver-rules-override.txt \
-              --last-release-url "${{ steps.last_release.outputs.url }}" \
-              --last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}" \
-              --last-release-date "${{ steps.last_release.outputs.date }}" \
+              --last-release-url "${LAST_RELEASE_URL}" \
+              --last-release-tag "${LAST_RELEASE_TAG}" \
+              --last-release-date "${LAST_RELEASE_DATE}" \
               --max-request-bytes "$max_request_bytes" \
               --metadata-output release-ai-request-metadata.json \
               --output request.json

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -528,6 +528,9 @@ jobs:
               --arg reasoning_effort "${{ steps.model_config.outputs.reasoning_effort }}" \
               --arg request_size "$request_size" \
               --arg max_request_bytes "$max_request_bytes" \
+              --arg lastReleaseTag "$LAST_RELEASE_TAG" \
+              --arg lastReleaseDate "$LAST_RELEASE_DATE" \
+              --arg lastReleaseUrl "$LAST_RELEASE_URL" \
               '{
                 schemaVersion: 2,
                 provider: "openai",
@@ -535,6 +538,9 @@ jobs:
                 model: $model,
                 reasoningEffort: $reasoning_effort,
                 promptProfile: "probe",
+                lastReleaseTag: $lastReleaseTag,
+                lastReleaseDate: $lastReleaseDate,
+                lastReleaseUrl: $lastReleaseUrl,
                 artifactBackedContext: false,
                 fullDossierChars: 0,
                 promptDossierChars: 0,

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -118,12 +118,25 @@ jobs:
           LAST_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}
         run: |
           set -euo pipefail
+          encode_tag() {
+            local s="$1" out="" c hex
+            while [ -n "$s" ]; do
+              c="${s%"${s#?}"}"
+              case "$c" in
+                [-_.~A-Za-z0-9]) out="${out}${c}" ;;
+                *) printf -v hex '%%%02X' "'${c}"; out="${out}${hex}" ;;
+              esac
+              s="${s#?}"
+            done
+            printf '%s' "$out"
+          }
           if [ "${LAST_TAG:-none}" = "none" ]; then
             release_date="none"
             release_url="https://github.com/${GITHUB_REPOSITORY}/releases"
           else
             release_date="$(bash scripts/release/release_helpers.sh last-release-date --tag "${LAST_TAG}")"
-            release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${LAST_TAG}"
+            encoded_tag="$(encode_tag "${LAST_TAG}")"
+            release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${encoded_tag}"
           fi
           echo "date=$release_date" >> "$GITHUB_OUTPUT"
           echo "url=$release_url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -120,11 +120,15 @@ jobs:
           set -euo pipefail
           if [ "${LAST_TAG:-none}" = "none" ]; then
             release_date="none"
+            release_url="https://github.com/${GITHUB_REPOSITORY}/releases"
           else
-            release_date="$(git log -1 --format=%cs "${LAST_TAG}" 2>/dev/null || echo none)"
+            release_date="$(bash scripts/release/release_helpers.sh last-release-date --tag "${LAST_TAG}")"
+            release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${LAST_TAG}"
           fi
-          echo "date=$release_date" >> $GITHUB_OUTPUT
+          echo "date=$release_date" >> "$GITHUB_OUTPUT"
+          echo "url=$release_url" >> "$GITHUB_OUTPUT"
           echo "audit:last_release_date=$release_date tag=${LAST_TAG:-none}"
+          echo "audit:last_release_url=$release_url"
 
       - name: Capture event and normalize dry run flag
         id: run_meta
@@ -546,7 +550,7 @@ jobs:
               --model "${{ steps.model_config.outputs.model_id }}" \
               --dossier release-dossier.md \
               --semver-rules .github/workflows/semver-rules-override.txt \
-              --last-release-url "https://github.com/${{ github.repository }}/releases" \
+              --last-release-url "${{ steps.last_release.outputs.url }}" \
               --last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}" \
               --last-release-date "${{ steps.last_release.outputs.date }}" \
               --max-request-bytes "$max_request_bytes" \

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -950,6 +950,7 @@ jobs:
           POM_BASE: ${{ steps.pom_version.outputs.base }}
           LAST_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}
           LAST_RELEASE_DATE: ${{ steps.last_release.outputs.date }}
+          LAST_RELEASE_URL: ${{ steps.last_release.outputs.url }}
         run: |
           if [ "${SCHEDULER_DUE:-true}" != "true" ]; then
             mutation_plan="no release mutation; scheduled run is outside the biweekly release window"
@@ -977,6 +978,7 @@ jobs:
           requestMaxBytes=${REQUEST_MAX_BYTES:-}
           computedVersion=${VERSION:-}
           bump=${BUMP:-}
+          lastReleaseUrl=${LAST_RELEASE_URL:-}
           mutationPlan=${mutation_plan}
           rerunGuidance=${rerun_guidance}
           EOF
@@ -1007,6 +1009,7 @@ jobs:
           echo "decision:pom_version=${POM_VERSION:-} pom_base=${POM_BASE:-}"
           echo "decision:last_reachable_default_branch_tag=${LAST_TAG:-}"
           echo "decision:last_release_date=${LAST_RELEASE_DATE:-unknown}"
+          echo "decision:last_release_url=${LAST_RELEASE_URL:-unknown}"
           echo "decision:last_first_parent_tag=${{ steps.lasttag.outputs.last_first_parent_tag }}"
           {
             echo "## Release Scheduler Decision"
@@ -1030,6 +1033,7 @@ jobs:
             echo "- computed version: ${VERSION:-none}"
             echo "- last reachable tag: ${LAST_TAG:-unknown}"
             echo "- last release date: ${LAST_RELEASE_DATE:-unknown}"
+            echo "- last release url: ${LAST_RELEASE_URL:-unknown}"
             echo "- reason: ${REASON:-none}"
             echo "- mutation plan: ${mutation_plan}"
             echo "- rerun guidance: ${rerun_guidance}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- _No changes yet._
+- **AI release scheduling now weighs release recency against pending changes**: `release-scheduler.yml` passes the last release's tag, commit date, and release link into the AI decision prompt. Recency is a judgment call instead of a fixed cooldown: the model defers (`should_release=false`) when the unreleased delta does not justify another release this soon, and the cadence input is omitted entirely when no prior release exists.
 
 ## 0.24.1 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- **AI release scheduling now weighs release recency against pending changes**: `release-scheduler.yml` passes the last release's tag, commit date, and release link into the AI decision prompt. Recency is a judgment call instead of a fixed cooldown: the model defers (`should_release=false`) when the unreleased delta does not justify another release this soon, and the cadence input is omitted entirely when no prior release exists.
+- **AI release scheduling now weighs release recency against pending changes**: `release-scheduler.yml` passes the last release's tag, creation date, and release link into the AI decision prompt. Recency is a judgment call instead of a fixed cooldown: the model defers (`should_release=false`) when the unreleased delta does not justify another release this soon, and the cadence input is omitted entirely when no prior release exists.
 
 ## 0.24.1 (2026-08-10)
 

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -18,7 +18,7 @@ Extend PDL.TASK.HANDOFF_REPORT:
 Report that ta4j is public and the PR is intentionally left open for public viewing and human merge. Before final handoff, delete temporary ignored PRD/checklist files under `.agents/plans/` unless the user explicitly asks to retain them. If one is intentionally retained, call out the path and reason in the handoff.
 
 Require QAS.TASK.PR_HANDOFF:
-Immediately after opening a ta4j PR, post `@coderabbitai full review` as a PR comment. Do not substitute the incremental `@coderabbitai review` command. Treat the PR as not ready for terminal handoff until CodeRabbit finishes the full review or explicitly reports that it cannot review the PR.
+Immediately after opening a ta4j PR, post `@coderabbitai full review` as a PR comment. Do not substitute the incremental `@coderabbitai review` command for that initial review. Treat the PR as not ready for terminal handoff until CodeRabbit finishes the full review or explicitly reports that it cannot review the PR. If remediation requires further CodeRabbit review rounds on the same PR, request them with `@coderabbitai incremental review` rather than repeating `@coderabbitai full review`.
 
 Override QAS.TASK.MERGE_POLICY:
 ta4j requires a human viewing opportunity before `master` changes. Automation prepares, verifies, monitors, fixes feedback, resolves conversations, and hands off the ready PR.

--- a/scripts/release/release_helpers.sh
+++ b/scripts/release/release_helpers.sh
@@ -355,7 +355,7 @@ build_ai_request_payload() {
   local release_context=""
   if [[ -n "$last_release_tag" && "$last_release_tag" != "none" ]]; then
     release_context="today (UTC): $(date -u +%F)
-last release: ${last_release_tag}, published ${last_release_date:-unknown} (${last_release_url})
+last release: ${last_release_tag}, created ${last_release_date:-unknown} (${last_release_url})
 Release recency is a judgment call: weigh the gap since the last release against the value of the unreleased changes. Defer (should_release=false) when the pending changes do not justify another release this soon. Calibration: 0.24.1 shipped too soon after 0.24.0 (minimal user-visible delta); 0.24.0 two days after 0.23.0 would have been justified (large delta)."
   fi
   jq -S -n \
@@ -405,6 +405,9 @@ command_last_release_date() {
   fi
   if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null 2>&1; then
     die "Tag ${tag} cannot be resolved in this repository; refusing to fabricate a release date"
+  fi
+  if [[ "$(git cat-file -t "refs/tags/${tag}")" != "tag" ]]; then
+    die "Tag ${tag} is a lightweight tag; a release date requires an annotated tag"
   fi
   local release_date
   release_date="$(git for-each-ref "refs/tags/${tag}" --format='%(creatordate:short)')"

--- a/scripts/release/release_helpers.sh
+++ b/scripts/release/release_helpers.sh
@@ -47,6 +47,7 @@ Commands:
   model-preflight
   build-dossier
   build-ai-request
+  last-release-date
   extract-response-content
   sanitize-response
   ai-transport-diagnostics
@@ -372,7 +373,7 @@ Release recency is a judgment call: weigh the gap since the last release against
       input: [
         {
           role: "system",
-          content: [{type: "input_text", text: "You are a SemVer release reviewer for a Java library. Return JSON only. Base every conclusion on the release dossier."}]
+          content: [{type: "input_text", text: "You are a SemVer release reviewer for a Java library. Return JSON only. Base every conclusion on the release dossier and any supplied release-cadence context."}]
         },
         {
           role: "user",
@@ -387,6 +388,30 @@ Release recency is a judgment call: weigh the gap since the last release against
         }
       ]
     }'
+}
+
+command_last_release_date() {
+  local tag=""
+  while (($#)); do
+    case "$1" in
+      --tag) require_value "$1" "${2:-}"; tag="$2"; shift 2 ;;
+      *) die "Unknown last-release-date option: $1" ;;
+    esac
+  done
+  [[ -n "$tag" ]] || die "--tag is required"
+  if [[ "$tag" == "none" ]]; then
+    printf 'none\n'
+    return 0
+  fi
+  if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null 2>&1; then
+    die "Tag ${tag} cannot be resolved in this repository; refusing to fabricate a release date"
+  fi
+  local release_date
+  release_date="$(git for-each-ref "refs/tags/${tag}" --format='%(creatordate:short)')"
+  if [[ -z "$release_date" ]]; then
+    die "Tag ${tag} has no resolvable creation date"
+  fi
+  printf '%s\n' "$release_date"
 }
 
 command_model_preflight() {
@@ -2020,6 +2045,7 @@ main() {
     model-preflight) command_model_preflight "$@" ;;
     build-dossier) command_build_dossier "$@" ;;
     build-ai-request) command_build_ai_request "$@" ;;
+    last-release-date) command_last_release_date "$@" ;;
     extract-response-content) command_extract_response_content "$@" ;;
     sanitize-response) command_sanitize_response_artifact "$@" ;;
     ai-transport-diagnostics) command_ai_transport_diagnostics "$@" ;;

--- a/scripts/release/release_helpers.sh
+++ b/scripts/release/release_helpers.sh
@@ -344,9 +344,18 @@ build_ai_request_payload() {
   local semver_file="$2"
   local dossier_file="$3"
   local prompt_profile="$4"
+  local last_release_url="$5"
+  local last_release_tag="$6"
+  local last_release_date="$7"
   local artifact_note=""
   if [[ "$prompt_profile" == compact* ]]; then
     artifact_note=$'\nThe full unabridged release dossier is preserved as release-dossier.md in the workflow audit artifact. Base the decision on this compact, artifact-backed dossier summary and explicitly call out uncertainty in missing or risks when the compact prompt omits detail.'
+  fi
+  local release_context=""
+  if [[ -n "$last_release_tag" && "$last_release_tag" != "none" ]]; then
+    release_context="today (UTC): $(date -u +%F)
+last release: ${last_release_tag}, published ${last_release_date:-unknown} (${last_release_url})
+Release recency is a judgment call: weigh the gap since the last release against the value of the unreleased changes. Defer (should_release=false) when the pending changes do not justify another release this soon. Calibration: 0.24.1 shipped too soon after 0.24.0 (minimal user-visible delta); 0.24.0 two days after 0.23.0 would have been justified (large delta)."
   fi
   jq -S -n \
     --arg model "$model" \
@@ -354,6 +363,7 @@ build_ai_request_payload() {
     --rawfile semver "$semver_file" \
     --rawfile dossier "$dossier_file" \
     --arg artifact_note "$artifact_note" \
+    --arg release_context "$release_context" \
     '{
       model: $model,
       reasoning: {effort: $reasoning_effort},
@@ -368,6 +378,7 @@ build_ai_request_payload() {
           role: "user",
           content: [{type: "input_text", text: (
             "Decide whether ta4j should cut a release from this dossier. If yes, choose bump patch or minor. Major is disabled for this workflow.\n\n"
+            + (if $release_context != "" then "Release cadence:\n" + $release_context + "\n\n" else "" end)
             + "SemVer rules:\n" + $semver + "\n\n"
             + "Return JSON only with this shape:\n"
             + "{\"should_release\": true|false, \"bump\": \"patch|minor\", \"confidence\": 0.0-1.0, \"reason\": \"1-2 sentences\", \"evidence\": [\"specific dossier facts\"], \"risks\": [\"release risks or empty array\"], \"missing\": [\"missing changelog/javadoc/test evidence or empty array\"]}."
@@ -709,12 +720,15 @@ command_build_dossier() {
 }
 
 command_build_ai_request() {
-  local model="" dossier="release-dossier.md" semver_rules=".github/workflows/semver-rules-override.txt" max_dossier_chars=900000 max_request_bytes="$DEFAULT_AI_REQUEST_MAX_BYTES" output="request.json" metadata_output="release-ai-request-metadata.json"
+  local model="" dossier="release-dossier.md" semver_rules=".github/workflows/semver-rules-override.txt" max_dossier_chars=900000 max_request_bytes="$DEFAULT_AI_REQUEST_MAX_BYTES" output="request.json" metadata_output="release-ai-request-metadata.json" last_release_url="https://github.com/ta4j/ta4j/releases" last_release_tag="none" last_release_date="none"
   while (($#)); do
     case "$1" in
       --model) require_value "$1" "${2:-}"; model="$2"; shift 2 ;;
       --dossier) require_value "$1" "${2:-}"; dossier="$2"; shift 2 ;;
       --semver-rules) require_value "$1" "${2:-}"; semver_rules="$2"; shift 2 ;;
+      --last-release-url) require_value "$1" "${2:-}"; last_release_url="$2"; shift 2 ;;
+      --last-release-tag) require_value "$1" "${2:-}"; last_release_tag="$2"; shift 2 ;;
+      --last-release-date) require_value "$1" "${2:-}"; last_release_date="$2"; shift 2 ;;
       --max-dossier-chars) require_value "$1" "${2:-}"; max_dossier_chars="$2"; shift 2 ;;
       --max-request-bytes) require_value "$1" "${2:-}"; max_request_bytes="$2"; shift 2 ;;
       --output) require_value "$1" "${2:-}"; output="$2"; shift 2 ;;
@@ -752,7 +766,7 @@ EOF
   fi
 
   request_tmp="$tmpdir/request.json"
-  build_ai_request_payload "$model" "$semver_file" "$prompt_dossier" "$prompt_profile" > "$request_tmp"
+  build_ai_request_payload "$model" "$semver_file" "$prompt_dossier" "$prompt_profile" "$last_release_url" "$last_release_tag" "$last_release_date" > "$request_tmp"
   full_request_size="$(file_size_bytes "$request_tmp")"
   local selected_diff_file
   selected_diff_file="$tmpdir/selected-diff.txt"
@@ -791,7 +805,7 @@ EOF
       candidate_request="$tmpdir/request-${compaction_level}.json"
       candidate_profile="compact-artifact-backed-v${compaction_level}"
       build_compact_dossier "$full_dossier" "$candidate_dossier" "${limits[$i]}" "${changelog_limits[$i]}" "${signals_limits[$i]}" "${diff_limits[$i]}"
-      build_ai_request_payload "$model" "$semver_file" "$candidate_dossier" "$candidate_profile" > "$candidate_request"
+      build_ai_request_payload "$model" "$semver_file" "$candidate_dossier" "$candidate_profile" "$last_release_url" "$last_release_tag" "$last_release_date" > "$candidate_request"
       candidate_size="$(file_size_bytes "$candidate_request")"
       if (( candidate_size <= max_request_bytes )); then
         prompt_dossier="$candidate_dossier"
@@ -806,7 +820,7 @@ EOF
       prompt_dossier="$tmpdir/compact-minimal.md"
       request_tmp="$tmpdir/request-minimal.json"
       build_compact_dossier "$dossier" "$prompt_dossier" 1 400 400 0
-      build_ai_request_payload "$model" "$semver_file" "$prompt_dossier" "$prompt_profile" > "$request_tmp"
+      build_ai_request_payload "$model" "$semver_file" "$prompt_dossier" "$prompt_profile" "$last_release_url" "$last_release_tag" "$last_release_date" > "$request_tmp"
       selected_diff_excerpt_chars=0
     fi
   fi
@@ -824,6 +838,9 @@ EOF
     --arg fullDossierPath "$dossier" \
     --arg compactedBecause "$([[ "$compacted" == true ]] && printf 'full request exceeded transport budget')" \
     --arg metadataOutput "$metadata_output" \
+    --arg lastReleaseTag "$last_release_tag" \
+    --arg lastReleaseDate "$last_release_date" \
+    --arg lastReleaseUrl "$last_release_url" \
     --argjson schemaVersion "$AI_REQUEST_METADATA_SCHEMA_VERSION" \
     --argjson artifactBackedContext "$compacted" \
     --argjson fullDossierChars "$(file_size_bytes "$dossier")" \
@@ -845,6 +862,9 @@ EOF
       reasoningEffort: $reasoningEffort,
       semverRulesSource: $semverRulesSource,
       promptProfile: $promptProfile,
+      lastReleaseTag: $lastReleaseTag,
+      lastReleaseDate: $lastReleaseDate,
+      lastReleaseUrl: $lastReleaseUrl,
       artifactBackedContext: $artifactBackedContext,
       fullDossierPath: $fullDossierPath,
       fullDossierChars: $fullDossierChars,

--- a/scripts/tests/test_release_helpers.sh
+++ b/scripts/tests/test_release_helpers.sh
@@ -608,8 +608,8 @@ test_build_ai_request_includes_release_cadence() {
     "system contract should admit cadence facts supplied outside the dossier"
   expect_file_contains request.json "https://github.com/ta4j/ta4j/releases" \
     "request should include the last release URL"
-  expect_file_contains request.json "last release: 1.0.0, published 2026-08-03" \
-    "request should include the last release tag and publish date"
+  expect_file_contains request.json "last release: 1.0.0, created 2026-08-03" \
+    "request should include the last release tag and creation date"
   expect_file_contains request.json "judgment call" \
     "request should frame release recency as a judgment call"
   expect_file_contains request.json "0.24.1 shipped too soon after 0.24.0" \
@@ -667,6 +667,15 @@ test_last_release_date_uses_annotated_tag_date() {
   local unresolved_output
   if unresolved_output="$(cd release-repo && bash "$SCRIPT" last-release-date --tag 9.9.9 2>&1)"; then
     fail "last-release-date should fail for a known-but-unresolvable tag (got: ${unresolved_output})"
+  fi
+
+  (
+    cd release-repo
+    git tag 2.0.0
+  )
+  local lightweight_output
+  if lightweight_output="$(cd release-repo && bash "$SCRIPT" last-release-date --tag 2.0.0 2>&1)"; then
+    fail "last-release-date should reject a lightweight tag whose creatordate is the commit date (got: ${lightweight_output})"
   fi
 
   finish_test

--- a/scripts/tests/test_release_helpers.sh
+++ b/scripts/tests/test_release_helpers.sh
@@ -604,6 +604,8 @@ test_build_ai_request_includes_release_cadence() {
 
   expect_file_contains request.json "Release cadence:" \
     "request should include the release cadence section when a last release tag is known"
+  expect_file_contains request.json "Base every conclusion on the release dossier and any supplied release-cadence context" \
+    "system contract should admit cadence facts supplied outside the dossier"
   expect_file_contains request.json "https://github.com/ta4j/ta4j/releases" \
     "request should include the last release URL"
   expect_file_contains request.json "last release: 1.0.0, published 2026-08-03" \
@@ -635,6 +637,40 @@ test_build_ai_request_includes_release_cadence() {
 
   finish_test
   pass "test_build_ai_request_includes_release_cadence"
+}
+
+test_last_release_date_uses_annotated_tag_date() {
+  echo "Running test_last_release_date_uses_annotated_tag_date"
+  run_test
+
+  git init -q -b master release-repo
+  (
+    cd release-repo
+    git config user.name "Release Test"
+    git config user.email "release-test@example.com"
+    GIT_AUTHOR_DATE=2026-07-01T00:00:00Z GIT_COMMITTER_DATE=2026-07-01T00:00:00Z git commit -q --allow-empty -m "base commit"
+    GIT_COMMITTER_DATE=2026-08-03T00:00:00Z git tag -a 1.0.0 -m "Release 1.0.0"
+  )
+
+  local date_out
+  date_out="$(cd release-repo && bash "$SCRIPT" last-release-date --tag 1.0.0)"
+  if [[ "$date_out" != "2026-08-03" ]]; then
+    fail "last-release-date should report the annotated tag date, not the tagged commit date (got '${date_out}')"
+  fi
+
+  local none_out
+  none_out="$(cd release-repo && bash "$SCRIPT" last-release-date --tag none)"
+  if [[ "$none_out" != "none" ]]; then
+    fail "last-release-date should pass through 'none' when there is no prior release (got '${none_out}')"
+  fi
+
+  local unresolved_output
+  if unresolved_output="$(cd release-repo && bash "$SCRIPT" last-release-date --tag 9.9.9 2>&1)"; then
+    fail "last-release-date should fail for a known-but-unresolvable tag (got: ${unresolved_output})"
+  fi
+
+  finish_test
+  pass "test_last_release_date_uses_annotated_tag_date"
 }
 
 test_ai_transport_diagnostics_records_curl_exit_18() {
@@ -777,6 +813,7 @@ test_release_pr_review_plan_preserves_team_reviewers
 test_build_dossier_groups_and_truncates_diff
 test_build_ai_request_compacts_oversized_dossier
 test_build_ai_request_includes_release_cadence
+test_last_release_date_uses_annotated_tag_date
 test_ai_transport_diagnostics_records_curl_exit_18
 test_artifact_manifest_validates_expected_release_jars
 test_javadoc_warning_baseline_rejects_new_warnings

--- a/scripts/tests/test_release_helpers.sh
+++ b/scripts/tests/test_release_helpers.sh
@@ -576,6 +576,67 @@ test_build_ai_request_compacts_oversized_dossier() {
   pass "test_build_ai_request_compacts_oversized_dossier"
 }
 
+test_build_ai_request_includes_release_cadence() {
+  echo "Running test_build_ai_request_includes_release_cadence"
+  run_test
+
+  {
+    echo "# ta4j Release Dossier"
+    echo
+    echo "## Metadata"
+    echo
+    echo "- generated_at: 2026-08-10T00:00:00+00:00"
+    echo "- last_reachable_tag: 1.0.0"
+    echo
+    echo "## Unreleased Changelog Context"
+    echo
+    echo "- change"
+  } > release-dossier.md
+
+  bash "$SCRIPT" build-ai-request \
+    --model gpt-5.6-luna \
+    --dossier release-dossier.md \
+    --last-release-url https://github.com/ta4j/ta4j/releases \
+    --last-release-tag 1.0.0 \
+    --last-release-date 2026-08-03 \
+    --output request.json \
+    --metadata-output release-ai-request-metadata.json
+
+  expect_file_contains request.json "Release cadence:" \
+    "request should include the release cadence section when a last release tag is known"
+  expect_file_contains request.json "https://github.com/ta4j/ta4j/releases" \
+    "request should include the last release URL"
+  expect_file_contains request.json "last release: 1.0.0, published 2026-08-03" \
+    "request should include the last release tag and publish date"
+  expect_file_contains request.json "judgment call" \
+    "request should frame release recency as a judgment call"
+  expect_file_contains request.json "0.24.1 shipped too soon after 0.24.0" \
+    "request should carry the too-soon calibration example"
+  expect_file_contains request.json "0.24.0 two days after 0.23.0" \
+    "request should carry the justified-gap calibration example"
+  expect_json_value release-ai-request-metadata.json lastReleaseTag 1.0.0
+  expect_json_value release-ai-request-metadata.json lastReleaseDate 2026-08-03
+  expect_json_value release-ai-request-metadata.json lastReleaseUrl https://github.com/ta4j/ta4j/releases
+  if grep -Fq "6 days" request.json || grep -Fq "5-7 day" request.json; then
+    fail "release cadence must stay a judgment call, not a day-based cooldown"
+  fi
+
+  bash "$SCRIPT" build-ai-request \
+    --model gpt-5.6-luna \
+    --dossier release-dossier.md \
+    --last-release-url https://github.com/ta4j/ta4j/releases \
+    --last-release-tag none \
+    --last-release-date none \
+    --output request-none.json \
+    --metadata-output release-ai-request-metadata-none.json
+  if grep -Fq "Release cadence:" request-none.json; then
+    fail "request should omit the release cadence section when there is no last release tag"
+  fi
+
+  finish_test
+  pass "test_build_ai_request_includes_release_cadence"
+}
+
 test_ai_transport_diagnostics_records_curl_exit_18() {
   echo "Running test_ai_transport_diagnostics_records_curl_exit_18"
   run_test
@@ -715,6 +776,7 @@ test_release_pr_review_plan_uses_non_author_fallback_reviewers
 test_release_pr_review_plan_preserves_team_reviewers
 test_build_dossier_groups_and_truncates_diff
 test_build_ai_request_compacts_oversized_dossier
+test_build_ai_request_includes_release_cadence
 test_ai_transport_diagnostics_records_curl_exit_18
 test_artifact_manifest_validates_expected_release_jars
 test_javadoc_warning_baseline_rejects_new_warnings

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -237,10 +237,12 @@ test_release_scheduler_feeds_last_release_to_ai() {
 
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" "Resolve last release date" \
     "release scheduler should resolve the last release date after the tag baselines"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'git log -1 --format=%cs' \
-    "release scheduler should derive the last release date from the tag commit"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-url "https://github.com/${{ github.repository }}/releases"' \
-    "release scheduler should pass a repo-derived last release URL to the AI request"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'release_helpers.sh last-release-date --tag' \
+    "release scheduler should derive the last release date from the annotated tag via the release helper"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'releases/tag/${LAST_TAG}' \
+    "release scheduler should build a tag-specific release URL"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-url "${{ steps.last_release.outputs.url }}"' \
+    "release scheduler should pass the resolved last release URL to the AI request"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
     "release scheduler should pass the last reachable tag to the AI request"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-date "${{ steps.last_release.outputs.date }}"' \
@@ -248,8 +250,8 @@ test_release_scheduler_feeds_last_release_to_ai() {
 
   local request_section
   request_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Build and validate AI request JSON" "Call AI API once")"
-  expect_section_contains "$request_section" '--last-release-url "https://github.com/${{ github.repository }}/releases"' \
-    "AI request build should receive the repo-derived last release URL"
+  expect_section_contains "$request_section" '--last-release-url "${{ steps.last_release.outputs.url }}"' \
+    "AI request build should receive the resolved last release URL"
   expect_section_contains "$request_section" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
     "AI request build should receive the last reachable tag"
   expect_section_contains "$request_section" '--last-release-date "${{ steps.last_release.outputs.date }}"' \

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -239,8 +239,10 @@ test_release_scheduler_feeds_last_release_to_ai() {
     "release scheduler should resolve the last release date after the tag baselines"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'release_helpers.sh last-release-date --tag' \
     "release scheduler should derive the last release date from the annotated tag via the release helper"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'releases/tag/${LAST_TAG}' \
-    "release scheduler should build a tag-specific release URL"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'releases/tag/${encoded_tag}' \
+    "release scheduler should build a tag-specific release URL from the percent-encoded tag"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'encode_tag()' \
+    "release scheduler should percent-encode the tag before building the release URL"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'LAST_RELEASE_URL: ${{ steps.last_release.outputs.url }}' \
     "release scheduler should pass the last release URL to the AI request step as an environment variable"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'LAST_RELEASE_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}' \

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -241,21 +241,33 @@ test_release_scheduler_feeds_last_release_to_ai() {
     "release scheduler should derive the last release date from the annotated tag via the release helper"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'releases/tag/${LAST_TAG}' \
     "release scheduler should build a tag-specific release URL"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-url "${{ steps.last_release.outputs.url }}"' \
-    "release scheduler should pass the resolved last release URL to the AI request"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
-    "release scheduler should pass the last reachable tag to the AI request"
-  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-date "${{ steps.last_release.outputs.date }}"' \
-    "release scheduler should pass the last release date to the AI request"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'LAST_RELEASE_URL: ${{ steps.last_release.outputs.url }}' \
+    "release scheduler should pass the last release URL to the AI request step as an environment variable"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'LAST_RELEASE_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}' \
+    "release scheduler should pass the last reachable tag to the AI request step as an environment variable"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'LAST_RELEASE_DATE: ${{ steps.last_release.outputs.date }}' \
+    "release scheduler should pass the last release date to the AI request step as an environment variable"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-url "${LAST_RELEASE_URL}"' \
+    "release scheduler should reference the last release URL through a quoted environment expansion"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-tag "${LAST_RELEASE_TAG}"' \
+    "release scheduler should reference the last release tag through a quoted environment expansion"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-date "${LAST_RELEASE_DATE}"' \
+    "release scheduler should reference the last release date through a quoted environment expansion"
 
   local request_section
   request_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Build and validate AI request JSON" "Call AI API once")"
-  expect_section_contains "$request_section" '--last-release-url "${{ steps.last_release.outputs.url }}"' \
-    "AI request build should receive the resolved last release URL"
-  expect_section_contains "$request_section" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
-    "AI request build should receive the last reachable tag"
-  expect_section_contains "$request_section" '--last-release-date "${{ steps.last_release.outputs.date }}"' \
-    "AI request build should receive the last release date"
+  expect_section_contains "$request_section" 'LAST_RELEASE_URL: ${{ steps.last_release.outputs.url }}' \
+    "AI request build should receive the resolved last release URL via its environment"
+  expect_section_contains "$request_section" 'LAST_RELEASE_TAG: ${{ steps.lasttag.outputs.last_reachable_tag }}' \
+    "AI request build should receive the last reachable tag via its environment"
+  expect_section_contains "$request_section" 'LAST_RELEASE_DATE: ${{ steps.last_release.outputs.date }}' \
+    "AI request build should receive the last release date via its environment"
+  expect_section_contains "$request_section" '--last-release-url "${LAST_RELEASE_URL}"' \
+    "AI request build should pass the last release URL through a quoted environment expansion"
+  expect_section_contains "$request_section" '--last-release-tag "${LAST_RELEASE_TAG}"' \
+    "AI request build should pass the last reachable tag through a quoted environment expansion"
+  expect_section_contains "$request_section" '--last-release-date "${LAST_RELEASE_DATE}"' \
+    "AI request build should pass the last release date through a quoted environment expansion"
 
   pass "test_release_scheduler_feeds_last_release_to_ai"
 }

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -253,6 +253,10 @@ test_release_scheduler_feeds_last_release_to_ai() {
     "release scheduler should reference the last release tag through a quoted environment expansion"
   expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-date "${LAST_RELEASE_DATE}"' \
     "release scheduler should reference the last release date through a quoted environment expansion"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'decision:last_release_url=${LAST_RELEASE_URL:-unknown}' \
+    "release scheduler should record the last release URL in the decision audit"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'lastReleaseUrl=${LAST_RELEASE_URL:-}' \
+    "release scheduler should record the last release URL in the mutation-plan artifact"
 
   local request_section
   request_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Build and validate AI request JSON" "Call AI API once")"

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -268,6 +268,12 @@ test_release_scheduler_feeds_last_release_to_ai() {
     "AI request build should pass the last reachable tag through a quoted environment expansion"
   expect_section_contains "$request_section" '--last-release-date "${LAST_RELEASE_DATE}"' \
     "AI request build should pass the last release date through a quoted environment expansion"
+  expect_section_contains "$request_section" 'lastReleaseTag: $lastReleaseTag' \
+    "probe metadata should record the last release tag for schema parity with full mode"
+  expect_section_contains "$request_section" 'lastReleaseDate: $lastReleaseDate' \
+    "probe metadata should record the last release date for schema parity with full mode"
+  expect_section_contains "$request_section" 'lastReleaseUrl: $lastReleaseUrl' \
+    "probe metadata should record the last release URL for schema parity with full mode"
 
   pass "test_release_scheduler_feeds_last_release_to_ai"
 }

--- a/scripts/tests/test_release_workflow_safety.sh
+++ b/scripts/tests/test_release_workflow_safety.sh
@@ -232,6 +232,32 @@ test_release_scheduler_uses_true_biweekly_cadence_guard() {
   pass "test_release_scheduler_uses_true_biweekly_cadence_guard"
 }
 
+test_release_scheduler_feeds_last_release_to_ai() {
+  echo "Running test_release_scheduler_feeds_last_release_to_ai"
+
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" "Resolve last release date" \
+    "release scheduler should resolve the last release date after the tag baselines"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" 'git log -1 --format=%cs' \
+    "release scheduler should derive the last release date from the tag commit"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-url "https://github.com/${{ github.repository }}/releases"' \
+    "release scheduler should pass a repo-derived last release URL to the AI request"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
+    "release scheduler should pass the last reachable tag to the AI request"
+  expect_file_contains "$WORKFLOWS/release-scheduler.yml" '--last-release-date "${{ steps.last_release.outputs.date }}"' \
+    "release scheduler should pass the last release date to the AI request"
+
+  local request_section
+  request_section="$(workflow_section "$WORKFLOWS/release-scheduler.yml" "Build and validate AI request JSON" "Call AI API once")"
+  expect_section_contains "$request_section" '--last-release-url "https://github.com/${{ github.repository }}/releases"' \
+    "AI request build should receive the repo-derived last release URL"
+  expect_section_contains "$request_section" '--last-release-tag "${{ steps.lasttag.outputs.last_reachable_tag }}"' \
+    "AI request build should receive the last reachable tag"
+  expect_section_contains "$request_section" '--last-release-date "${{ steps.last_release.outputs.date }}"' \
+    "AI request build should receive the last release date"
+
+  pass "test_release_scheduler_feeds_last_release_to_ai"
+}
+
 test_downstream_dispatches_explicitly_pass_dry_run() {
   echo "Running test_downstream_dispatches_explicitly_pass_dry_run"
 
@@ -666,6 +692,7 @@ test_maven_workflow_jobs_setup_jdk25_before_maven
 test_mutating_manual_workflows_default_to_dry_run
 test_official_triggers_normalize_to_non_dry_run
 test_release_scheduler_uses_true_biweekly_cadence_guard
+test_release_scheduler_feeds_last_release_to_ai
 test_downstream_dispatches_explicitly_pass_dry_run
 test_mutating_steps_remain_dry_run_gated
 test_dry_run_summaries_and_audits_show_rerun_guidance


### PR DESCRIPTION
Changes proposed in this pull request:
- `build-ai-request` accepts `--last-release-url` / `--last-release-tag` / `--last-release-date` and embeds a release-cadence block in the AI prompt when a prior release tag exists; the block is omitted when there is no prior release
- `release-scheduler.yml` resolves the last release date from the last reachable tag's annotated-tag creation date (via a new `last-release-date` helper command) and passes the tag, date, and a tag-specific release URL to the AI request; recency is a judgment call weighing the gap against the unreleased delta, not a day-based cooldown
- Request metadata records `lastReleaseTag` / `lastReleaseDate` / `lastReleaseUrl` for audit parity, and the debug decision summary surfaces the last release date
- Prior-release values reach the AI request step through environment variables referenced as quoted shell expansions, so tag-derived content cannot alter shell syntax

Reuse audit: no new types or classes were introduced. The three CLI flags extend the existing `build-ai-request` interface following the established `--semver-rules` flag pattern (`require_value` + case arm), and the cadence block reuses the existing `build_ai_request_payload` assembly with an additional `--arg` instead of adding a parallel prompt builder. The new `last-release-date` command exists because no existing release helper resolves a tag's creation date: `resolve-release-tags.sh` emits tag names only, and `build-ai-request` is prompt assembly; date resolution from the tag object is a distinct workflow-facing primitive, so a small command reusing `require_value`/`die` was warranted instead of overloading an existing command's flags.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format spotless:apply verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [x] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI-assisted release scheduling now considers the previous release’s date, tag, and link.
  - Releases can be deferred when the previous release was published too recently.
  - Release dates can be retrieved from annotated tags, with support for first-release scenarios.
  - Release decisions and summaries now include relevant release context.

- **Documentation**
  - Updated the Unreleased changelog with recency-aware scheduling details.

- **Tests**
  - Added coverage for release context, date resolution, scheduling behavior, and workflow data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->