### PR TITLE
fix: remediate overlooked PR review comments across recent merges

### DIFF
--- a/scripts/agents_for_target.sh
+++ b/scripts/agents_for_target.sh
@@ -46,22 +46,61 @@ if command -v rg >/dev/null 2>&1; then
     rg --files --no-ignore --hidden -g "$target_glob" "$root" 2>/dev/null
   }
 else
-  # Portable fallback: BSD and GNU find both support -name glob matching.
+  # Portable fallback: BSD and GNU find both support -name and -path glob matching.
   # MSYS/Git Bash find emits backslash separators; normalize them so the
   # upward AGENTS.md walk sees ordinary slash-separated paths.
-  # Path-shaped targets (containing "/") are matched by splitting the
-  # directory prefix from the basename, preserving the rg path-input contract.
+  # Path-shaped targets (containing "/") preserve the rg path-input contract
+  # including recursive glob expressions (such as "**").
   file_listing() {
     case "$target_glob" in
       */*)
-        local dir_glob="${target_glob%/*}"
-        local base_glob="${target_glob##*/}"
-        local match
-        for match in "$root"/"$dir_glob"/"$base_glob"; do
-          if [ -f "$match" ]; then
-            printf '%s\n' "$match"
-          fi
-        done
+        if [ -f "$root/$target_glob" ]; then
+          printf '%s\n' "$root/$target_glob"
+          return
+        fi
+        local clean_glob="${target_glob#./}"
+        case "$clean_glob" in
+          *\*\*/*)
+            local prefix="${clean_glob%%\*\*/*}"
+            local suffix="${clean_glob#*\*\*/*}"
+            prefix="${prefix%/}"
+            if [ -n "$prefix" ]; then
+              local p0="./$prefix/$suffix"
+              local p1="./$prefix/*/$suffix"
+              local p2="./$prefix/*/*/$suffix"
+              local p3="./$prefix/*/*/*/$suffix"
+              local p4="./$prefix/*/*/*/*/$suffix"
+            else
+              local p0="./$suffix"
+              local p1="./*/$suffix"
+              local p2="./*/*/$suffix"
+              local p3="./*/*/*/$suffix"
+              local p4="./*/*/*/*/$suffix"
+            fi
+            (
+              cd "$root" || exit
+              find . -type f \( -path "$p0" -o -path "$p1" -o -path "$p2" -o -path "$p3" -o -path "$p4" \) 2>/dev/null \
+                | sed "s|^\./|$root/|" \
+                | tr '\\' '/'
+            )
+            ;;
+          *)
+            local dir_prefix="${clean_glob%/*}"
+            local base_name="${clean_glob##*/}"
+            (
+              cd "$root" || exit
+              if [ -d "$dir_prefix" ] && case "$dir_prefix" in *\**|*\?*) false;; *) true;; esac; then
+                find "$dir_prefix" -maxdepth 1 -type f -name "$base_name" 2>/dev/null \
+                  | sed "s|^|$root/|" \
+                  | tr '\\' '/'
+              else
+                find . -type f -path "./$clean_glob" 2>/dev/null \
+                  | sed "s|^\./|$root/|" \
+                  | tr '\\' '/'
+              fi
+            )
+            ;;
+        esac
         ;;
       *)
         find "$root" -type f -name "$target_glob" 2>/dev/null | tr '\\' '/'

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/WildersMAIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/averages/WildersMAIndicator.java
@@ -86,6 +86,20 @@ public class WildersMAIndicator extends RecursiveCachedIndicator<Num> {
         return indicator.getCountOfUnstableBars() + (barCount * 2);
     }
 
+    /**
+     * The Wilder's MA recursion seeds at the first retained bar (see
+     * {@link #calculate(int)}), so after a head advance every cached value embeds
+     * the pre-advance chain. Discard the whole cache so the retained head
+     * re-anchors the recurrence from the first retained bar instead of serving
+     * stale values.
+     *
+     * @return {@code true}
+     */
+    @Override
+    protected boolean requiresFullCacheInvalidationAfterHeadAdvance() {
+        return true;
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + " barCount: " + barCount;

--- a/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/indicators/helpers/CrossIndicator.java
@@ -28,8 +28,7 @@ public class CrossIndicator extends CachedIndicator<Boolean> {
      * @param low the lower indicator
      */
     public CrossIndicator(Indicator<Num> up, Indicator<Num> low) {
-        // TODO: check if up series is equal to low series
-        super(up, low);
+        super(up.getBarSeries(), up, low);
         this.up = up;
         this.low = low;
     }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/WildersMAIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/averages/WildersMAIndicatorTest.java
@@ -404,4 +404,20 @@ public class WildersMAIndicatorTest extends AbstractIndicatorTest<Indicator<Num>
         assertNumEquals(5, indicator.getValue(5));
     }
 
+    @Test
+    public void clearsCacheWhenSeriesHeadAdvances() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 2, 3, 4, 5, 6).build();
+        WildersMAIndicator indicator = new WildersMAIndicator(new ClosePriceIndicator(series), 3);
+
+        // Cache values before head advance
+        indicator.getValue(5);
+
+        // Advance series head by setting maximum bar count
+        series.setMaximumBarCount(3);
+
+        // Values should match a freshly seeded indicator over retained bars [4, 5, 6]
+        assertNumEquals(4, indicator.getValue(3));
+        assertNumEquals(5, indicator.getValue(5));
+    }
+
 }

--- a/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CrossIndicatorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/indicators/helpers/CrossIndicatorTest.java
@@ -42,4 +42,20 @@ public class CrossIndicatorTest extends AbstractIndicatorTest<Indicator<Boolean>
         assertFalse(indicator.getValue(5));
         assertTrue(indicator.getValue(6));
     }
+
+    @Test
+    public void supportsCrossSeriesIndicators() {
+        BarSeries series1 = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(1, 1, 1, 1).build();
+        BarSeries series2 = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(2, 2, 2, 2).build();
+
+        MockIndicator up = new MockIndicator(series1, 0, List.of(numOf(10), numOf(10), numOf(8), numOf(7)));
+        MockIndicator low = new MockIndicator(series2, 0, List.of(numOf(9), numOf(9), numOf(9), numOf(9)));
+
+        CrossIndicator indicator = new CrossIndicator(up, low);
+
+        assertEquals(List.of(up, low), indicator.getDependencies());
+        assertFalse(indicator.getValue(0));
+        assertFalse(indicator.getValue(1));
+        assertTrue(indicator.getValue(2));
+    }
 }


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- `scripts/agents_for_target.sh`: support recursive pattern matching (`**`) in the non-`rg` fallback path using portable `find` matching so nested path glob queries resolve correctly when `rg` is unavailable.
- `WildersMAIndicator`: override `requiresFullCacheInvalidationAfterHeadAdvance()` to return `true`, ensuring the recurrence seed is re-anchored at the retained series head after a head advance rather than serving stale pre-advance values.
- `CrossIndicator`: invoke `super(up.getBarSeries(), up, low)` to register both indicators as multi-source dependencies under the series, enabling robust cross-series evaluation, and remove leftover TODO comment.
- Add regression unit tests in `WildersMAIndicatorTest` and `CrossIndicatorTest`.

- [x] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format spotless:apply verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
