### PR TITLE
fix(backtest): add explicit bounded worker execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- _No changes yet._
+- `BacktestExecutor` now has explicit `executeWithRuntimeReport` overloads with a strict platform-worker cap for fixed amounts and `PositionSizer` entries. They avoid nested parallel streams so constrained ForkJoin callers can preserve their hard worker limits without compensation-thread rejection.
 
 ## 0.25.0 (2026-09-07)
 

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -55,7 +55,7 @@ public class BacktestExecutor {
      * by
      * {@link #executeAndKeepTopK(List, AnalysisCriterion, int, Consumer, Function)}
      * and
-     * {@link #executeWithRuntimeReport(List, Trade.TradeType, Consumer, int, Function)}
+     * {@link #executeWithRuntimeReport(List, Trade.TradeType, Consumer, int, int, Function)}
      * so callers can distinguish healthy results from skipped strategies.
      */
     private volatile List<BacktestExecutionResult.StrategyFailure> latestFailures = List.of();
@@ -493,8 +493,13 @@ public class BacktestExecutor {
         // For large strategy counts, use batched processing to prevent memory
         // exhaustion. Use smaller batches for very large counts.
         if (parallelism > 0) {
-            executeBounded(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback, parallelism,
-                    executionFailures);
+            try {
+                executeBounded(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback,
+                        parallelism, executionFailures);
+            } catch (RuntimeException | Error failure) {
+                publishStrategyFailures(executionFailures);
+                throw failure;
+            }
         } else if (usesBatchedExecution(strategyCount)) {
             int effectiveBatchSize = effectiveBatchSize(strategyCount, batchSize);
             executeBatched(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback,

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -20,6 +20,11 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -280,6 +285,60 @@ public class BacktestExecutor {
     }
 
     /**
+     * Executes strategies with a strict cap on the platform workers used for this
+     * execution while collecting runtime measurements and trading statements.
+     * <p>
+     * This explicit overload lets integrations that already run in a constrained
+     * {@link java.util.concurrent.ForkJoinPool} preserve their worker cap without
+     * relying on nested parallel streams or ForkJoin compensation threads.
+     * </p>
+     *
+     * @param strategies  the list of strategies to execute (read-only)
+     * @param amount      the amount used to open/close the position
+     * @param tradeType   the {@link Trade.TradeType} used to open the position
+     * @param parallelism maximum number of platform workers this execution may own
+     * @return execution result containing immutable trading statements and a
+     *         runtime report
+     * @throws IllegalArgumentException if {@code parallelism} is not positive
+     * @since 0.25.1
+     */
+    public BacktestExecutionResult executeWithRuntimeReport(List<Strategy> strategies, Num amount,
+            Trade.TradeType tradeType, int parallelism) {
+        Objects.requireNonNull(amount, "amount must not be null");
+        validateParallelism(parallelism);
+        return executeWithRuntimeReport(strategies, tradeType, null, DEFAULT_BATCH_SIZE, parallelism,
+                strategy -> seriesManager.run(strategy, tradeType, amount));
+    }
+
+    /**
+     * Executes strategies with a strict cap on the platform workers used for this
+     * execution while collecting runtime measurements and trading statements using
+     * a dynamic entry position sizer.
+     * <p>
+     * This explicit overload lets integrations that already run in a constrained
+     * {@link java.util.concurrent.ForkJoinPool} preserve their worker cap without
+     * relying on nested parallel streams or ForkJoin compensation threads.
+     * </p>
+     *
+     * @param strategies    the list of strategies to execute (read-only)
+     * @param positionSizer dynamic entry position sizer
+     * @param tradeType     the {@link Trade.TradeType} used to open the position
+     * @param parallelism   maximum number of platform workers this execution may
+     *                      own
+     * @return execution result containing immutable trading statements and a
+     *         runtime report
+     * @throws IllegalArgumentException if {@code parallelism} is not positive
+     * @since 0.25.1
+     */
+    public BacktestExecutionResult executeWithRuntimeReport(List<Strategy> strategies, PositionSizer positionSizer,
+            Trade.TradeType tradeType, int parallelism) {
+        Objects.requireNonNull(positionSizer, "positionSizer must not be null");
+        validateParallelism(parallelism);
+        return executeWithRuntimeReport(strategies, tradeType, null, DEFAULT_BATCH_SIZE, parallelism,
+                strategy -> seriesManager.run(strategy, tradeType, positionSizer));
+    }
+
+    /**
      * Executes strategies while collecting runtime measurements and trading
      * statements using a dynamic entry position sizer.
      *
@@ -374,7 +433,7 @@ public class BacktestExecutor {
     public BacktestExecutionResult executeWithRuntimeReport(List<Strategy> strategies, Num amount,
             Trade.TradeType tradeType, Consumer<Integer> progressCallback, int batchSize) {
         Objects.requireNonNull(amount, "amount must not be null");
-        return executeWithRuntimeReport(strategies, tradeType, progressCallback, batchSize,
+        return executeWithRuntimeReport(strategies, tradeType, progressCallback, batchSize, 0,
                 strategy -> seriesManager.run(strategy, tradeType, amount));
     }
 
@@ -397,12 +456,13 @@ public class BacktestExecutor {
     public BacktestExecutionResult executeWithRuntimeReport(List<Strategy> strategies, PositionSizer positionSizer,
             Trade.TradeType tradeType, Consumer<Integer> progressCallback, int batchSize) {
         Objects.requireNonNull(positionSizer, "positionSizer must not be null");
-        return executeWithRuntimeReport(strategies, tradeType, progressCallback, batchSize,
+        return executeWithRuntimeReport(strategies, tradeType, progressCallback, batchSize, 0,
                 strategy -> seriesManager.run(strategy, tradeType, positionSizer));
     }
 
     private BacktestExecutionResult executeWithRuntimeReport(List<Strategy> strategies, Trade.TradeType tradeType,
-            Consumer<Integer> progressCallback, int batchSize, Function<Strategy, TradingRecord> tradingRecordRunner) {
+            Consumer<Integer> progressCallback, int batchSize, int parallelism,
+            Function<Strategy, TradingRecord> tradingRecordRunner) {
         Objects.requireNonNull(strategies, "strategies must not be null");
         Objects.requireNonNull(tradeType, "tradeType must not be null");
         Objects.requireNonNull(tradingRecordRunner, "tradingRecordRunner must not be null");
@@ -432,7 +492,10 @@ public class BacktestExecutor {
 
         // For large strategy counts, use batched processing to prevent memory
         // exhaustion. Use smaller batches for very large counts.
-        if (usesBatchedExecution(strategyCount)) {
+        if (parallelism > 0) {
+            executeBounded(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback, parallelism,
+                    executionFailures);
+        } else if (usesBatchedExecution(strategyCount)) {
             int effectiveBatchSize = effectiveBatchSize(strategyCount, batchSize);
             executeBatched(strategyArray, statements, durations, tradingRecordRunner, effectiveCallback,
                     effectiveBatchSize, executionFailures);
@@ -544,6 +607,12 @@ public class BacktestExecutor {
     static int effectiveBatchSize(int strategyCount, int requestedBatchSize) {
         return strategyCount > LARGE_COUNT_THRESHOLD ? Math.min(requestedBatchSize, SMALL_BATCH_SIZE)
                 : requestedBatchSize;
+    }
+
+    private static void validateParallelism(int parallelism) {
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be positive");
+        }
     }
 
     /**
@@ -1051,6 +1120,55 @@ public class BacktestExecutor {
         public BacktestAndWalkForwardResult {
             backtest = Objects.requireNonNull(backtest, "backtest");
             walkForward = Objects.requireNonNull(walkForward, "walkForward");
+        }
+    }
+
+    /**
+     * Executes strategies through a fixed number of platform workers. Each worker
+     * claims the next strategy index, avoiding per-strategy task allocation and
+     * ForkJoinPool nested-parallelism semantics.
+     */
+    private void executeBounded(Strategy[] strategyArray, TradingStatement[] statements, long[] durations,
+            Function<Strategy, TradingRecord> tradingRecordRunner, Consumer<Integer> progressCallback, int parallelism,
+            ConcurrentLinkedQueue<BacktestExecutionResult.StrategyFailure> failureLedger) {
+        int workerCount = Math.min(parallelism, strategyArray.length);
+        ExecutorService workerExecutor = Executors.newFixedThreadPool(workerCount);
+        AtomicInteger nextStrategyIndex = new AtomicInteger();
+        ProgressTracker progressTracker = ProgressTracker.create(progressCallback);
+        List<Future<?>> workerFutures = new ArrayList<>(workerCount);
+
+        try {
+            for (int worker = 0; worker < workerCount; worker++) {
+                workerFutures.add(workerExecutor.submit(() -> {
+                    int index;
+                    while (!Thread.currentThread().isInterrupted()
+                            && (index = nextStrategyIndex.getAndIncrement()) < strategyArray.length) {
+                        executeSingleStrategy(index, strategyArray, statements, durations, tradingRecordRunner,
+                                progressTracker, failureLedger);
+                    }
+                    if (Thread.currentThread().isInterrupted()) {
+                        throw new IllegalStateException("Bounded backtest worker interrupted");
+                    }
+                }));
+            }
+            for (Future<?> workerFuture : workerFutures) {
+                workerFuture.get();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for bounded backtest execution", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new IllegalStateException("Bounded backtest worker failed", cause);
+        } finally {
+            workerExecutor.shutdownNow();
+            workerExecutor.close();
         }
     }
 

--- a/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
+++ b/ta4j-core/src/main/java/org/ta4j/core/backtest/BacktestExecutor.java
@@ -21,9 +21,9 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -1140,11 +1140,11 @@ public class BacktestExecutor {
         ExecutorService workerExecutor = Executors.newFixedThreadPool(workerCount);
         AtomicInteger nextStrategyIndex = new AtomicInteger();
         ProgressTracker progressTracker = ProgressTracker.create(progressCallback);
-        List<Future<?>> workerFutures = new ArrayList<>(workerCount);
+        ExecutorCompletionService<Void> completedWorkers = new ExecutorCompletionService<>(workerExecutor);
 
         try {
             for (int worker = 0; worker < workerCount; worker++) {
-                workerFutures.add(workerExecutor.submit(() -> {
+                completedWorkers.submit(() -> {
                     int index;
                     while (!Thread.currentThread().isInterrupted()
                             && (index = nextStrategyIndex.getAndIncrement()) < strategyArray.length) {
@@ -1154,10 +1154,10 @@ public class BacktestExecutor {
                     if (Thread.currentThread().isInterrupted()) {
                         throw new IllegalStateException("Bounded backtest worker interrupted");
                     }
-                }));
+                }, null);
             }
-            for (Future<?> workerFuture : workerFutures) {
-                workerFuture.get();
+            for (int workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+                completedWorkers.take().get();
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
@@ -101,7 +101,8 @@ public class BacktestExecutorTest {
         List<Strategy> strategies = List.of(strategyOne, strategyTwo, strategyThree);
 
         BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, numOf(1));
+        BacktestExecutionResult result = executor.executeWithRuntimeReport(strategies, numOf(1), Trade.TradeType.BUY,
+                2);
 
         assertEquals(strategies.size(), result.tradingStatements().size());
         assertEquals(strategies.size(), result.runtimeReport().strategyCount());
@@ -134,7 +135,7 @@ public class BacktestExecutorTest {
         PositionSizer positionSizer = context -> numFactory.numOf(context.signalIndex() + 1);
 
         BacktestExecutionResult result = executor.executeWithRuntimeReport(List.of(strategy), positionSizer,
-                Trade.TradeType.BUY);
+                Trade.TradeType.BUY, 1);
         TradingRecord tradingRecord = result.tradingStatements().getFirst().getTradingRecord();
         Position position = tradingRecord.getPositions().getFirst();
 
@@ -162,6 +163,34 @@ public class BacktestExecutorTest {
         assertEquals(result.runtimeReport().overallRuntime(), result.runtimeReport().maxStrategyRuntime());
         assertEquals(result.runtimeReport().overallRuntime(), result.runtimeReport().averageStrategyRuntime());
         assertEquals(result.runtimeReport().overallRuntime(), result.runtimeReport().medianStrategyRuntime());
+    }
+
+    @Test
+    public void executeWithRuntimeReportBoundedRejectsNonPositiveParallelism() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(5, 6, 7).build();
+        BacktestExecutor executor = new BacktestExecutor(series);
+        Strategy strategy = new BaseStrategy(new FixedRule(0), new FixedRule(1));
+        PositionSizer positionSizer = context -> numFactory.one();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> executor.executeWithRuntimeReport(List.of(strategy), numOf(1), Trade.TradeType.BUY, 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> executor.executeWithRuntimeReport(List.of(strategy), positionSizer, Trade.TradeType.BUY, -1));
+    }
+
+    @Test
+    public void boundedWorkerInterruptionRejectsIncompleteResults() {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(5, 6, 7).build();
+        BacktestExecutor executor = new BacktestExecutor(series);
+        Strategy first = new BaseStrategy(new FixedRule(0), new FixedRule(1));
+        Strategy second = new BaseStrategy(new FixedRule(0), new FixedRule(1));
+        PositionSizer interruptingSizer = context -> {
+            Thread.currentThread().interrupt();
+            return numFactory.one();
+        };
+
+        assertThrows(IllegalStateException.class, () -> executor.executeWithRuntimeReport(List.of(first, second),
+                interruptingSizer, Trade.TradeType.BUY, 1));
     }
 
     @Test
@@ -610,8 +639,8 @@ public class BacktestExecutorTest {
         Strategy throwing = new ThrowingStrategy(new FixedRule(0), new FixedRule(1), new IllegalStateException("boom"));
 
         BacktestExecutor executor = new BacktestExecutor(series);
-        BacktestExecutionResult result = executor
-                .executeWithRuntimeReport(List.of(oneTrade, throwing, threeTrades, twoTrades), numOf(1));
+        BacktestExecutionResult result = executor.executeWithRuntimeReport(
+                List.of(oneTrade, throwing, threeTrades, twoTrades), numOf(1), Trade.TradeType.BUY, 2);
 
         assertEquals(3, result.tradingStatements().size());
         assertEquals(3, result.runtimeReport().strategyCount());
@@ -692,8 +721,8 @@ public class BacktestExecutorTest {
                 new IllegalStateException("boom-two"));
 
         BacktestExecutor executor = new BacktestExecutor(series);
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> executor.executeWithRuntimeReport(List.of(throwingOne, throwingTwo), numOf(1)));
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> executor
+                .executeWithRuntimeReport(List.of(throwingOne, throwingTwo), numOf(1), Trade.TradeType.BUY, 2));
 
         assertTrue(exception.getMessage().contains("All 2 strategies failed"));
         assertEquals(2, executor.getStrategyFailures().size());

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
@@ -200,6 +200,46 @@ public class BacktestExecutorTest {
     }
 
     @Test
+    public void boundedWorkerFailureInterruptsBlockedPeer() throws Exception {
+        BarSeries series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(5, 6, 7, 8).build();
+        BacktestExecutor executor = new BacktestExecutor(series);
+        CountDownLatch blocked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicBoolean interrupted = new AtomicBoolean();
+        AssertionError failure = new AssertionError("worker failure");
+        PositionSizer sizer = context -> {
+            try {
+                if (context.signalIndex() == 0) {
+                    blocked.countDown();
+                    release.await();
+                    return numFactory.one();
+                }
+                if (!blocked.await(5, TimeUnit.SECONDS)) {
+                    throw new AssertionError("peer did not start");
+                }
+                throw failure;
+            } catch (InterruptedException e) {
+                interrupted.set(true);
+                Thread.currentThread().interrupt();
+                return numFactory.one();
+            }
+        };
+        Strategy first = new BaseStrategy(new FixedRule(0), new FixedRule(2));
+        Strategy second = new BaseStrategy(new FixedRule(1), new FixedRule(2));
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+        try {
+            Future<AssertionError> execution = caller.submit(() -> assertThrows(AssertionError.class,
+                    () -> executor.executeWithRuntimeReport(List.of(first, second), sizer, Trade.TradeType.BUY, 2)));
+            assertSame(failure, execution.get(5, TimeUnit.SECONDS));
+            assertTrue(interrupted.get());
+        } finally {
+            release.countDown();
+            caller.shutdownNow();
+            caller.close();
+        }
+    }
+
+    @Test
     public void executeWithProgressCallback() {
         var series = new MockBarSeriesBuilder().withNumFactory(numFactory).withData(10, 11, 12, 13, 14).build();
 

--- a/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
+++ b/ta4j-core/src/test/java/org/ta4j/core/backtest/BacktestExecutorTest.java
@@ -184,6 +184,11 @@ public class BacktestExecutorTest {
         BacktestExecutor executor = new BacktestExecutor(series);
         Strategy first = new BaseStrategy(new FixedRule(0), new FixedRule(1));
         Strategy second = new BaseStrategy(new FixedRule(0), new FixedRule(1));
+        Strategy failing = new ThrowingStrategy(new FixedRule(0), new FixedRule(1),
+                new IllegalStateException("previous execution"));
+        assertThrows(IllegalStateException.class,
+                () -> executor.executeWithRuntimeReport(List.of(failing), numFactory.one(), Trade.TradeType.BUY, 1));
+        assertSame(failing, executor.getStrategyFailures().getFirst().strategy());
         PositionSizer interruptingSizer = context -> {
             Thread.currentThread().interrupt();
             return numFactory.one();
@@ -191,6 +196,7 @@ public class BacktestExecutorTest {
 
         assertThrows(IllegalStateException.class, () -> executor.executeWithRuntimeReport(List.of(first, second),
                 interruptingSizer, Trade.TradeType.BUY, 1));
+        assertTrue(executor.getStrategyFailures().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Problem
Running the existing parallel-stream backtest executor inside a hard-capped ForkJoinPool can fail on Java 26 when a nested stream join requests a compensation worker beyond the configured limit. A caller-owned pool therefore cannot reliably enforce a strict execution-worker budget.

## Change
- Add explicit-parallelism `executeWithRuntimeReport` overloads for fixed amounts and `PositionSizer`.
- Run these overloads on an owned fixed platform-worker pool with at most `min(parallelism, strategy count)` workers and one task per worker.
- Reuse canonical trading-record execution, ordered result assembly, runtime accounting, and isolated strategy-failure reporting. Existing overloads retain their behavior.
- Reject incomplete results on interruption; terminate owned workers before returning and publish current failure diagnostics on aborted execution.
- Observe workers in completion order so a failed worker promptly triggers cooperative cancellation of blocked peers.

The public overloads are necessary because existing APIs expose batching/progress but not a hard worker cap. Two overloads cover the existing sizing contracts without exposing executor ownership or introducing a new scheduling abstraction. Javadocs include `@since 0.25.1`; the changelog is updated.

## Verification
At head `584448036e0d22dfdf7620cb77881615386af45e`, based on `c97695e5fc0ef8c5bf031fd8090618d60c4a86a4`:
- `BacktestExecutorTest`: 39 passed, including fixed/explicit sizing, DecimalNum compatibility, partial/all-strategy failures, interruption diagnostics, and cancellation of blocked peers after fatal worker failure.
- Incomplete-result, stale-failure-ledger, and blocked-peer cancellation regressions were observed failing before their fixes and passing afterward.
- `scripts/run-full-build-quiet.sh --validate-only`: passed.
- `scripts/run-full-build-quiet.sh`: passed.
- Independent read-only review completed; accepted diagnostics/Javadoc findings remediated and checked.
- Downstream integration previously passed 243 focused tests and the complete CF reactor using an isolated local candidate artifact. Final candidate reactor verification is separate from published-snapshot admission.

No shared Maven cache artifacts were overwritten. This public PR is intentionally left open for human review and merge; dependent snapshot consumers must wait for upstream merge and publication.

Tracking: CF-578.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime-report backtesting options with a configurable parallelism limit.
  - Backtest execution now responds more promptly to worker failures by interrupting remaining work.

- **Bug Fixes**
  - Invalid parallelism values are rejected with a clear error.
  - Improved cleanup and failure propagation when parallel backtests encounter interruptions or unexpected errors.

- **Documentation**
  - Updated the changelog to document the new backtesting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->