### PR TITLE
docs: load Java review requirements only for relevant tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,35 +35,8 @@ Before editing a feature area, discover and follow all applicable scoped `AGENTS
 - This helper is only for path-scoped `AGENTS.md` discovery. Agents must still apply normal system, developer, user, and workflow-specific instructions independently, including any personal PR workflow guidance.
 
 ## 5) Process/worktree guidance
-Worktree lifecycle and PRD/checklist process conventions live in `scripts/AGENTS.md`.
+Load `scripts/AGENTS.md` for worktree lifecycle or PRD/checklist operations, and when it is an ancestor of a changed script. Do not load it merely to read unrelated code.
 
-## 6) Reuse-first policy (MUST)
+## Task-specific engineering requirements
 
-- Before adding a new type or API, search for existing equivalents and reuse them when possible.
-- Do not introduce a new enum when an existing project enum already models the behavior.
-- Prefer extending/adapting existing classes over creating parallel abstractions.
-- If a new type is still required, document in the PRD/checklist or PR notes why existing types were insufficient.
-- Reuse audit checkpoint: before introducing a new type, run a targeted code search for equivalent behavior and capture the reuse decision in 1-2 lines in PRD/checklist or PR notes.
-
-## 7) Consolidation and API exposure (MUST)
-
-- Consolidation-first helper rule: inline new logic into the owning type (private static methods or package-private nested helpers) before creating a new utility class.
-- Only extract to a dedicated helper/utility class after at least two concrete call sites require shared behavior, or when testability/complexity clearly demands extraction.
-- Readability-first helper rule: do not extract private helpers that are only 1-3 lines and used once unless the extracted name carries important domain meaning or materially simplifies a long method.
-- When a tiny helper forces readers to jump around for one or two lines of logic, inline it back into the main flow.
-- When stronger invariants already hold at the call site, prefer direct code over generic fallback helpers that obscure those invariants.
-- New classes and methods should be package-private by default; treat public API additions as exceptional and require a short rationale in PRD/checklist or PR notes.
-- Redundancy cleanup requirement: when new code overlaps existing behavior, remove or fold the redundant abstraction in the same change unless there is a documented blocker.
-
-## 8) Local typing style (MUST)
-
-- Prefer explicit local variable types.
-- Use `var` only when the type is immediately and unambiguously obvious from the right-hand side.
-- Do not use `var` for method-return values unless the type is trivial and fully clear from constructor/factory literal context.
-
-## 9) Test runtime discipline (MUST)
-
-- Use the full gate's Surefire class timings to identify the slowest five classes before optimizing and retain comparable before/after evidence for every targeted class.
-- During iteration, run focused `mvn -pl <module> -am -Dtest=<TestClass> test` commands without `clean`; reserve the clean full wrapper for the candidate final patch.
-- Keep one exhaustive owner for a meaningful numeric, history, or permutation matrix. Use representative nominal, boundary, invalid, and interaction cases in neighboring tests rather than repeating the full sweep.
-- Replace deterministic waits with package-private, production-default-preserving seams; never increase timeouts or skip tests merely to improve wall-clock time.
+Before Java implementation, API design, test changes, test-runtime optimization, or reviews of those surfaces, read [JAVA_REVIEW.md](JAVA_REVIEW.md). It owns the reuse audit, consolidation/public-surface rules, local typing style, and test-runtime discipline. Documentation-only work need not load those details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,4 +39,4 @@ Load `scripts/AGENTS.md` for worktree lifecycle or PRD/checklist operations, and
 
 ## Task-specific engineering requirements
 
-Before Java implementation, API design, test changes, test-runtime optimization, or reviews of those surfaces, read [JAVA_REVIEW.md](JAVA_REVIEW.md). It owns the reuse audit, consolidation/public-surface rules, local typing style, and test-runtime discipline. Documentation-only work need not load those details.
+Before Java implementation, API design (including documentation-only PRDs and checklists), test changes, test-runtime optimization, or reviews of those surfaces, read [JAVA_REVIEW.md](JAVA_REVIEW.md). It owns the reuse audit, consolidation/public-surface rules, local typing style, and test-runtime discipline. Documentation-only work may omit it only when it does not design, specify, or review Java/API/test behavior. The documentation-only completion-gate exception above does not waive these engineering requirements.

--- a/JAVA_REVIEW.md
+++ b/JAVA_REVIEW.md
@@ -1,6 +1,6 @@
 # Java and test review requirements
 
-Load before Java implementation, API design, test changes, test-runtime optimization, or reviews of those surfaces. Apply these requirements alongside the target's ancestor-scoped guides; this file does not replace them or the root completion gate.
+Load before Java implementation, API design, test changes, test-runtime optimization, or reviews of those surfaces. These are repository-wide defaults with the same scope and precedence as the root `AGENTS.md`. Apply them with the target's ancestor-scoped guides; when requirements conflict, the target's closest applicable scoped `AGENTS.md` takes precedence over this file. All non-conflicting requirements and the root completion gate still apply.
 
 ## 6) Reuse-first policy (MUST)
 

--- a/JAVA_REVIEW.md
+++ b/JAVA_REVIEW.md
@@ -1,0 +1,34 @@
+# Java and test review requirements
+
+Load before Java implementation, API design, test changes, test-runtime optimization, or reviews of those surfaces. Apply these requirements alongside the target's ancestor-scoped guides; this file does not replace them or the root completion gate.
+
+## 6) Reuse-first policy (MUST)
+
+- Before adding a new type or API, search for existing equivalents and reuse them when possible.
+- Do not introduce a new enum when an existing project enum already models the behavior.
+- Prefer extending/adapting existing classes over creating parallel abstractions.
+- If a new type is still required, document in the PRD/checklist or PR notes why existing types were insufficient.
+- Reuse audit checkpoint: before introducing a new type, run a targeted code search for equivalent behavior and capture the reuse decision in 1-2 lines in PRD/checklist or PR notes.
+
+## 7) Consolidation and API exposure (MUST)
+
+- Consolidation-first helper rule: inline new logic into the owning type (private static methods or package-private nested helpers) before creating a new utility class.
+- Only extract to a dedicated helper/utility class after at least two concrete call sites require shared behavior, or when testability/complexity clearly demands extraction.
+- Readability-first helper rule: do not extract private helpers that are only 1-3 lines and used once unless the extracted name carries important domain meaning or materially simplifies a long method.
+- When a tiny helper forces readers to jump around for one or two lines of logic, inline it back into the main flow.
+- When stronger invariants already hold at the call site, prefer direct code over generic fallback helpers that obscure those invariants.
+- New classes and methods should be package-private by default; treat public API additions as exceptional and require a short rationale in PRD/checklist or PR notes.
+- Redundancy cleanup requirement: when new code overlaps existing behavior, remove or fold the redundant abstraction in the same change unless there is a documented blocker.
+
+## 8) Local typing style (MUST)
+
+- Prefer explicit local variable types.
+- Use `var` only when the type is immediately and unambiguously obvious from the right-hand side.
+- Do not use `var` for method-return values unless the type is trivial and fully clear from constructor/factory literal context.
+
+## 9) Test runtime discipline (MUST)
+
+- Use the full gate's Surefire class timings to identify the slowest five classes before optimizing and retain comparable before/after evidence for every targeted class.
+- During iteration, run focused `mvn -pl <module> -am -Dtest=<TestClass> test` commands without `clean`; reserve the clean full wrapper for the candidate final patch.
+- Keep one exhaustive owner for a meaningful numeric, history, or permutation matrix. Use representative nominal, boundary, invalid, and interaction cases in neighboring tests rather than repeating the full sweep.
+- Replace deterministic waits with package-private, production-default-preserving seams; never increase timeouts or skip tests merely to improve wall-clock time.


### PR DESCRIPTION
Changes proposed in this pull request:
- Keep repository-wide completion gates, failure policy, and ancestor-scoped guide discovery in `AGENTS.md`.
- Move the existing reuse, consolidation/public-surface, typing, and test-runtime requirements verbatim into `JAVA_REVIEW.md`, loaded for relevant implementation, design, and review tasks.
- Preserve scoped-guide precedence explicitly and distinguish ordinary documentation edits from documentation that designs or specifies Java/API/test behavior.

## Review fixes
Commit `8c0943e3fb87c43b9d1e1f7c4d2474db8c7437ee` addresses both review findings:

1. `JAVA_REVIEW.md` has the same scope and precedence as root `AGENTS.md`; the target's closest applicable scoped guide wins on conflict. Non-conflicting rules and the root completion gate remain applicable.
2. Documentation-only API-design PRDs and checklists must load the engineering requirements. Only documentation that does not design, specify, or review Java/API/test behavior may omit them. The documentation-only full-build exception does not waive instruction loading.

That follow-up changes exactly one paragraph in each of the existing two Markdown files. Root sections 1–5 and engineering sections 6–9 are unchanged. The subsequent September 9 pass found no new actionable feedback; both review threads remain resolved and no further source changes were needed.

## Verification
Base: `240deb4c236dc296bc301bb3c4801f3d86a58366`.
Current head: `8c0943e3fb87c43b9d1e1f7c4d2474db8c7437ee`.

Two deterministic source-contract regressions failed against the pre-fix text; all eight final routing/preservation checks passed. The uploaded file blobs match the checked snapshots. Manual scenario review covered a scoped candlestick typing rule, a documentation-only public-API PRD, and an unrelated prose edit. These are instruction-text checks, not automated agent-behavior or Java-runtime tests.

**Both hosted workflows passed for this head:** [Run Verify 34377275746](https://github.com/ta4j/ta4j/actions/runs/34377275746) and [Release Merge Freeze 34377560604](https://github.com/ta4j/ta4j/actions/runs/34377560604). This replaces the earlier in-progress verification note.

- [ ] I have run `scripts/run-full-build-quiet.sh` (or its PowerShell counterpart) or `./mvnw -B clean license:format spotless:apply verify` (or its `mvnw.cmd` counterpart), reviewed any formatting or license-header repairs, and committed the intended result per the [contributing guidelines](.github/CONTRIBUTING.md)
- [ ] I have added an entry with applicable ticket number(s) to the appropriate unreleased section of `CHANGELOG.md`

Both changed files remain Markdown, so the existing documentation-only local full-build exception applies. No local Java build or changelog entry is claimed. The installed exact-head/base quiet-window monitor was not executed in this connector-backed follow-up; direct head, feedback, and workflow reads are not represented as that monitor. No approval, merge, or auto-merge was performed in these comment follow-ups.