### PR TITLE
build: remove Ruby preflight dependency and make shell scripts cross-platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 /mvnw.cmd text eol=crlf
+# Shell scripts must keep LF endings on every platform: CRLF breaks
+# bash (`set -o pipefail\r` -> invalid option) under Git Bash/MSYS on Windows.
+*.sh text eol=lf
+mvnw text eol=lf

--- a/scripts/agents_for_target.sh
+++ b/scripts/agents_for_target.sh
@@ -49,8 +49,24 @@ else
   # Portable fallback: BSD and GNU find both support -name glob matching.
   # MSYS/Git Bash find emits backslash separators; normalize them so the
   # upward AGENTS.md walk sees ordinary slash-separated paths.
+  # Path-shaped targets (containing "/") are matched by splitting the
+  # directory prefix from the basename, preserving the rg path-input contract.
   file_listing() {
-    find "$root" -type f -name "$target_glob" 2>/dev/null | tr '\\' '/'
+    case "$target_glob" in
+      */*)
+        local dir_glob="${target_glob%/*}"
+        local base_glob="${target_glob##*/}"
+        local match
+        for match in "$root"/"$dir_glob"/"$base_glob"; do
+          if [ -f "$match" ]; then
+            printf '%s\n' "$match"
+          fi
+        done
+        ;;
+      *)
+        find "$root" -type f -name "$target_glob" 2>/dev/null | tr '\\' '/'
+        ;;
+    esac
   }
 fi
 

--- a/scripts/agents_for_target.sh
+++ b/scripts/agents_for_target.sh
@@ -39,15 +39,22 @@ workspace_root() {
 
 root="$(workspace_root)"
 
-# If rg isn't available, fail fast with a clear message
-if ! command -v rg >/dev/null 2>&1; then
-  echo "Error: ripgrep (rg) not found in PATH." >&2
-  exit 127
-fi
-
 # Find matches under root, including hidden and ignored files,
 # so AGENTS candidates are discovered even in filtered directories.
-rg --files --no-ignore --hidden -g "$target_glob" "$root" 2>/dev/null \
+if command -v rg >/dev/null 2>&1; then
+  file_listing() {
+    rg --files --no-ignore --hidden -g "$target_glob" "$root" 2>/dev/null
+  }
+else
+  # Portable fallback: BSD and GNU find both support -name glob matching.
+  # MSYS/Git Bash find emits backslash separators; normalize them so the
+  # upward AGENTS.md walk sees ordinary slash-separated paths.
+  file_listing() {
+    find "$root" -type f -name "$target_glob" 2>/dev/null | tr '\\' '/'
+  }
+fi
+
+file_listing \
 | while IFS= read -r file; do
     [ -z "$file" ] && continue
     dir="$(dirname "$file")"

--- a/scripts/benchmark-backtest-throughput.sh
+++ b/scripts/benchmark-backtest-throughput.sh
@@ -50,6 +50,11 @@ if [[ "${1:-}" == "--" ]]; then
   shift
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: required tool 'python3' not found in PATH" >&2
+  exit 1
+fi
+
 default_harness_args=(
   --throughputControl
   --matrixStrategyCounts "250,500,1000"

--- a/scripts/docs-integrity-check.sh
+++ b/scripts/docs-integrity-check.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export ROOT_DIR
 
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: required tool 'python3' not found in PATH" >&2
+    exit 1
+fi
+
 python3 <<'PY'
 import os
 import re

--- a/scripts/release/release_helpers.sh
+++ b/scripts/release/release_helpers.sh
@@ -1697,7 +1697,12 @@ command_snapshot_publication() {
 }
 
 sha256_file() {
-  shasum -a 256 "$1" | awk '{print $1}'
+  # sha256sum ships with GNU coreutils and MSYS; shasum covers macOS.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
 }
 
 resolved_snapshot_value() {
@@ -1740,12 +1745,10 @@ fetch_snapshot_metadata() {
 run_with_timeout() {
   local timeout_seconds="$1"
   shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout -s KILL "$timeout_seconds" "$@"
-    return $?
-  fi
-
+  # Portable Bash watchdog: the GNU `timeout -s KILL` fast path was removed
+  # because macOS/BSD ship without a compatible timeout binary.
   "$@" &
+
   local pid=$!
   local elapsed=0
   while kill -0 "$pid" 2>/dev/null; do

--- a/scripts/run-full-build-quiet.sh
+++ b/scripts/run-full-build-quiet.sh
@@ -66,22 +66,31 @@ cleanup_old_logs() {
         return 0
     fi
     
-    # Find all full-build-*.log files and sort by filename (which contains timestamp)
-    # Filenames are in format: full-build-YYYYMMDD-HHMMSS.log
-    # Sorting alphabetically gives chronological order (newest last)
-    local files
-    files=$(find "$log_dir" -maxdepth 1 -type f -name "full-build-*.log" 2>/dev/null | sort || true)
-    if [[ -z "$files" ]]; then
+    # Find all full-build-*.log files and sort by filename (which contains timestamp).
+    # Filenames are in format: full-build-YYYYMMDD-HHMMSS.log; sorting alphabetically
+    # gives chronological order (newest last). Bash globs stay portable across
+    # GNU find and BSD find (macOS lacks -maxdepth).
+    local -a log_files=()
+    local entry
+    for entry in "$log_dir"/full-build-*.log; do
+        if [[ -f "$entry" ]]; then
+            log_files+=("$entry")
+        fi
+    done
+    if ((${#log_files[@]} == 0)); then
         return 0
     fi
-
-    # Delete everything except the newest keep_count files; use POSIX-safe tail/awk
+    local sorted_files
+    sorted_files="$(printf '%s\n' "${log_files[@]}" | sort || true)"
+    if [[ -z "$sorted_files" ]]; then
+        return 0
+    fi
     local file_count
-    file_count=$(printf '%s\n' "$files" | grep -c . || true)
+    file_count=$(printf '%s\n' "$sorted_files" | grep -c . || true)
     local delete_count=$((file_count - keep_count))
     if ((delete_count > 0)); then
         local files_to_delete
-        files_to_delete=$(printf '%s\n' "$files" | head -n "$delete_count")
+        files_to_delete=$(printf '%s\n' "$sorted_files" | head -n "$delete_count")
         while IFS= read -r file; do
             if [[ -n "$file" && -f "$file" ]]; then
                 rm -f "$file"

--- a/scripts/tests/test_prepare_release_workflow.sh
+++ b/scripts/tests/test_prepare_release_workflow.sh
@@ -58,7 +58,18 @@ test_issue_permissions_declared() {
   echo "Running test_issue_permissions_declared"
 
   local permissions
-  permissions="$(ruby -e 'require "yaml"; workflow = YAML.load_file(ARGV[0]); puts workflow.fetch("permissions").fetch("issues")' "$WORKFLOW")"
+  # sub() strips a CR so CRLF checkouts of the workflow compare equal.
+  permissions="$(awk '
+    { sub(/\r$/, "") }
+    /^[[:space:]]*#/ { next }
+    /^permissions:/ { in_permissions = 1; next }
+    in_permissions && /^[^[:space:]]/ { exit }
+    in_permissions && $1 == "issues:" {
+      sub(/^[[:space:]]*issues:[[:space:]]*/, "")
+      print
+      exit
+    }
+  ' "$WORKFLOW")"
   if [[ "$permissions" != "write" ]]; then
     fail "prepare-release workflow should request issues: write permission"
   fi

--- a/scripts/tests/test_resolve_release_tags.sh
+++ b/scripts/tests/test_resolve_release_tags.sh
@@ -34,7 +34,7 @@ expect_output_value() {
 }
 
 run_test() {
-  TMP="$(mktemp -d)"
+  TMP="$(mktemp -d "${TMPDIR:-/tmp}/ta4j-resolve-tags.XXXXXX")"
   mkdir -p "$TMP/scripts"
   cp "$SCRIPT" "$TMP/scripts/resolve-release-tags.sh"
   chmod +x "$TMP/scripts/resolve-release-tags.sh"


### PR DESCRIPTION
## Summary
- replace the Ruby-based YAML permission check in the prepare-release fixture with portable awk (also tolerates CRLF workflow checkouts)
- force LF endings for *.sh and mvnw via .gitattributes so Git Bash/MSYS on Windows no longer chokes on `set -o pipefail\r`
- drop the GNU-only `timeout -s KILL` fast path in release helpers in favor of the existing portable Bash watchdog
- prefer `sha256sum` with a `shasum -a 256` fallback for checksums
- add a find-based fallback to agents_for_target.sh when ripgrep is unavailable, with backslash path normalization
- replace GNU `find -maxdepth 1` in log cleanup with a portable glob loop
- use a mktemp template and add explicit python3 prerequisite guards

## Verification
- `bash scripts/run-full-build-quiet.sh --preflight-only`: success in 16s on Windows Git Bash without Ruby installed (previously failed)
- Full gate: `bash scripts/run-full-build-quiet.sh`: success, Tests run 8680 / Failures 0 / Errors 0 / Skipped 0, log at .agents/logs/full-build-20260825-143553.log
- bash -n syntax check across all repository shell scripts